### PR TITLE
Docs: correct the generator to correct paths for index files

### DIFF
--- a/docs/bin/generate-manifest.php
+++ b/docs/bin/generate-manifest.php
@@ -54,7 +54,12 @@ foreach ( $paths as $path_pattern ) {
 		$manifest[ $key ] = array(
 			'slug'            => $slug,
 			'parent'          => $parent,
-			'markdown_source' => sprintf( 'https://github.com/%s/blob/trunk/docs/%s.md', $repo, $key . ( 'index' === basename( $key ) ? '' : '/index' ) ),
+			'markdown_source' => sprintf(
+				'https://github.com/%s/blob/trunk/docs/%s%s',
+				$repo,
+				$key,
+				basename( $file ) === 'index.md' ? '/index.md' : '.md'
+			),
 		);
 	}
 }

--- a/docs/bin/manifest.json
+++ b/docs/bin/manifest.json
@@ -2,7 +2,7 @@
     "concepts/architecture": {
         "slug": "architecture",
         "parent": "concepts",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/concepts/architecture/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/concepts/architecture.md"
     },
     "concepts": {
         "slug": "concepts",
@@ -12,12 +12,12 @@
     "concepts/security": {
         "slug": "security",
         "parent": "concepts",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/concepts/security/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/concepts/security.md"
     },
     "contributing/documentation": {
         "slug": "documentation",
         "parent": "contributing",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/contributing/documentation/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/contributing/documentation.md"
     },
     "contributing": {
         "slug": "contributing",
@@ -27,7 +27,7 @@
     "features/api": {
         "slug": "api",
         "parent": "features",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/api/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/api.md"
     },
     "features/fields": {
         "slug": "fields",
@@ -42,7 +42,7 @@
     "features/post-types": {
         "slug": "post-types",
         "parent": "features",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/post-types/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/post-types.md"
     },
     "getting-started": {
         "slug": "getting-started",
@@ -52,17 +52,17 @@
     "getting-started/installation": {
         "slug": "installation",
         "parent": "getting-started",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/getting-started/installation/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/getting-started/installation.md"
     },
     "getting-started/quick-start": {
         "slug": "quick-start",
         "parent": "getting-started",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/getting-started/quick-start/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/getting-started/quick-start.md"
     },
     "tutorials/first-post-type": {
         "slug": "first-post-type",
         "parent": "tutorials",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/tutorials/first-post-type/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/tutorials/first-post-type.md"
     },
     "tutorials": {
         "slug": "tutorials",
@@ -77,7 +77,7 @@
     "features/fields/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/tutorial.md"
     },
     "features/fields/accordion": {
         "slug": "accordion",
@@ -87,7 +87,7 @@
     "features/fields/accordion/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/accordion",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/accordion/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/accordion/tutorial.md"
     },
     "features/fields/button-group": {
         "slug": "button-group",
@@ -97,7 +97,7 @@
     "features/fields/button-group/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/button-group",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/button-group/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/button-group/tutorial.md"
     },
     "features/fields/checkbox": {
         "slug": "checkbox",
@@ -107,12 +107,12 @@
     "features/fields/checkbox/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/checkbox",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/checkbox/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/checkbox/tutorial.md"
     },
     "features/fields/clone/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/clone",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/clone/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/clone/tutorial.md"
     },
     "features/fields/color-picker": {
         "slug": "color-picker",
@@ -122,7 +122,7 @@
     "features/fields/color-picker/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/color-picker",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/color-picker/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/color-picker/tutorial.md"
     },
     "features/fields/date-picker": {
         "slug": "date-picker",
@@ -132,7 +132,7 @@
     "features/fields/date-picker/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/date-picker",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/date-picker/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/date-picker/tutorial.md"
     },
     "features/fields/date-time-picker": {
         "slug": "date-time-picker",
@@ -142,7 +142,7 @@
     "features/fields/date-time-picker/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/date-time-picker",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/date-time-picker/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/date-time-picker/tutorial.md"
     },
     "features/fields/email": {
         "slug": "email",
@@ -152,7 +152,7 @@
     "features/fields/email/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/email",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/email/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/email/tutorial.md"
     },
     "features/fields/file": {
         "slug": "file",
@@ -162,7 +162,7 @@
     "features/fields/file/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/file",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/file/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/file/tutorial.md"
     },
     "features/fields/flexible-content": {
         "slug": "flexible-content",
@@ -172,7 +172,7 @@
     "features/fields/flexible-content/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/flexible-content",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/flexible-content/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/flexible-content/tutorial.md"
     },
     "features/fields/gallery": {
         "slug": "gallery",
@@ -182,7 +182,7 @@
     "features/fields/gallery/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/gallery",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/gallery/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/gallery/tutorial.md"
     },
     "features/fields/google-map": {
         "slug": "google-map",
@@ -192,7 +192,7 @@
     "features/fields/google-map/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/google-map",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/google-map/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/google-map/tutorial.md"
     },
     "features/fields/group": {
         "slug": "group",
@@ -202,7 +202,7 @@
     "features/fields/group/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/group",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/group/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/group/tutorial.md"
     },
     "features/fields/icon-picker": {
         "slug": "icon-picker",
@@ -212,7 +212,7 @@
     "features/fields/icon-picker/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/icon-picker",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/icon-picker/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/icon-picker/tutorial.md"
     },
     "features/fields/image": {
         "slug": "image",
@@ -222,7 +222,7 @@
     "features/fields/image/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/image",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/image/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/image/tutorial.md"
     },
     "features/fields/link": {
         "slug": "link",
@@ -232,7 +232,7 @@
     "features/fields/link/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/link",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/link/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/link/tutorial.md"
     },
     "features/fields/message": {
         "slug": "message",
@@ -242,7 +242,7 @@
     "features/fields/message/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/message",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/message/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/message/tutorial.md"
     },
     "features/fields/number": {
         "slug": "number",
@@ -252,7 +252,7 @@
     "features/fields/number/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/number",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/number/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/number/tutorial.md"
     },
     "features/fields/oembed": {
         "slug": "oembed",
@@ -262,7 +262,7 @@
     "features/fields/oembed/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/oembed",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/oembed/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/oembed/tutorial.md"
     },
     "features/fields/page-link": {
         "slug": "page-link",
@@ -272,7 +272,7 @@
     "features/fields/page-link/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/page-link",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/page-link/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/page-link/tutorial.md"
     },
     "features/fields/password": {
         "slug": "password",
@@ -282,7 +282,7 @@
     "features/fields/password/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/password",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/password/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/password/tutorial.md"
     },
     "features/fields/post-object": {
         "slug": "post-object",
@@ -292,7 +292,7 @@
     "features/fields/post-object/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/post-object",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/post-object/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/post-object/tutorial.md"
     },
     "features/fields/radio": {
         "slug": "radio",
@@ -302,7 +302,7 @@
     "features/fields/radio/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/radio",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/radio/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/radio/tutorial.md"
     },
     "features/fields/range": {
         "slug": "range",
@@ -312,6 +312,6 @@
     "features/fields/range/tutorial": {
         "slug": "tutorial",
         "parent": "features/fields/range",
-        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/range/tutorial/index.md"
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/fields/range/tutorial.md"
     }
 }


### PR DESCRIPTION
Corrects an issue where the manifest for the "index" level files and the other files were being confused.

See https://github.com/WordPress/secure-custom-fields/issues/35
