### PR TITLE
Resolve issue with option pages no longer displaying

### DIFF
--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -227,7 +227,7 @@ if ( ! class_exists( 'ACF' ) ) {
 				acf_include( 'includes/admin/admin-notices.php' );
 				acf_include( 'includes/admin/admin-tools.php' );
 				acf_include( 'includes/admin/admin-upgrade.php' );
-				acf_include( 'includes/admin/admin-options-page.php' );
+				acf_include( 'includes/admin/class-acf-admin-options-page.php' );
 			}
 
 			// Include legacy.


### PR DESCRIPTION
Fixes #24 
After the tree combining, there was a file name mismatch for including the option page execution file. This commit resolves by including the correct file.
