### PR TITLE
Translations: add script to remove 90% translations

### DIFF
--- a/bin/prepare-release.php
+++ b/bin/prepare-release.php
@@ -49,6 +49,7 @@ class Release_Preparation {
 		$this->build_assets();
 		$this->run_tests();
 		$this->generate_docs();
+		$this->update_translations();
 		$this->commit_changes();
 
 		$current_version = $this->get_current_version();
@@ -186,7 +187,7 @@ class Release_Preparation {
 			if ( 0 !== $return ) {
 				exit( $return );
 			}
-			passthru( 'git commit -m "Build assets and documentation"', $return );
+			passthru( 'git commit -m "Build assets, documentation, and translations"', $return );
 			if ( 0 !== $return ) {
 				exit( $return );
 			}
@@ -345,6 +346,15 @@ class Release_Preparation {
 		$line   = strtolower( trim( fgets( $handle ) ) );
 		fclose( $handle );
 		return 'y' === $line;
+	}
+
+	/**
+	 * Update plugin translations and cleanup
+	 */
+	private function update_translations() {
+		require_once __DIR__ . '/update-translations.php';
+		$updater = new Translation_Updater();
+		$updater->run();
 	}
 }
 

--- a/bin/prepare-release.php
+++ b/bin/prepare-release.php
@@ -50,6 +50,8 @@ class Release_Preparation {
 		$this->run_tests();
 		$this->generate_docs();
 		$this->update_translations();
+		// need to return to correct directory after running `update_translations`.
+		exec( chdir( dirname( __DIR__ ) ) );
 		$this->commit_changes();
 
 		$current_version = $this->get_current_version();

--- a/bin/prepare-release.php
+++ b/bin/prepare-release.php
@@ -50,8 +50,6 @@ class Release_Preparation {
 		$this->run_tests();
 		$this->generate_docs();
 		$this->update_translations();
-		// need to return to correct directory after running `update_translations`.
-		exec( chdir( dirname( __DIR__ ) ) );
 		$this->commit_changes();
 
 		$current_version = $this->get_current_version();

--- a/bin/update-translations.php
+++ b/bin/update-translations.php
@@ -1,0 +1,134 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Update plugin translations
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+namespace WordPress\SCF\Scripts;
+
+// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+// phpcs:disable WordPress.WP.AlternativeFunctions
+
+// Ensure we're in the right directory.
+chdir( dirname( dirname( __DIR__ ) ) );
+
+/**
+ * Handles the translation update process for Secure Custom Fields.
+ */
+class Translation_Updater {
+	/**
+	 * Plugin slug
+	 *
+	 * @var string
+	 */
+	private $plugin_slug = 'secure-custom-fields';
+
+	/**
+	 * Language directory
+	 *
+	 * @var string
+	 */
+	private $lang_dir;
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		$this->lang_dir = __DIR__ . '/../lang';
+	}
+
+	/**
+	 * Run the translation update
+	 */
+	public function run() {
+		if ( ! is_dir( $this->lang_dir ) ) {
+			echo "Language directory not found: {$this->lang_dir}\n";
+			return;
+		}
+
+		// Get available translations from WordPress.org
+		$translations = $this->get_available_translations();
+		if ( empty( $translations ) ) {
+			echo "No translations available from WordPress.org\n";
+			return;
+		}
+
+		// Get existing translation files
+		$pattern  = $this->lang_dir . '/' . $this->plugin_slug . '-*.po';
+		$po_files = glob( $pattern );
+
+		if ( empty( $po_files ) ) {
+			echo "No translation files found in {$this->lang_dir}\n";
+			return;
+		}
+
+		foreach ( $po_files as $po_file ) {
+			$basename = basename( $po_file );
+			$locale   = str_replace( array( $this->plugin_slug . '-', '.po' ), '', $basename );
+
+			echo "→ Checking $locale...\n";
+
+			$po_path   = $this->lang_dir . '/' . $this->plugin_slug . '-' . $locale . '.po';
+			$mo_path   = $this->lang_dir . '/' . $this->plugin_slug . '-' . $locale . '.mo';
+			$l10n_path = $this->lang_dir . '/' . $this->plugin_slug . '-' . $locale . '.l10n.php';
+
+			// If translation is in WordPress.org list, delete local files
+			if ( isset( $translations[ $locale ] ) ) {
+				if ( file_exists( $po_path ) ) {
+					unlink( $po_path );
+					echo "  ✓ Deleted .po file\n";
+				}
+				if ( file_exists( $mo_path ) ) {
+					unlink( $mo_path );
+					echo "  ✓ Deleted .mo file\n";
+				}
+				if ( file_exists( $l10n_path ) ) {
+					unlink( $l10n_path );
+					echo "  ✓ Deleted .l10n.php file\n";
+				}
+				echo "  ✓ Translation available on WordPress.org\n\n";
+				continue;
+			}
+
+			echo "  ⚠️ Translation not available on WordPress.org\n";
+		}
+	}
+
+	/**
+	 * Get available translations from WordPress.org
+	 *
+	 * @return array
+	 */
+	private function get_available_translations() {
+		$api_url = sprintf(
+			'https://api.wordpress.org/translations/plugins/1.0/?slug=%s',
+			$this->plugin_slug
+		);
+
+		$response = file_get_contents( $api_url );
+		if ( false === $response ) {
+			return array();
+		}
+
+		$data = json_decode( $response, true );
+		if ( ! isset( $data['translations'] ) ) {
+			return array();
+		}
+
+		$translations = array();
+		foreach ( $data['translations'] as $translation ) {
+			$translations[ $translation['language'] ] = array(
+				'package' => $translation['package'],
+			);
+		}
+
+		return $translations;
+	}
+}
+
+// Run the script
+$updater = new Translation_Updater();
+$updater->run();

--- a/bin/update-translations.php
+++ b/bin/update-translations.php
@@ -12,9 +12,6 @@ namespace WordPress\SCF\Scripts;
 // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 // phpcs:disable WordPress.WP.AlternativeFunctions
 
-// Ensure we're in the right directory.
-chdir( dirname( dirname( __DIR__ ) ) );
-
 /**
  * Handles the translation update process for Secure Custom Fields.
  */

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
         ],
         "test:php": "phpunit",
         "test:phpstan": "phpstan analyze --memory-limit=2G",
-        "test:phpstan:baseline": "phpstan analyze --memory-limit=2G --generate-baseline=bin/baseline.neon"
+        "test:phpstan:baseline": "phpstan analyze --memory-limit=2G --generate-baseline=bin/baseline.neon",
+        "update-translations": "php bin/update-translations.php"
     }
 }


### PR DESCRIPTION
Fixes #105

When preparing for a new release via `composer prepare-release` or a new `composer update-translations`, check for language packs on WordPress.org and remove any that are at 90%.

Future work would be to see if we can programmatically export the current translate.wordpress.org files for languages so any improvements made by volunteers make it to site owners.
