### PR TITLE
Playground: Add blueprint json asset file

### DIFF
--- a/assets/blueprints/blueprint.json
+++ b/assets/blueprints/blueprint.json
@@ -1,0 +1,23 @@
+{
+  "landingPage": "/wp-admin/edit.php?post_type=acf-field-group",
+  "features": {
+    "networking": true
+  },
+  "steps": [
+    {
+        "step": "login",
+        "username": "admin",
+        "password": "password"
+      },
+    {
+      "step": "installPlugin",
+      "pluginZipFile": {
+        "resource": "wordpress.org/plugins",
+        "slug": "secure-custom-fields"
+      },
+      "options": {
+        "activate": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds `blueprint.json` file to enable live preview in plugins.

Followed this doc: https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/#enabling-plugin-previews

Co-authored with @santosguillamot.

PD: I may need extra permissions to test this, a plugin committer needs to enable live previews 😅 