### PR TITLE
Docs: a handbook home file is required

### DIFF
--- a/docs/bin/manifest.json
+++ b/docs/bin/manifest.json
@@ -1,4 +1,9 @@
 {
+    "scf": {
+        "slug": "scf",
+        "parent": null,
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/scf.md"
+    },
     "concepts/architecture": {
         "slug": "architecture",
         "parent": "concepts",

--- a/docs/scf.md
+++ b/docs/scf.md
@@ -1,0 +1,7 @@
+# Welcome to Secure Custom Fields
+
+Secure Custom Fields is a WordPress plugin that allows you to create custom fields for your posts, pages, and custom post types.
+
+## Features
+
+- [Fields](features/fields/index.md) - Create and manage custom fields.


### PR DESCRIPTION
See https://github.com/WordPress/secure-custom-fields/issues/35
See https://wordpress.slack.com/archives/C02RRH4GA/p1740038694447639?thread_ts=1740025944.999619&cid=C02RRH4GA

Resolves a warning:

> Warning: A landing page for this handbook has not been created or is not published. You can title it anything you like (suggestions: Scf Handbook or Welcome). However, you must ensure that it has one of the following slugs: welcome, handbook, scf, scf-handbook. The slug will ultimately be omitted from the page’s permalink URL, but will still appear in the permalinks for its sub-pages. Without this page your handbook’s URL will show a seemingly random handbook page.
