### PR TITLE
Revert text domain change

### DIFF
--- a/includes/api/api-template.php
+++ b/includes/api/api-template.php
@@ -1040,7 +1040,7 @@ function acf_shortcode( $atts ) {
 			'format_value' => true,
 		),
 		$atts,
-		'secure-custom-fields'
+		'acf'
 	);
 
 	// Decode the post ID for filtering.


### PR DESCRIPTION
In order for the filter to be named correctly (https://developer.wordpress.org/reference/functions/shortcode_atts/), the 3rd parameter should be the shortcode.