### PR TITLE
Resolve missing function from clone field

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: fields, custom fields, meta, scf
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable tag: 6.4.1-beta5
+Stable tag: 6.4.1-beta6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -81,5 +81,5 @@ This plugin builds upon and is a fork of the previous work done by the contribut
 
 == Upgrade Notice ==
 
-= 6.4.1-beta5 =
-Corrects some translation strings and now relies on the WordPress.org translation packs for Russian and Vietnamese.
+= 6.4.1-beta6 =
+Corrects issue where Options page would not display in wp-admin and a missing function from the Clone field.

--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -6,7 +6,7 @@
  * Plugin Name:       Secure Custom Fields
  * Plugin URI:        http://wordpress.org/plugins/secure-custom-fields/
  * Description:       Secure Custom Fields (SCF) offers an intuitive way for developers to enhance WordPress content management by adding extra fields and options without coding requirements.
- * Version:           6.4.1-beta5
+ * Version:           6.4.1-beta6
  * Author:            WordPress.org
  * Author URI:        https://wordpress.org/
  * Text Domain:       secure-custom-fields
@@ -35,7 +35,7 @@ if ( ! class_exists( 'ACF' ) ) {
 		 *
 		 * @var string
 		 */
-		public $version = '6.4.1-beta5';
+		public $version = '6.4.1-beta6';
 
 		/**
 		 * The plugin settings array.


### PR DESCRIPTION
During the file move and following PHPCS clean up, this function somehow was removed. Not sure what happened, but this will put it back pending deeper dive.
