### PR TITLE
Refactor: Prevent some `undefined` array key warnings.

### DIFF
--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -192,7 +192,7 @@ if ( ! class_exists( 'ACF_Compatibility' ) ) :
 			}
 
 			// object is now array
-			if ( isset( $field['return_format'] ) && 'object' === $field['return_format'] ) {
+			if ( 'object' === acf_maybe_get( $field, 'return_format' ) ) {
 				$field['return_format'] = 'array';
 			}
 

--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -192,7 +192,7 @@ if ( ! class_exists( 'ACF_Compatibility' ) ) :
 			}
 
 			// object is now array
-			if ( $field['return_format'] == 'object' ) {
+			if ( isset( $field['return_format'] ) && 'object' === $field['return_format'] ) {
 				$field['return_format'] = 'array';
 			}
 

--- a/includes/fields/class-acf-field-button-group.php
+++ b/includes/fields/class-acf-field-button-group.php
@@ -75,19 +75,22 @@ if ( ! class_exists( 'acf_field_button_group' ) ) :
 			}
 
 			// maybe select initial value
-			if ( ! $field['allow_null'] && $selected === null ) {
+			if ( ( ! isset( $field['allow_null'] ) || ! $field['allow_null'] ) && null === $selected ) {
 				$buttons[0]['checked'] = true;
 			}
 
 			// div
 			$div = array( 'class' => 'acf-button-group' );
 
-			if ( $field['layout'] == 'vertical' ) {
-				$div['class'] .= ' -vertical'; }
-			if ( $field['class'] ) {
-				$div['class'] .= ' ' . $field['class']; }
-			if ( $field['allow_null'] ) {
-				$div['data-allow_null'] = 1; }
+			if ( 'vertical' === acf_maybe_get( $field, 'layout' ) ) {
+				$div['class'] .= ' -vertical';
+			}
+			if ( acf_maybe_get( $field, 'class' ) ) {
+				$div['class'] .= ' ' . acf_maybe_get( $field, 'class' );
+			}
+			if ( acf_maybe_get( $field, 'allow_null' ) ) {
+				$div['data-allow_null'] = 1;
+			}
 
 			// hidden input
 			$html .= acf_get_hidden_input( array( 'name' => $field['name'] ) );

--- a/includes/fields/class-acf-field-checkbox.php
+++ b/includes/fields/class-acf-field-checkbox.php
@@ -70,22 +70,23 @@ if ( ! class_exists( 'acf_field_checkbox' ) ) :
 			);
 
 			// append to class
-			$ul['class'] .= ' ' . ( isset( $field['layout'] ) && 'horizontal' === $field['layout'] ? 'acf-hl' : 'acf-bl' );
-			$ul['class'] .= ' ' . ( isset( $field['class'] ) ? $field['class'] : '' );
+			$ul['class'] .= ' ' . ( 'horizontal' === acf_maybe_get( $field, 'layout' ) ? 'acf-hl' : 'acf-bl' );
+			$ul['class'] .= ' ' . acf_maybe_get( $field, 'class', '' );
 
 			// checkbox saves an array
