### PR TITLE
Fixes old json in acf-json folder not showing in Sync available

### DIFF
--- a/includes/admin/admin-internal-post-type-list.php
+++ b/includes/admin/admin-internal-post-type-list.php
@@ -189,7 +189,7 @@ if ( ! class_exists( 'ACF_Admin_Internal_Post_Type_List' ) ) :
 						continue;
 
 						// Ignore not local "json".
-					} elseif ( 'json' === $local ) {
+					} elseif ( $local !== 'json' ) {
 						continue;
 
 						// Append to sync if not yet in database.

--- a/includes/admin/admin-internal-post-type-list.php
+++ b/includes/admin/admin-internal-post-type-list.php
@@ -189,7 +189,7 @@ if ( ! class_exists( 'ACF_Admin_Internal_Post_Type_List' ) ) :
 						continue;
 
 						// Ignore not local "json".
-					} elseif ( $local !== 'json' ) {
+					} elseif ( 'json' !== $local ) {
 						continue;
 
 						// Append to sync if not yet in database.


### PR DESCRIPTION
https://github.com/WordPress/secure-custom-fields/issues/27