### PR TITLE
Add PHPStan and baseline

### DIFF
--- a/bin/baseline.neon
+++ b/bin/baseline.neon
@@ -1,0 +1,691 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Path in include_once\(\) "\./wp\-admin/includes/plugin\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../acf.php
+
+		-
+			message: '#^Action callback returns array but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: ../includes/acf-bidirectional-functions.php
+
+		-
+			message: '#^@param array \$sub_field does not accept actual type of parameter\: int\|false\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: ../includes/acf-field-functions.php
+
+		-
+			message: '#^Action callback returns array but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: ../includes/acf-field-functions.php
+
+		-
+			message: '#^Expected 2 @param tags, found 1\.$#'
+			identifier: paramTag.count
+			count: 1
+			path: ../includes/acf-field-functions.php
+
+		-
+			message: '#^Function wp_trash_post invoked with 2 parameters, 0\-1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../includes/acf-field-functions.php
+
+		-
+			message: '#^Function wp_untrash_post invoked with 2 parameters, 0\-1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../includes/acf-field-functions.php
+
+		-
+			message: '#^One or more @param tags has an invalid name or invalid syntax\.$#'
+			identifier: phpDoc.parseError
+			count: 2
+			path: ../includes/acf-field-functions.php
+
+		-
+			message: '#^Constant ACF_PATH not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: ../includes/acf-helper-functions.php
+
+		-
+			message: '#^Function acf_set_filters\(\) should return array but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: ../includes/acf-helper-functions.php
+
+		-
+			message: '#^Action callback returns mixed but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: ../includes/acf-hook-functions.php
+
+		-
+			message: '#^Function acf_checkbox_input\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: ../includes/acf-input-functions.php
+
+		-
+			message: '#^Function acf_file_input\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: ../includes/acf-input-functions.php
+
+		-
+			message: '#^Function acf_hidden_input\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: ../includes/acf-input-functions.php
+
+		-
+			message: '#^Function acf_radio_input\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: ../includes/acf-input-functions.php
+
+		-
+			message: '#^Function acf_select_input\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: ../includes/acf-input-functions.php
+
+		-
+			message: '#^Function acf_text_input\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: ../includes/acf-input-functions.php
+
+		-
+			message: '#^Function acf_textarea_input\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: ../includes/acf-input-functions.php
+
+		-
+			message: '#^Result of function acf_add_validation_error \(void\) is used\.$#'
+			identifier: function.void
+			count: 1
+			path: ../includes/acf-internal-post-type-functions.php
+
+		-
+			message: '#^Result of function acf_copy_metadata \(void\) is used\.$#'
+			identifier: function.void
+			count: 1
+			path: ../includes/acf-meta-functions.php
+
+		-
+			message: '#^One or more @param tags has an invalid name or invalid syntax\.$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: ../includes/acf-user-functions.php
+
+		-
+			message: '#^Constant ACF_PATH not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: ../includes/acf-utility-functions.php
+
+		-
+			message: '#^Action callback returns string but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: ../includes/admin/admin-internal-post-type-list.php
+
+		-
+			message: '#^Constant ACF_PATH not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: ../includes/admin/admin-internal-post-type-list.php
+
+		-
+			message: '#^Action callback returns string but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: ../includes/admin/admin-internal-post-type.php
+
+		-
+			message: '#^Filter callback return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: ../includes/admin/admin-internal-post-type.php
+
+		-
+			message: '#^Action callback returns string but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: ../includes/admin/admin-tools.php
+
+		-
+			message: '#^Action callback returns string but should not return anything\.$#'
+			identifier: return.void
+			count: 2
+			path: ../includes/admin/admin-upgrade.php
+
+		-
+			message: '#^Constant ACF_UPGRADE_VERSION not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: ../includes/admin/admin-upgrade.php
+
+		-
+			message: '#^Action callback returns string but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: ../includes/admin/admin.php
+
+		-
+			message: '#^Access to an undefined property ACF_Admin_Field_Groups\:\:\$not_found_label\.$#'
+			identifier: property.notFound
+			count: 1
+			path: ../includes/admin/post-types/admin-field-groups.php
+
+		-
+			message: '#^Action callback returns array but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: ../includes/admin/post-types/admin-field-groups.php
+
+		-
+			message: '#^Class ACF_Admin_Post_type referenced with incorrect case\: ACF_Admin_Post_Type\.$#'
+			identifier: class.nameCase
+			count: 1
+			path: ../includes/admin/post-types/admin-post-type.php
+
+		-
+			message: '#^Access to an undefined property ACF_Admin_Post_Types\:\:\$not_found_label\.$#'
+			identifier: property.notFound
+			count: 1
+			path: ../includes/admin/post-types/admin-post-types.php
+
+		-
+			message: '#^Access to an undefined property ACF_Admin_Taxonomies\:\:\$not_found_label\.$#'
+			identifier: property.notFound
+			count: 1
+			path: ../includes/admin/post-types/admin-taxonomies.php
+
+		-
+			message: '#^Access to an undefined property ACF_Admin_UI_Options_Pages\:\:\$not_found_label\.$#'
+			identifier: property.notFound
+			count: 1
+			path: ../includes/admin/post-types/class-acf-admin-ui-options-pages.php
+
+		-
+			message: '#^Variable \$field might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../includes/admin/views/acf-field-group/field.php
+
+		-
+			message: '#^Variable \$i might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: ../includes/admin/views/acf-field-group/field.php
+
+		-
+			message: '#^Variable \$fields might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: ../includes/admin/views/acf-field-group/fields.php
+
+		-
+			message: '#^Variable \$parent might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: ../includes/admin/views/acf-field-group/fields.php
+
+		-
+			message: '#^Variable \$group might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../includes/admin/views/acf-field-group/location-group.php
+
+		-
+			message: '#^Variable \$group_id might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: ../includes/admin/views/acf-field-group/location-group.php
+
+		-
+			message: '#^Variable \$rule might not be defined\.$#'
+			identifier: variable.undefined
+			count: 8
+			path: ../includes/admin/views/acf-field-group/location-rule.php
+
+		-
+			message: '#^Variable \$acf_parent_page_choices might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../includes/admin/views/acf-ui-options-page/create-options-page-modal.php
+
+		-
+			message: '#^Variable \$page_title might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../includes/admin/views/html-options-page.php
+
+		-
+			message: '#^Variable \$post_id might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../includes/admin/views/html-options-page.php
+
+		-
+			message: '#^Variable \$active might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../includes/admin/views/tools/tools.php
+
+		-
+			message: '#^Variable \$screen_id might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../includes/admin/views/tools/tools.php
+
+		-
+			message: '#^Constant ACF_VERSION not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: ../includes/admin/views/upgrade/network.php
+
+		-
+			message: '#^Variable \$button_text might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../includes/admin/views/upgrade/notice.php
+
+		-
+			message: '#^Variable \$button_url might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../includes/admin/views/upgrade/notice.php
+
+		-
+			message: '#^Variable \$confirm might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../includes/admin/views/upgrade/notice.php
+
+		-
+			message: '#^Constant ACF_VERSION not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: ../includes/admin/views/upgrade/upgrade.php
+
+		-
+			message: '#^Function remove_filter invoked with 4 parameters, 2\-3 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../includes/api/api-helpers.php
+
+		-
+			message: '#^One or more @param tags has an invalid name or invalid syntax\.$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: ../includes/api/api-helpers.php
+
+		-
+			message: '#^Path in include_once\(\) "\./wp\-admin/includes/plugin\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../includes/api/api-helpers.php
+
+		-
+			message: '#^Path in require_once\(\) "\.//wp\-admin/includes/file\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../includes/api/api-helpers.php
+
+		-
+			message: '#^Path in require_once\(\) "\.//wp\-admin/includes/image\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../includes/api/api-helpers.php
+
+		-
+			message: '#^Path in require_once\(\) "\.//wp\-admin/includes/media\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../includes/api/api-helpers.php
+
+		-
+			message: '#^Function remove_filter invoked with 4 parameters, 2\-3 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../includes/api/api-term.php
+
+		-
+			message: '#^Constant ACF_VERSION not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: ../includes/blocks.php
+
+		-
+			message: '#^Access to an undefined property ACF_Data\:\:\$site_aliases\.$#'
+			identifier: property.notFound
+			count: 2
+			path: ../includes/class-acf-data.php
+
+		-
+			message: '#^Access to an undefined property ACF_Data\:\:\$site_data\.$#'
+			identifier: property.notFound
+			count: 1
+			path: ../includes/class-acf-data.php
+
+		-
+			message: '#^Action callback returns array but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: ../includes/class-acf-internal-post-type.php
+
+		-
+			message: '#^Action callback returns string but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: ../includes/class-acf-internal-post-type.php
+
+		-
+			message: '#^Expected 2 @param tags, found 1\.$#'
+			identifier: paramTag.count
+			count: 1
+			path: ../includes/class-acf-internal-post-type.php
+
+		-
+			message: '#^Expected 3 @param tags, found 2\.$#'
+			identifier: paramTag.count
+			count: 1
+			path: ../includes/class-acf-internal-post-type.php
+
+		-
+			message: '#^Action callback returns array but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: ../includes/class-acf-site-health.php
+
+		-
+			message: '#^Action callback returns bool but should not return anything\.$#'
+			identifier: return.void
+			count: 2
+			path: ../includes/class-acf-site-health.php
+
+		-
+			message: '#^Access to an undefined property acf_field_checkbox\:\:\$_all_checked\.$#'
+			identifier: property.notFound
+			count: 3
+			path: ../includes/fields/class-acf-field-checkbox.php
+
+		-
+			message: '#^Access to an undefined property acf_field_checkbox\:\:\$_values\.$#'
+			identifier: property.notFound
+			count: 3
+			path: ../includes/fields/class-acf-field-checkbox.php
+
+		-
+			message: '#^Access to an undefined property acf_field_clone\:\:\$cloning\.$#'
+			identifier: property.notFound
+			count: 2
+			path: ../includes/fields/class-acf-field-clone.php
+
+		-
+			message: '#^Access to an undefined property acf_field_clone\:\:\$have_rows\.$#'
+			identifier: property.notFound
+			count: 1
+			path: ../includes/fields/class-acf-field-clone.php
+
+		-
+			message: '#^Offset ''thumb'' on array\{alt\: string, author\: string, authorName\: string, caption\: string, compat\: array, context\: string, date\: int, dateFormatted\: string, \.\.\.\}\|null in isset\(\) does not exist\.$#'
+			identifier: isset.offset
+			count: 1
+			path: ../includes/fields/class-acf-field-gallery.php
+
+		-
+			message: '#^Access to an undefined property acf_field_google_map\:\:\$default_values\.$#'
+			identifier: property.notFound
+			count: 6
+			path: ../includes/fields/class-acf-field-google-map.php
+
+		-
+			message: '#^Access to an undefined property acf_field__group\:\:\$have_rows\.$#'
+			identifier: property.notFound
+			count: 1
+			path: ../includes/fields/class-acf-field-group.php
+
+		-
+			message: '#^Access to an undefined property acf_field_oembed\:\:\$height\.$#'
+			identifier: property.notFound
+			count: 3
+			path: ../includes/fields/class-acf-field-oembed.php
+
+		-
+			message: '#^Access to an undefined property acf_field_oembed\:\:\$width\.$#'
+			identifier: property.notFound
+			count: 3
+			path: ../includes/fields/class-acf-field-oembed.php
+
+		-
+			message: '#^Action callback returns void\|WP_Error but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: ../includes/fields/class-acf-field-repeater.php
+
+		-
+			message: '#^Class acf_field referenced with incorrect case\: ACF_Field\.$#'
+			identifier: class.nameCase
+			count: 1
+			path: ../includes/fields/class-acf-field-user.php
+
+		-
+			message: '#^Expected 4 @param tags, found 3\.$#'
+			identifier: paramTag.count
+			count: 1
+			path: ../includes/fields/class-acf-field-user.php
+
+		-
+			message: '#^One or more @param tags has an invalid name or invalid syntax\.$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: ../includes/fields/class-acf-field-user.php
+
+		-
+			message: '#^Path in require\(\) "\./wp\-admin/includes/media\.php" is not a file or it does not exist\.$#'
+			identifier: require.fileNotFound
+			count: 1
+			path: ../includes/fields/class-acf-field-wysiwyg.php
+
+		-
+			message: '#^Access to an undefined property acf_form_customizer\:\:\$preview_errors\.$#'
+			identifier: property.notFound
+			count: 1
+			path: ../includes/forms/form-customizer.php
+
+		-
+			message: '#^Access to an undefined property acf_form_customizer\:\:\$preview_fields\.$#'
+			identifier: property.notFound
+			count: 2
+			path: ../includes/forms/form-customizer.php
+
+		-
+			message: '#^Access to an undefined property acf_form_customizer\:\:\$preview_values\.$#'
+			identifier: property.notFound
+			count: 2
+			path: ../includes/forms/form-customizer.php
+
+		-
+			message: '#^Action callback returns type but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: ../includes/forms/form-nav-menu.php
+
+		-
+			message: '#^Method acf_form_nav_menu\:\:wp_nav_menu_item_custom_fields\(\) should return type but return statement is missing\.$#'
+			identifier: return.missing
+			count: 2
+			path: ../includes/forms/form-nav-menu.php
+
+		-
+			message: '#^Action callback returns int but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: ../includes/forms/form-post.php
+
+		-
+			message: '#^Access to an undefined property acf_form_widget\:\:\$preview_errors\.$#'
+			identifier: property.notFound
+			count: 1
+			path: ../includes/forms/form-widget.php
+
+		-
+			message: '#^Access to an undefined property acf_form_widget\:\:\$preview_reference\.$#'
+			identifier: property.notFound
+			count: 1
+			path: ../includes/forms/form-widget.php
+
+		-
+			message: '#^Access to an undefined property acf_form_widget\:\:\$preview_values\.$#'
+			identifier: property.notFound
+			count: 1
+			path: ../includes/forms/form-widget.php
+
+		-
+			message: '#^One or more @param tags has an invalid name or invalid syntax\.$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: ../includes/l10n.php
+
+		-
+			message: '#^Function acf_add_local_fields\(\) should return array but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: ../includes/local-fields.php
+
+		-
+			message: '#^Action callback returns bool but should not return anything\.$#'
+			identifier: return.void
+			count: 10
+			path: ../includes/local-json.php
+
+		-
+			message: '#^Function remove_filter invoked with 4 parameters, 2\-3 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../includes/local-meta.php
+
+		-
+			message: '#^Expected 2 @param tags, found 1\.$#'
+			identifier: paramTag.count
+			count: 2
+			path: ../includes/locations.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ACF_Legacy_Location\)\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 3
+			path: ../includes/locations/abstract-acf-legacy-location.php
+
+		-
+			message: '#^Undefined variable\: \$method$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../includes/locations/abstract-acf-legacy-location.php
+
+		-
+			message: '#^Variable \$method in isset\(\) is never defined\.$#'
+			identifier: isset.variable
+			count: 1
+			path: ../includes/locations/abstract-acf-legacy-location.php
+
+		-
+			message: '#^Access to an undefined property acf_loop\:\:\$loops\.$#'
+			identifier: property.notFound
+			count: 7
+			path: ../includes/loop.php
+
+		-
+			message: '#^Method acf_loop\:\:remove_loop\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 2
+			path: ../includes/loop.php
+
+		-
+			message: '#^Callback expects 1 parameter, \$accepted_args is set to 2\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../includes/revisions.php
+
+		-
+			message: '#^Constant ACF_VERSION not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: ../includes/third-party.php
+
+		-
+			message: '#^Constant ACF_UPGRADE_VERSION not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: ../includes/upgrades.php
+
+		-
+			message: '#^Constant ACF_VERSION not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: ../includes/upgrades.php
+
+		-
+			message: '#^Access to an undefined property acf_validation\:\:\$errors\.$#'
+			identifier: property.notFound
+			count: 3
+			path: ../includes/validation.php
+
+		-
+			message: '#^Access to an undefined property ACF_WPML_Compatibility\:\:\$trid_ref\.$#'
+			identifier: property.notFound
+			count: 1
+			path: ../includes/wpml.php
+
+		-
+			message: '#^Constant ACF_BASENAME not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: ../secure-custom-fields.php
+
+		-
+			message: '#^Constant ACF_FIELD_API_VERSION not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: ../secure-custom-fields.php
+
+		-
+			message: '#^Constant ACF_MAJOR_VERSION not found\.$#'
+			identifier: constant.notFound
+			count: 4
+			path: ../secure-custom-fields.php
+
+		-
+			message: '#^Constant ACF_PATH not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: ../secure-custom-fields.php
+
+		-
+			message: '#^Constant ACF_VERSION not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: ../secure-custom-fields.php
+
+		-
+			message: '#^One or more @param tags has an invalid name or invalid syntax\.$#'
+			identifier: phpDoc.parseError
+			count: 7
+			path: ../secure-custom-fields.php
+
+		-
+			message: '#^Path in require_once\(\) "\./wp\-admin/includes/plugin\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../secure-custom-fields.php

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,16 @@
         "sirbrillig/phpcs-changed": "^2.11",
         "symfony/finder": "^5.0 || ^6.0",
         "wp-coding-standards/wpcs": "^3.0",
