### PR TITLE
Loading: do not translate early

### DIFF
--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -91,7 +91,7 @@ if ( ! class_exists( 'ACF' ) ) {
 
 			// Define settings.
 			$this->settings = array(
-				'name'                    => __( 'Secure Custom Fields', 'secure-custom-fields' ),
+				'name'                    => 'Secure Custom Fields', // Will be updated in the init hook to i18n string.
 				'slug'                    => dirname( ACF_BASENAME ),
 				'version'                 => ACF_VERSION,
 				'basename'                => ACF_BASENAME,
@@ -207,18 +207,6 @@ if ( ! class_exists( 'ACF' ) ) {
 			acf_include( 'includes/ajax/class-acf-ajax-query-users.php' );
 			acf_include( 'includes/ajax/class-acf-ajax-local-json-diff.php' );
 
-			// Include forms.
-			acf_include( 'includes/forms/form-attachment.php' );
-			acf_include( 'includes/forms/form-comment.php' );
-			acf_include( 'includes/forms/form-customizer.php' );
-			acf_include( 'includes/forms/form-front.php' );
-			acf_include( 'includes/forms/form-nav-menu.php' );
-			acf_include( 'includes/forms/form-post.php' );
-			acf_include( 'includes/forms/form-gutenberg.php' );
-			acf_include( 'includes/forms/form-taxonomy.php' );
-			acf_include( 'includes/forms/form-user.php' );
-			acf_include( 'includes/forms/form-widget.php' );
-
 			// Include admin.
 			if ( is_admin() ) {
 				acf_include( 'includes/admin/admin.php' );
@@ -269,6 +257,9 @@ if ( ! class_exists( 'ACF' ) ) {
 			// Load textdomain file.
 			acf_load_textdomain();
 
+			// Update the name setting now that we're in the init hook.
+			acf_update_setting( 'name', __( 'Secure Custom Fields', 'secure-custom-fields' ) );
+
 			// Include 3rd party compatiblity.
 			acf_include( 'includes/third-party.php' );
 
@@ -276,6 +267,18 @@ if ( ! class_exists( 'ACF' ) ) {
 			if ( defined( 'ICL_SITEPRESS_VERSION' ) ) {
 				acf_include( 'includes/wpml.php' );
 			}
+
+			// Include forms.
+			acf_include( 'includes/forms/form-attachment.php' );
+			acf_include( 'includes/forms/form-comment.php' );
+			acf_include( 'includes/forms/form-customizer.php' );
+			acf_include( 'includes/forms/form-front.php' );
+			acf_include( 'includes/forms/form-nav-menu.php' );
+			acf_include( 'includes/forms/form-post.php' );
+			acf_include( 'includes/forms/form-gutenberg.php' );
+			acf_include( 'includes/forms/form-taxonomy.php' );
+			acf_include( 'includes/forms/form-user.php' );
+			acf_include( 'includes/forms/form-widget.php' );
 
 			// Add post types and taxonomies.
 			if ( acf_get_setting( 'enable_post_types' ) ) {


### PR DESCRIPTION
Fixes #45

There are two things throwing `doing_it_wrong` for translating too early.

1. The "name" setting. Resolved by setting name to "Secure Custom Fields" initially in case anything uses it super early and updating it to the translated version on the `init` hood.
2. Loading the front form. This isn't needed immediately, but the initial constructor translates a few fields. Move all form loading to the init hook.
