### PR TITLE
e2e: use nvmrc version

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20.15.1"
+          node-version-file: '.nvmrc'
           cache: "npm"
 
       - name: Install dependencies


### PR DESCRIPTION
Update the e2e tests to use the nvmrc version per code review https://github.com/WordPress/secure-custom-fields/pull/91#pullrequestreview-2721114274