-        "yoast/phpunit-polyfills": "^1.1.0"
+        "yoast/phpunit-polyfills": "^1.1.0",
+        "szepeviktor/phpstan-wordpress": "^2.0",
+        "phpstan/extension-installer": "^1.4"
     },
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "ergebnis/composer-normalize": true,
-            "roots/wordpress-core-installer": true
+            "roots/wordpress-core-installer": true,
+            "phpstan/extension-installer": true
         },
         "platform": {
             "php": "7.4"
@@ -63,7 +66,11 @@
             "@format:packages",
             "php bin/prepare-release.php"
         ],
-        "test": "@test:php",
-        "test:php": "phpunit"
+        "test": [
+            "@test:php",
+            "@test:phpstan"
+        ],
+        "test:php": "phpunit",
+        "test:phpstan": "phpstan analyze --memory-limit=2G"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b0dbcb52c8c469c2f9bcc152f8f03ec9",
+    "content-hash": "0ed549f49528a34912ada7cdd46e44ca",
     "packages": [],
     "packages-dev": [
         {
@@ -1201,6 +1201,54 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "c04f96cb232fab12a3cbcccf5a47767f0665c3f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/c04f96cb232fab12a3cbcccf5a47767f0665c3f4",
+                "reference": "c04f96cb232fab12a3cbcccf5a47767f0665c3f4",
+                "shasum": ""
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^4.13",
+                "php": "^7.4 || ^8.0",
+                "php-stubs/generator": "^0.8.3",
+                "phpdocumentor/reflection-docblock": "^5.4.1",
+                "phpstan/phpstan": "^1.11",
+                "phpunit/phpunit": "^9.5",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.7.2"
+            },
+            "time": "2025-02-12T04:51:58+00:00"
+        },
+        {
             "name": "phpcompatibility/php-compatibility",
             "version": "9.3.5",
             "source": {
@@ -1569,6 +1617,112 @@
                 }
             ],
             "time": "2024-05-20T13:34:27+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/85e90b3942d06b2326fba0403ec24fe912372936",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.9.0 || ^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.4.3"
