### PR TITLE
E2E: Add a trash all post types step.

### DIFF
--- a/tests/e2e/create-post-type.spec.ts
+++ b/tests/e2e/create-post-type.spec.ts
@@ -122,6 +122,7 @@ async function trashAllPostTypes(page, admin) {
   const emptyTrashButton = page.locator('.tablenav.bottom input[name="delete_all"][value="Empty Trash"]');
   await emptyTrashButton.waitFor({ state: 'visible' });
   await emptyTrashButton.click();
-  // Verify trash is empty. 
-  await expect(page.locator('.wp-list-table tbody tr td')).toHaveText('No Post Types found in Trash');
+  const successNotice = page.locator('.notice.updated p');
+  await expect(successNotice).toBeVisible();
+  await expect(successNotice).toHaveText(/post permanently deleted/);
 }

--- a/tests/e2e/create-post-type.spec.ts
+++ b/tests/e2e/create-post-type.spec.ts
@@ -35,6 +35,9 @@ test.describe('Post Type Creation', () => {
     
     // SECTION: Clean up - delete the post type
     await deletePostType(page, admin);
+
+    // SECTION: Trash all post types created
+    await trashAllPostTypes(page, admin);
   });
 });
 
@@ -109,4 +112,16 @@ async function deletePostType(page, admin) {
   const deleteMessage = page.locator('.updated.notice');
   await expect(deleteMessage).toBeVisible({ timeout: 5000 });
   await expect(deleteMessage).toContainText('moved to the Trash');
+}
+
+/**
+ * Helper function to trash all post types created.
+ */
+async function trashAllPostTypes(page, admin) {
+  await admin.visitAdminPage('edit.php', 'post_status=trash&post_type=acf-post-type');
+  const emptyTrashButton = page.locator('.tablenav.bottom input[name="delete_all"][value="Empty Trash"]');
+  await emptyTrashButton.waitFor({ state: 'visible' });
+  await emptyTrashButton.click();
+  // Verify trash is empty. 
+  await expect(page.locator('.wp-list-table tbody tr td')).toHaveText('No Post Types found in Trash');
 }


### PR DESCRIPTION
## What

Adds a `trashAllPostTypes` helper to clean the testing environment when you run it locally. On GitHub Actions, the env is destroyed after running it, but still cleaning is a good approach to keep consistency with future tests.