-			if ( isset( $field['name'] ) ) {
+			if ( acf_maybe_get( $field, 'name' ) ) {
 				$field['name'] .= '[]';
 			}
 
 			// choices
-			if ( isset( $field['choices'] ) && ! empty( $field['choices'] ) ) {
+			$choices = acf_maybe_get( $field, 'choices', array() );
+			if ( ! empty( $choices ) ) {
 
 				// choices
 				$li .= $this->render_field_choices( $field );
 
 				// toggle
-				if ( isset( $field['toggle'] ) && $field['toggle'] ) {
+				if ( acf_maybe_get( $field, 'toggle' ) ) {
 					$li = $this->render_field_toggle( $field ) . $li;
 				}
 			}
@@ -161,8 +162,9 @@ if ( ! class_exists( 'acf_field_checkbox' ) ) :
 			);
 
 			// custom label
-			if ( isset( $field['toggle'] ) && is_string( $field['toggle'] ) ) {
-				$atts['label'] = $field['toggle'];
+			$toggle = acf_maybe_get( $field, 'toggle' );
+			if ( is_string( $toggle ) ) {
+				$atts['label'] = $toggle;
 			}
 
 			// checked
@@ -191,19 +193,21 @@ if ( ! class_exists( 'acf_field_checkbox' ) ) :
 			$html = '';
 
 			// loop
-			if ( isset( $field['value'] ) && is_array( $field['value'] ) ) {
-				foreach ( $field['value'] as $value ) {
+			$value = acf_maybe_get( $field, 'value', array() );
+			if ( is_array( $value ) ) {
+				foreach ( $value as $item ) {
 
 					// ignore if already exists
-					if ( isset( $field['choices'][ $value ] ) ) {
+					$choices = acf_maybe_get( $field, 'choices', array() );
+					if ( isset( $choices[ $item ] ) ) {
 						continue;
 					}
 
 					// vars
-					$esc_value  = esc_attr( $value );
+					$esc_value  = esc_attr( $item );
 					$text_input = array(
-						'name'  => isset( $field['name'] ) ? $field['name'] : '',
-						'value' => $value,
+						'name'  => acf_maybe_get( $field, 'name', '' ),
+						'value' => $item,
 					);
 
 					// bail early if choice already exists
@@ -218,7 +222,7 @@ if ( ! class_exists( 'acf_field_checkbox' ) ) :
 
 			// append button
 			// We need to check if is better to just not display the li if the button text is empty. But for now let's keep it as stable as possible.
-			$html .= '<li><a href="#" class="button acf-add-checkbox">' . esc_attr( isset( $field['custom_choice_button_text'] ) ? $field['custom_choice_button_text'] : '' ) . '</a></li>' . "\n";
+			$html .= '<li><a href="#" class="button acf-add-checkbox">' . esc_attr( acf_maybe_get( $field, 'custom_choice_button_text', '' ) ) . '</a></li>' . "\n";
 
 			// return
 			return $html;

--- a/includes/fields/class-acf-field-checkbox.php
+++ b/includes/fields/class-acf-field-checkbox.php
@@ -70,26 +70,28 @@ if ( ! class_exists( 'acf_field_checkbox' ) ) :
 			);
 
 			// append to class
-			$ul['class'] .= ' ' . ( $field['layout'] == 'horizontal' ? 'acf-hl' : 'acf-bl' );
-			$ul['class'] .= ' ' . $field['class'];
+			$ul['class'] .= ' ' . ( isset( $field['layout'] ) && 'horizontal' === $field['layout'] ? 'acf-hl' : 'acf-bl' );
+			$ul['class'] .= ' ' . ( isset( $field['class'] ) ? $field['class'] : '' );
 
 			// checkbox saves an array
-			$field['name'] .= '[]';
+			if ( isset( $field['name'] ) ) {
+				$field['name'] .= '[]';
+			}
 
 			// choices
-			if ( ! empty( $field['choices'] ) ) {
+			if ( isset( $field['choices'] ) && ! empty( $field['choices'] ) ) {
 
 				// choices
 				$li .= $this->render_field_choices( $field );
 
 				// toggle
-				if ( $field['toggle'] ) {
+				if ( isset( $field['toggle'] ) && $field['toggle'] ) {
 					$li = $this->render_field_toggle( $field ) . $li;
 				}
 			}
 
 			// custom
-			if ( $field['allow_custom'] ) {
+			if ( isset( $field['allow_custom'] ) && $field['allow_custom'] ) {
 				$li .= $this->render_field_custom( $field );
 			}
 
@@ -159,7 +161,7 @@ if ( ! class_exists( 'acf_field_checkbox' ) ) :
 			);
 
 			// custom label
-			if ( is_string( $field['toggle'] ) ) {
+			if ( isset( $field['toggle'] ) && is_string( $field['toggle'] ) ) {
 				$atts['label'] = $field['toggle'];
 			}
 
@@ -189,31 +191,34 @@ if ( ! class_exists( 'acf_field_checkbox' ) ) :
 			$html = '';
 
 			// loop
-			foreach ( $field['value'] as $value ) {
+			if ( isset( $field['value'] ) && is_array( $field['value'] ) ) {
+				foreach ( $field['value'] as $value ) {
 
-				// ignore if already exists
-				if ( isset( $field['choices'][ $value ] ) ) {
-					continue;
+					// ignore if already exists
+					if ( isset( $field['choices'][ $value ] ) ) {
+						continue;
+					}
+
+					// vars
+					$esc_value  = esc_attr( $value );
+					$text_input = array(
+						'name'  => isset( $field['name'] ) ? $field['name'] : '',
+						'value' => $value,
+					);
+
+					// bail early if choice already exists
+					if ( in_array( $esc_value, $this->_values, true ) ) {
+						continue;
+					}
+
+					// append
+					$html .= '<li><input class="acf-checkbox-custom" type="checkbox" checked="checked" />' . acf_get_text_input( $text_input ) . '</li>' . "\n";
 				}
-
-				// vars
-				$esc_value  = esc_attr( $value );
-				$text_input = array(
-					'name'  => $field['name'],
-					'value' => $value,
-				);
-
-				// bail early if choice already exists
-				if ( in_array( $esc_value, $this->_values ) ) {
-					continue;
-				}
-
-				// append
-				$html .= '<li><input class="acf-checkbox-custom" type="checkbox" checked="checked" />' . acf_get_text_input( $text_input ) . '</li>' . "\n";
 			}
 
 			// append button
-			$html .= '<li><a href="#" class="button acf-add-checkbox">' . esc_attr( $field['custom_choice_button_text'] ) . '</a></li>' . "\n";
+			// We need to check if is better to just not display the li if the button text is empty. But for now let's keep it as stable as possible.
+			$html .= '<li><a href="#" class="button acf-add-checkbox">' . esc_attr( isset( $field['custom_choice_button_text'] ) ? $field['custom_choice_button_text'] : '' ) . '</a></li>' . "\n";
 
 			// return
 			return $html;

--- a/includes/fields/class-acf-field-file.php
+++ b/includes/fields/class-acf-field-file.php
@@ -95,8 +95,8 @@ if ( ! class_exists( 'acf_field_file' ) ) :
 
 			$div = array(
 				'class'           => 'acf-file-uploader',
-				'data-library'    => isset( $field['library'] ) ? $field['library'] : '',
-				'data-mime_types' => isset( $field['mime_types'] ) ? $field['mime_types'] : '',
+				'data-library'    => acf_maybe_get( $field, 'library', '' ),
+				'data-mime_types' => acf_maybe_get( $field, 'mime_types', '' ),
 				'data-uploader'   => $uploader,
 			);
 

--- a/includes/fields/class-acf-field-file.php
+++ b/includes/fields/class-acf-field-file.php
@@ -95,8 +95,8 @@ if ( ! class_exists( 'acf_field_file' ) ) :
 
 			$div = array(
 				'class'           => 'acf-file-uploader',
-				'data-library'    => $field['library'],
-				'data-mime_types' => $field['mime_types'],
+				'data-library'    => isset( $field['library'] ) ? $field['library'] : '',
+				'data-mime_types' => isset( $field['mime_types'] ) ? $field['mime_types'] : '',
 				'data-uploader'   => $uploader,
 			);
 

--- a/includes/fields/class-acf-field-number.php
+++ b/includes/fields/class-acf-field-number.php
@@ -55,18 +55,18 @@ if ( ! class_exists( 'acf_field_number' ) ) :
 			$html  = '';
 
 			// step
-			if ( ! $field['step'] ) {
+			if ( ! isset( $field['step'] ) || ! $field['step'] ) {
 				$field['step'] = 'any';
 			}
 
 			// prepend
-			if ( $field['prepend'] !== '' ) {
-				$field['class'] .= ' acf-is-prepended';
-				$html           .= '<div class="acf-input-prepend">' . acf_esc_html( $field['prepend'] ) . '</div>';
+			if ( isset( $field['prepend'] ) && '' !== $field['prepend'] ) {
+				$field['class'] = isset( $field['class'] ) ? $field['class'] . ' acf-is-prepended' : 'acf-is-prepended';
+				$html          .= '<div class="acf-input-prepend">' . acf_esc_html( $field['prepend'] ) . '</div>';
 			}
 
 			// append
-			if ( $field['append'] !== '' ) {
+			if ( isset( $field['append'] ) && '' !== $field['append'] ) {
 				$field['class'] .= ' acf-is-appended';
 				$html           .= '<div class="acf-input-append">' . acf_esc_html( $field['append'] ) . '</div>';
 			}

--- a/includes/fields/class-acf-field-select.php
+++ b/includes/fields/class-acf-field-select.php
@@ -248,14 +248,14 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 
 			// vars
 			$select = array(
-				'id'               => isset( $field['id'] ) ? $field['id'] : '',
-				'class'            => isset( $field['class'] ) ? $field['class'] : '',
-				'name'             => isset( $field['name'] ) ? $field['name'] : '',
-				'data-ui'          => isset( $field['ui'] ) ? $field['ui'] : '',
-				'data-ajax'        => isset( $field['ajax'] ) ? $field['ajax'] : '',
-				'data-multiple'    => isset( $field['multiple'] ) ? $field['multiple'] : '',
-				'data-placeholder' => isset( $field['placeholder'] ) ? $field['placeholder'] : '',
-				'data-allow_null'  => isset( $field['allow_null'] ) ? $field['allow_null'] : '',
+				'id'               => acf_maybe_get( $field, 'id', '' ),
+				'class'            => acf_maybe_get( $field, 'class', '' ),
+				'name'             => acf_maybe_get( $field, 'name', '' ),
+				'data-ui'          => acf_maybe_get( $field, 'ui', '' ),
+				'data-ajax'        => acf_maybe_get( $field, 'ajax', '' ),
+				'data-multiple'    => acf_maybe_get( $field, 'multiple', '' ),
+				'data-placeholder' => acf_maybe_get( $field, 'placeholder', '' ),
+				'data-allow_null'  => acf_maybe_get( $field, 'allow_null', '' ),
 			);
 
 			if ( ! empty( $field['aria-label'] ) ) {
@@ -615,7 +615,7 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 				return $valid;
 			}
 
-			if ( ! isset( $field['choices'] ) ) {
+			if ( ! acf_maybe_get( $field, 'choices' ) ) {
 				return $valid;
 			}
 

--- a/includes/fields/class-acf-field-select.php
+++ b/includes/fields/class-acf-field-select.php
@@ -583,13 +583,13 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 			// value
 			$return_format = isset( $field['return_format'] ) ? $field['return_format'] : 'value';
 
-			if ( isset( $return_format ) && 'value' === $return_format ) {
+			if ( 'value' === $return_format ) {
 				// do nothing
 				return $value;
-			} elseif ( isset( $return_format ) && 'label' === $return_format ) {
+			} elseif ( 'label' === $return_format ) {
 				// label
 				$value = $label;
-			} elseif ( isset( $return_format ) && 'array' === $return_format ) {
+			} elseif ( 'array' === $return_format ) {
 				// array
 				$value = array(
 					'value' => $value,

--- a/includes/fields/class-acf-field-select.php
+++ b/includes/fields/class-acf-field-select.php
@@ -171,7 +171,7 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 			$s       = null;
 
 			// search.
-			if ( $options['s'] !== '' ) {
+			if ( isset( $options['s'] ) && '' !== $options['s'] ) {
 
 				// strip slashes (search may be integer)
 				$s = strval( $options['s'] );
@@ -231,12 +231,12 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 			// prepend empty choice
 			// - only for single selects
 			// - have tried array_merge but this causes keys to re-index if is numeric (post ID's)
-			if ( $field['allow_null'] && ! $field['multiple'] ) {
+			if ( isset( $field['allow_null'] ) && $field['allow_null'] && isset( $field['multiple'] ) && ! $field['multiple'] ) {
 				$choices = array( '' => "- {$field['placeholder']} -" ) + $choices;
 			}
 
 			// clean up choices if using ajax
-			if ( $field['ui'] && $field['ajax'] ) {
+			if ( isset( $field['ui'] ) && $field['ui'] && isset( $field['ajax'] ) && $field['ajax'] ) {
 				$minimal = array();
 				foreach ( $value as $key ) {
 					if ( isset( $choices[ $key ] ) ) {
@@ -248,14 +248,14 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 
 			// vars
 			$select = array(
-				'id'               => $field['id'],
-				'class'            => $field['class'],
-				'name'             => $field['name'],
-				'data-ui'          => $field['ui'],
-				'data-ajax'        => $field['ajax'],
-				'data-multiple'    => $field['multiple'],
-				'data-placeholder' => $field['placeholder'],
-				'data-allow_null'  => $field['allow_null'],
+				'id'               => isset( $field['id'] ) ? $field['id'] : '',
+				'class'            => isset( $field['class'] ) ? $field['class'] : '',
+				'name'             => isset( $field['name'] ) ? $field['name'] : '',
+				'data-ui'          => isset( $field['ui'] ) ? $field['ui'] : '',
+				'data-ajax'        => isset( $field['ajax'] ) ? $field['ajax'] : '',
+				'data-multiple'    => isset( $field['multiple'] ) ? $field['multiple'] : '',
+				'data-placeholder' => isset( $field['placeholder'] ) ? $field['placeholder'] : '',
+				'data-allow_null'  => isset( $field['allow_null'] ) ? $field['allow_null'] : '',
 			);
 
 			if ( ! empty( $field['aria-label'] ) ) {
@@ -263,13 +263,13 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 			}
 
 			// multiple
-			if ( $field['multiple'] ) {
+			if ( isset( $field['multiple'] ) && $field['multiple'] ) {
 				$select['multiple'] = 'multiple';
 				$select['size']     = 5;
 				$select['name']    .= '[]';
 
 				// Reduce size to single line if UI.
-				if ( $field['ui'] ) {
+				if ( isset( $field['ui'] ) && $field['ui'] ) {
 					$select['size'] = 1;
 				}
 			}
@@ -287,7 +287,7 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 			if ( ! empty( $field['nonce'] ) ) {
 				$select['data-nonce'] = $field['nonce'];
 			}
-			if ( $field['ajax'] && empty( $field['nonce'] ) && acf_is_field_key( $field['key'] ) ) {
+			if ( isset( $field['ajax'] ) && $field['ajax'] && empty( $field['nonce'] ) && isset( $field['key'] ) && acf_is_field_key( $field['key'] ) ) {
 				$select['data-nonce'] = wp_create_nonce( $field['key'] );
 			}
 			if ( ! empty( $field['hide_search'] ) ) {
@@ -295,7 +295,7 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 			}
 
 			// hidden input is needed to allow validation to see <select> element with no selected value
-			if ( $field['multiple'] || $field['ui'] ) {
+			if ( ( isset( $field['multiple'] ) && $field['multiple'] ) || ( isset( $field['ui'] ) && $field['ui'] ) ) {
 				acf_hidden_input(
 					array(
 						'id'   => $field['id'] . '-input',
@@ -581,15 +581,16 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 			$label = acf_maybe_get( $field['choices'], $value, $value );
 
 			// value
-			if ( $field['return_format'] == 'value' ) {
+			$return_format = isset( $field['return_format'] ) ? $field['return_format'] : 'value';
 
+			if ( isset( $return_format ) && 'value' === $return_format ) {
 				// do nothing
+				return $value;
+			} elseif ( isset( $return_format ) && 'label' === $return_format ) {
 				// label
-			} elseif ( $field['return_format'] == 'label' ) {
 				$value = $label;
-
+			} elseif ( isset( $return_format ) && 'array' === $return_format ) {
 				// array
-			} elseif ( $field['return_format'] == 'array' ) {
 				$value = array(
 					'value' => $value,
 					'label' => $label,
@@ -614,6 +615,10 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 				return $valid;
 			}
 
+			if ( ! isset( $field['choices'] ) ) {
+				return $valid;
+			}
+
 			$option_keys = array_diff(
 				array_keys( $field['choices'] ),
 				array_values( $field['choices'] )
@@ -622,12 +627,14 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 			$allowed = empty( $option_keys ) ? $field['choices'] : $option_keys;
 
 			if ( ! in_array( $value, $allowed ) ) {
-				$param = sprintf( '%s[%s]', $field['prefix'], $field['name'] );
-				$data  = array(
+				$prefix = isset( $field['prefix'] ) ? $field['prefix'] : '';
+				$name   = isset( $field['name'] ) ? $field['name'] : '';
+				$param  = sprintf( '%s[%s]', $prefix, $name );
+				$data   = array(
 					'param' => $param,
 					'value' => $value,
 				);
-				$error = sprintf(
+				$error  = sprintf(
 					/* translators: 1: parameter, 2: allowed values */
 					__( '%1$s is not one of %2$s', 'secure-custom-fields' ),
 					$param,

--- a/includes/fields/class-acf-field-text.php
+++ b/includes/fields/class-acf-field-text.php
@@ -48,15 +48,15 @@ if ( ! class_exists( 'acf_field_text' ) ) :
 			$html = '';
 
 			// Prepend text.
-			if ( $field['prepend'] !== '' ) {
-				$field['class'] .= ' acf-is-prepended';
-				$html           .= '<div class="acf-input-prepend">' . acf_esc_html( $field['prepend'] ) . '</div>';
+			if ( isset( $field['prepend'] ) && '' !== $field['prepend'] ) {
+				$field['class'] = isset( $field['class'] ) ? $field['class'] . ' acf-is-prepended' : 'acf-is-prepended';
+				$html          .= '<div class="acf-input-prepend">' . acf_esc_html( $field['prepend'] ) . '</div>';
 			}
 
 			// Append text.
-			if ( $field['append'] !== '' ) {
-				$field['class'] .= ' acf-is-appended';
-				$html           .= '<div class="acf-input-append">' . acf_esc_html( $field['append'] ) . '</div>';
+			if ( isset( $field['append'] ) && '' !== $field['append'] ) {
+				$field['class'] = isset( $field['class'] ) ? $field['class'] . ' acf-is-appended' : 'acf-is-appended';
+				$html          .= '<div class="acf-input-append">' . acf_esc_html( $field['append'] ) . '</div>';
 			}
 
 			// Input.
@@ -179,7 +179,7 @@ if ( ! class_exists( 'acf_field_text' ) ) :
 		function validate_value( $valid, $value, $field, $input ) {
 
 			// Check maxlength
-			if ( $field['maxlength'] && ( acf_strlen( $value ) > $field['maxlength'] ) ) {
+			if ( isset( $field['maxlength'] ) && $field['maxlength'] && ( acf_strlen( $value ) > $field['maxlength'] ) ) {
 				/* translators: %d: the maximum number of characters */
 				return sprintf( __( 'Value must not exceed %d characters', 'secure-custom-fields' ), $field['maxlength'] );
 			}

--- a/includes/fields/class-acf-field-true_false.php
+++ b/includes/fields/class-acf-field-true_false.php
@@ -84,8 +84,8 @@ if ( ! class_exists( 'acf_field_true_false' ) ) :
 				$input['class'] .= ' acf-switch-input';
 				// $input['style'] = 'display:none;';
 				$switch .= '<div class="acf-switch' . ( $active ? ' -on' : '' ) . '">';
-				$switch .= '<span class="acf-switch-on">' . ( isset( $field['ui_on_text'] ) ? $field['ui_on_text'] : '' ) . '</span>';
-				$switch .= '<span class="acf-switch-off">' . ( isset( $field['ui_off_text'] ) ? $field['ui_off_text'] : '' ) . '</span>';
+				$switch .= '<span class="acf-switch-on">' . acf_maybe_get( $field, 'ui_on_text', '' ) . '</span>';
+				$switch .= '<span class="acf-switch-off">' . acf_maybe_get( $field, 'ui_off_text', '' ) . '</span>';
 				$switch .= '<div class="acf-switch-slider"></div>';
 				$switch .= '</div>';
 			}
@@ -100,7 +100,7 @@ if ( ! class_exists( 'acf_field_true_false' ) ) :
 				echo acf_esc_html( $switch );}
 			?>
 			<?php
-			if ( isset( $field['message'] ) && $field['message'] ) :
+			if ( acf_maybe_get( $field, 'message' ) ) :
 				?>
 				<span class="message"><?php echo acf_esc_html( $field['message'] ); ?></span><?php endif; ?>
 	</label>

--- a/includes/fields/class-acf-field-true_false.php
+++ b/includes/fields/class-acf-field-true_false.php
@@ -61,7 +61,7 @@ if ( ! class_exists( 'acf_field_true_false' ) ) :
 				'value' => 0,
 			);
 
-			$active = $field['value'] ? true : false;
+			$active = isset( $field['value'] ) && $field['value'] ? true : false;
 			$switch = '';
 
 			// checked
@@ -70,13 +70,13 @@ if ( ! class_exists( 'acf_field_true_false' ) ) :
 			}
 
 			// ui
-			if ( $field['ui'] ) {
+			if ( isset( $field['ui'] ) && $field['ui'] ) {
 
 				// vars
-				if ( $field['ui_on_text'] === '' ) {
+				if ( isset( $field['ui_on_text'] ) && '' === $field['ui_on_text'] ) {
 					$field['ui_on_text'] = __( 'Yes', 'secure-custom-fields' );
 				}
-				if ( $field['ui_off_text'] === '' ) {
+				if ( isset( $field['ui_off_text'] ) && '' === $field['ui_off_text'] ) {
 					$field['ui_off_text'] = __( 'No', 'secure-custom-fields' );
 				}
 
@@ -84,8 +84,8 @@ if ( ! class_exists( 'acf_field_true_false' ) ) :
 				$input['class'] .= ' acf-switch-input';
 				// $input['style'] = 'display:none;';
 				$switch .= '<div class="acf-switch' . ( $active ? ' -on' : '' ) . '">';
-				$switch .= '<span class="acf-switch-on">' . $field['ui_on_text'] . '</span>';
-				$switch .= '<span class="acf-switch-off">' . $field['ui_off_text'] . '</span>';
+				$switch .= '<span class="acf-switch-on">' . ( isset( $field['ui_on_text'] ) ? $field['ui_on_text'] : '' ) . '</span>';
+				$switch .= '<span class="acf-switch-off">' . ( isset( $field['ui_off_text'] ) ? $field['ui_off_text'] : '' ) . '</span>';
 				$switch .= '<div class="acf-switch-slider"></div>';
 				$switch .= '</div>';
 			}
@@ -100,7 +100,7 @@ if ( ! class_exists( 'acf_field_true_false' ) ) :
 				echo acf_esc_html( $switch );}
 			?>
 			<?php
-			if ( $field['message'] ) :
+			if ( isset( $field['message'] ) && $field['message'] ) :
 				?>
 				<span class="message"><?php echo acf_esc_html( $field['message'] ); ?></span><?php endif; ?>
 	</label>


### PR DESCRIPTION
## What

While working on SCF. I have been receiving several warnings that made field creation difficult. Something like this:

![Screenshot 2025-04-07 at 18 10 13](https://github.com/user-attachments/assets/28252bde-7a4c-46f5-91ca-46fa9a28b426)
![Screenshot 2025-04-07 at 18 10 19](https://github.com/user-attachments/assets/cbe9b4d5-c8fe-4e1f-a2f2-f230bdd70cc2)

## Test

- Check that you have similar warnings than the ones shown in the screenshot when you try to create custom fields.
- Check that with the PR they are gone.