+            },
+            "time": "2024-09-04T20:21:43+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c",
+                "reference": "6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-19T15:46:42+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3486,6 +3640,68 @@
                 }
             ],
             "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "szepeviktor/phpstan-wordpress",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
+                "reference": "f7beb13cd22998e3d913fdb897a1e2553ccd637e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/f7beb13cd22998e3d913fdb897a1e2553ccd637e",
+                "reference": "f7beb13cd22998e3d913fdb897a1e2553ccd637e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "php-stubs/wordpress-stubs": "^6.6.2",
+                "phpstan/phpstan": "^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.1.14",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.0",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "swissspidy/phpstan-no-private": "Detect usage of internal core functions, classes and methods"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SzepeViktor\\PHPStan\\WordPress\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress extensions for PHPStan",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v2.0.1"
+            },
+            "time": "2024-12-01T02:13:05+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,13 @@
+includes:
+	- bin/baseline.neon
+parameters:
+	level: 1
+	paths:
+		- .
+	excludePaths:
+		- node_modules
+		- assets
+		- vendor
+		- docs
+		- lang
+		- wordpress


### PR DESCRIPTION
Adds PHPStan for static analysis.

To start, setting it loose (level 1 of 0-10) and putting all errors into a baseline file for now. The idea is not to add any additional errors without slowing down any other work.

Over time, reduce the number of errors down and increasing the level to one that if sufficiently strict.
