### PR TITLE
Update initialization of the `acfL10n` object to ensure it's available globally

### DIFF
--- a/assets/src/js/_acf.js
+++ b/assets/src/js/_acf.js
@@ -673,9 +673,8 @@
 	 *  @return	string Translated text.
 	 */
 
-	if ( window.acfL10n == undefined ) {
-		acfL10n = {};
-	}
+	// Make sure a global acfL10n object exists to prevent errors in other scopes
+	window.acfL10n = window.acfL10n || {};
 
 	acf.__ = function ( text ) {
 		return acfL10n[ text ] || text;


### PR DESCRIPTION
## What and why
When working with translations in the client, I ran into some issues with the `acfL10n` not being initialized properly in my scope. This change ensures `acfL10n` is available in all browsers and conditions.

## Testing instructions
Just use SCF and notice that nothing changed for the current features. However, this change will come in handy in the new features we are working on inside the editor.