### PR TITLE
phpstan fixes (includes/admin/*)

### DIFF
--- a/bin/baseline.neon
+++ b/bin/baseline.neon
@@ -1,42 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Access to an undefined property ACF_Admin_Field_Groups\:\:\$not_found_label\.$#'
-			identifier: property.notFound
-			count: 1
-			path: ../includes/admin/post-types/admin-field-groups.php
-
-		-
-			message: '#^Action callback returns array but should not return anything\.$#'
-			identifier: return.void
-			count: 1
-			path: ../includes/admin/post-types/admin-field-groups.php
-
-		-
-			message: '#^Class ACF_Admin_Post_type referenced with incorrect case\: ACF_Admin_Post_Type\.$#'
-			identifier: class.nameCase
-			count: 1
-			path: ../includes/admin/post-types/admin-post-type.php
-
-		-
-			message: '#^Access to an undefined property ACF_Admin_Post_Types\:\:\$not_found_label\.$#'
-			identifier: property.notFound
-			count: 1
-			path: ../includes/admin/post-types/admin-post-types.php
-
-		-
-			message: '#^Access to an undefined property ACF_Admin_Taxonomies\:\:\$not_found_label\.$#'
-			identifier: property.notFound
-			count: 1
-			path: ../includes/admin/post-types/admin-taxonomies.php
-
-		-
-			message: '#^Access to an undefined property ACF_Admin_UI_Options_Pages\:\:\$not_found_label\.$#'
-			identifier: property.notFound
-			count: 1
-			path: ../includes/admin/post-types/class-acf-admin-ui-options-pages.php
-
-		-
 			message: '#^Variable \$field might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1

--- a/includes/admin/admin-internal-post-type-list.php
+++ b/includes/admin/admin-internal-post-type-list.php
@@ -70,6 +70,13 @@ if ( ! class_exists( 'ACF_Admin_Internal_Post_Type_List' ) ) :
 		public $is_pro_feature = false;
 
 		/**
+		 * The label for the "not found" message.
+		 *
+		 * @var string
+		 */
+		public $not_found_label = '';
+
+		/**
 		 * Constructs the class.
 		 */
 		public function __construct() {

--- a/includes/admin/post-types/admin-field-groups.php
+++ b/includes/admin/post-types/admin-field-groups.php
@@ -40,7 +40,7 @@ if ( ! class_exists( 'ACF_Admin_Field_Groups' ) ) :
 		public function __construct() {
 			add_action( 'admin_menu', array( $this, 'admin_menu' ), 7 );
 			add_action( 'load-edit.php', array( $this, 'handle_redirection' ) );
-			add_action( 'post_class', array( $this, 'get_admin_table_post_classes' ), 10, 3 );
+			add_filter( 'post_class', array( $this, 'get_admin_table_post_classes' ), 10, 3 );
 
 			parent::__construct();
 		}

--- a/includes/admin/post-types/admin-post-type.php
+++ b/includes/admin/post-types/admin-post-type.php
@@ -15,7 +15,7 @@ if ( ! class_exists( 'ACF_Admin_Post_Type' ) ) :
 	 *
 	 * All the logic for editing a post type.
 	 */
-	class ACF_Admin_Post_type extends ACF_Admin_Internal_Post_Type {
+	class ACF_Admin_Post_Type extends ACF_Admin_Internal_Post_Type {
 
 		/**
 		 * The slug for the internal post type.


### PR DESCRIPTION
Some phpstan failures would require a more thorough fix, re-templating some of the plugin `Variable $field might not be defined.` so haven't tackled those here, but think we can consider the issue resolved and leave in the exception in the `baseline.neon` file

Fixes #63.