### PR TITLE
Allow config errors to be display to users

### DIFF
--- a/includes/api/api-template.php
+++ b/includes/api/api-template.php
@@ -1084,7 +1084,7 @@ function acf_shortcode( $atts ) {
 	}
 
 	if ( isset( $field['allow_in_bindings'] ) && ! $field['allow_in_bindings'] ) {
-		if ( is_preview() || current_user_can( $display_errors_to_user )) {
+		if ( is_preview() || current_user_can( $display_errors_to_user ) ) {
 			return apply_filters( 'acf/shortcode/field_not_allowed_message', '[' . esc_html__( 'The requested ACF field is not allowed to be output in bindings or the ACF Shortcode.', 'secure-custom-fields' ) . ']' );
 		} else {
 			return;

--- a/includes/api/api-template.php
+++ b/includes/api/api-template.php
@@ -1072,8 +1072,11 @@ function acf_shortcode( $atts ) {
 
 	$field_type = is_array( $field ) && isset( $field['type'] ) ? $field['type'] : 'text';
 
+	// Allow config errors to show for appropriate caps checked users.
+	$display_errors_to_user = apply_filters( 'acf/shortcode/display_admin_errors', 'manage_options' );
+
 	if ( ! acf_field_type_supports( $field_type, 'bindings', true ) ) {
-		if ( is_preview() ) {
+		if ( is_preview() || current_user_can( $display_errors_to_user ) ) {
 			return apply_filters( 'acf/shortcode/field_not_supported_message', '[' . esc_html__( 'The requested ACF field type does not support output in bindings or the ACF Shortcode.', 'secure-custom-fields' ) . ']' );
 		} else {
 			return;
@@ -1081,7 +1084,7 @@ function acf_shortcode( $atts ) {
 	}
 
 	if ( isset( $field['allow_in_bindings'] ) && ! $field['allow_in_bindings'] ) {
-		if ( is_preview() ) {
+		if ( is_preview() || current_user_can( $display_errors_to_user )) {
 			return apply_filters( 'acf/shortcode/field_not_allowed_message', '[' . esc_html__( 'The requested ACF field is not allowed to be output in bindings or the ACF Shortcode.', 'secure-custom-fields' ) . ']' );
 		} else {
 			return;


### PR DESCRIPTION
Shows errors when user is logged in, and has appropriate capabilities.

Fixes #85.

## Testing instructions

1. Add field to new install of SCF
2. Use shortcode [acf] to output field via [acf field=""]
3. Observe that with an administrator role, no output is display
4. Apply this PR
5. Re-test output, and a display error should be displayed in place of the field output
6. Check while logged out that no output is display as was show when logged in as administrator

Note: considered adding this to (https://github.com/WordPress/secure-custom-fields/blob/a1257ed19fbcf335411f0d0567c90154c78084d9/includes/api/api-template.php#L1053), but given the additional filter, it didn't seem appropriate, although happy to be convinced otherwise.