### PR TITLE
Specify the version refers to `SCF` in `@since` annotations

### DIFF
--- a/assets/src/js/_acf-validation.js
+++ b/assets/src/js/_acf-validation.js
@@ -168,7 +168,7 @@
 		 *
 		 *  @since	ACF 5.7.5
 		 *
-		 *  @param	{string} [location=before] - The location to add the error, before or after the input. Default before. Since 6.3.
+		 *  @param	{string} [location=before] - The location to add the error, before or after the input. Default before. Since ACF 6.3.
 		 *  @return	void
 		 */
 		showErrors: function ( location = 'before' ) {

--- a/docs/code-reference/admin/admin-notices-file.md
+++ b/docs/code-reference/admin/admin-notices-file.md
@@ -25,8 +25,8 @@ Creates and returns a new notice.
 * @since ACF 5.0.0
 * @param   string  $text        The admin notice text.
 * @param string  $type        The type of notice (warning, error, success, info).
-* @param boolean $dismissible Is this notification dismissible (default true) (since 5.11.0).
-* @param boolean $persisted   Store once a notice has been dismissed per user and prevent showing it again. (since 6.1.0).
+* @param boolean $dismissible Is this notification dismissible (default true) (since ACF 5.11.0).
+* @param boolean $persisted   Store once a notice has been dismissed per user and prevent showing it again. (since ACF 6.1.0).
 * @return ACF_Admin_Notice
 
 ---

--- a/docs/code-reference/api/api-template-file.md
+++ b/docs/code-reference/api/api-template-file.md
@@ -52,7 +52,7 @@ Updates the array of instances where HTML was altered due to escaping in the_fie
 ## `_acf_delete_escaped_html_log()`
 
 Deletes the array of instances where HTML was altered due to escaping in the_field or a shortcode.
-Since 6.2.7, also clears the legacy `acf_will_escape_html_log` option to clean up.
+Since ACF 6.2.7, also clears the legacy `acf_will_escape_html_log` option to clean up.
 
 * @since ACF 6.2.5
 * @return boolean True on success, or false on failure.

--- a/docs/code-reference/validation-file.md
+++ b/docs/code-reference/validation-file.md
@@ -30,7 +30,7 @@ Get the validation error.
 * @type    function
 * @date 6/10/13
 * @since ACF 5.0.0
-* @since 6.4.1 Added the $input parameter, which is required in the get_error method.
+* @since SCF 6.4.1 Added the $input parameter, which is required in the get_error method.
 * @param   string $input name attribute of DOM element.
 * @return  string|bool
 

--- a/includes/admin/admin-notices.php
+++ b/includes/admin/admin-notices.php
@@ -131,7 +131,7 @@ add_action( 'admin_notices', 'acf_render_admin_notices', 99 );
  * @param   string  $text        The admin notice text.
  * @param   string  $type        The type of notice (warning, error, success, info).
  * @param   boolean $dismissible Is this notification dismissible (default true) (since 5.11.0).
- * @param   boolean $persisted   Store once a notice has been dismissed per user and prevent showing it again. (since SCF 6.1.0).
+ * @param   boolean $persisted   Store once a notice has been dismissed per user and prevent showing it again. (since ACF 6.1.0).
  * @return  ACF_Admin_Notice
  */
 function acf_add_admin_notice( $text = '', $type = 'info', $dismissible = true, $persisted = false ) {

--- a/includes/admin/admin-notices.php
+++ b/includes/admin/admin-notices.php
@@ -131,7 +131,7 @@ add_action( 'admin_notices', 'acf_render_admin_notices', 99 );
  * @param   string  $text        The admin notice text.
  * @param   string  $type        The type of notice (warning, error, success, info).
  * @param   boolean $dismissible Is this notification dismissible (default true) (since 5.11.0).
- * @param   boolean $persisted   Store once a notice has been dismissed per user and prevent showing it again. (since 6.1.0).
+ * @param   boolean $persisted   Store once a notice has been dismissed per user and prevent showing it again. (since SCF 6.1.0).
  * @return  ACF_Admin_Notice
  */
 function acf_add_admin_notice( $text = '', $type = 'info', $dismissible = true, $persisted = false ) {

--- a/includes/admin/beta-features.php
+++ b/includes/admin/beta-features.php
@@ -5,7 +5,7 @@
  * This file contains the admin beta features functionality for Secure Custom Fields.
  *
  * @package    Secure Custom Fields
- * @since      6.5.0
+ * @since      SCF 6.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/beta-features/class-scf-beta-feature-editor-sidebar.php
+++ b/includes/admin/beta-features/class-scf-beta-feature-editor-sidebar.php
@@ -5,7 +5,7 @@
  * This beta feature allows moving field group elements to the editor sidebar.
  *
  * @package    Secure Custom Fields
- * @since      6.5.0
+ * @since      SCF 6.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -20,7 +20,7 @@ if ( ! class_exists( 'SCF_Admin_Beta_Feature_Editor_Sidebar' ) ) :
 	 * for a cleaner interface.
 	 *
 	 * @package    Secure Custom Fields
-	 * @since      6.5.0
+	 * @since      SCF 6.5.0
 	 */
 	class SCF_Admin_Beta_Feature_Editor_Sidebar extends SCF_Admin_Beta_Feature {
 

--- a/includes/admin/beta-features/class-scf-beta-feature.php
+++ b/includes/admin/beta-features/class-scf-beta-feature.php
@@ -5,7 +5,7 @@
  * This class serves as the base for all beta features in Secure Custom Fields.
  *
  * @package    Secure Custom Fields
- * @since      6.5.0
+ * @since      SCF 6.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -20,7 +20,7 @@ if ( ! class_exists( 'SCF_Admin_Beta_Feature' ) ) :
 	 * for managing beta feature settings and UI.
 	 *
 	 * @package    Secure Custom Fields
-	 * @since      6.5.0
+	 * @since      SCF 6.5.0
 	 */
 	class SCF_Admin_Beta_Feature {
 

--- a/includes/admin/views/beta-features/beta-features.php
+++ b/includes/admin/views/beta-features/beta-features.php
@@ -3,7 +3,7 @@
  * Admin Beta Features View
  *
  * @package    Secure Custom Fields
- * @since      6.5.0
+ * @since      SCF 6.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/api-template.php
+++ b/includes/api/api-template.php
@@ -205,7 +205,7 @@ function _acf_update_escaped_html_log( $escaped = array() ) {
 
 /**
  * Deletes the array of instances where HTML was altered due to escaping in the_field or a shortcode.
- * Since 6.2.7, also clears the legacy `acf_will_escape_html_log` option to clean up.
+ * Since ACF 6.2.7, also clears the legacy `acf_will_escape_html_log` option to clean up.
  *
  * @since ACF 6.2.5
  *

--- a/includes/fields/class-acf-field-clone.php
+++ b/includes/fields/class-acf-field-clone.php
@@ -5,7 +5,7 @@
  * This class handles the clone field type, which allows users to select and display existing fields.
  *
  * @package wordpress/secure-custom-fields
- * @since 5.0.0
+ * @since ACF 5.0.0
  */
 
 // phpcs:disable PEAR.NamingConventions.ValidClassName
@@ -15,7 +15,7 @@ if ( ! class_exists( 'acf_field_clone' ) ) :
 	 *
 	 * Handles the functionality for the clone field type.
 	 *
-	 * @since 5.0.0
+	 * @since ACF 5.0.0
 	 */
 	class acf_field_clone extends acf_field {
 

--- a/includes/fields/class-acf-field-nav-menu.php
+++ b/includes/fields/class-acf-field-nav-menu.php
@@ -3,7 +3,7 @@
  * This is a PHP file containing the code for the acf_field_nav_menu class.
  *
  * @package wordpress/secure-custom-fields
- * @since 6.5.0
+ * @since SCF 6.5.0
  */
 
 if ( ! class_exists( 'Acf_Field_Nav_Menu' ) ) :
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Acf_Field_Nav_Menu' ) ) :
 		 *
 		 * @type    function
 		 * @date    5/03/2014
-		 * @since  6.5.0
+		 * @since  SCF 6.5.0
 		 */
 		public function initialize() {
 

--- a/includes/fields/class-acf-field-output.php
+++ b/includes/fields/class-acf-field-output.php
@@ -33,7 +33,7 @@ if ( ! class_exists( 'acf_field_output' ) ) :
 		 */
 		public function render_field( $field ) {
 
-			// Deprecated since 6.3.2 and will be removed in a future release.
+			// Deprecated since SCF 6.3.2 and will be removed in a future release.
 			_deprecated_function( __FUNCTION__, '6.3.2' );
 			return false;
 		}

--- a/includes/fields/class-acf-field-output.php
+++ b/includes/fields/class-acf-field-output.php
@@ -33,7 +33,7 @@ if ( ! class_exists( 'acf_field_output' ) ) :
 		 */
 		public function render_field( $field ) {
 
-			// Deprecated since SCF 6.3.2 and will be removed in a future release.
+			// Deprecated since ACF 6.3.2 and will be removed in a future release.
 			_deprecated_function( __FUNCTION__, '6.3.2' );
 			return false;
 		}

--- a/includes/locations.php
+++ b/includes/locations.php
@@ -180,7 +180,7 @@ function acf_validate_location_rule( $rule = array() ) {
 function acf_get_location_rule_operators( $rule ) {
 	$operators = ACF_Location::get_operators( $rule );
 
-	// Get operators from location type since 5.9.
+	// Get operators from location type since ACF 5.9.
 	$location_type = acf_get_location_type( $rule['param'] );
 	if ( $location_type ) {
 		$operators = $location_type->get_operators( $rule );
@@ -213,7 +213,7 @@ function acf_get_location_rule_operators( $rule ) {
 function acf_get_location_rule_values( $rule ) {
 	$values = array();
 
-	// Get values from location type since 5.9.
+	// Get values from location type since ACF 5.9.
 	$location_type = acf_get_location_type( $rule['param'] );
 	if ( $location_type ) {
 		$values = $location_type->get_values( $rule );
@@ -248,7 +248,7 @@ function acf_get_location_rule_values( $rule ) {
 function acf_match_location_rule( $rule, $screen, $field_group ) {
 	$result = false;
 
-	// Get result from location type since 5.9.
+	// Get result from location type since ACF 5.9.
 	$location_type = acf_get_location_type( $rule['param'] );
 	if ( $location_type ) {
 		$result = $location_type->match( $rule, $screen, $field_group );

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -3,7 +3,7 @@
  * REST API
  *
  * @package    Secure Custom Fields
- * @since      6.4.0
+ * @since      SCF 6.4.0
  */
 
 // Exit if accessed directly.

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -3,7 +3,7 @@
  * REST API
  *
  * @package    Secure Custom Fields
- * @since      SCF 6.4.0
+ * @since      ACF 6.4.0
  */
 
 // Exit if accessed directly.

--- a/includes/rest-api/class-acf-rest-types-endpoint.php
+++ b/includes/rest-api/class-acf-rest-types-endpoint.php
@@ -16,14 +16,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Extends the /wp/v2/types endpoint to include SCF fields.
  *
- * @since 6.5.0
+ * @since SCF 6.5.0
  */
 class SCF_Rest_Types_Endpoint {
 
 	/**
 	 * Initialize the class.
 	 *
-	 * @since 6.5.0
+	 * @since SCF 6.5.0
 	 */
 	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'register_extra_fields' ) );
@@ -32,7 +32,7 @@ class SCF_Rest_Types_Endpoint {
 	/**
 	 * Register extra SCF fields for the post types endpoint.
 	 *
-	 * @since 6.5.0
+	 * @since SCF 6.5.0
 	 *
 	 * @return void
 	 */
@@ -53,7 +53,7 @@ class SCF_Rest_Types_Endpoint {
 	/**
 	 * Get SCF fields for a post type.
 	 *
-	 * @since 6.5.0
+	 * @since SCF 6.5.0
 	 *
 	 * @param array $post_type_object The post type object.
 	 * @return array Array of field data.
@@ -86,7 +86,7 @@ class SCF_Rest_Types_Endpoint {
 	/**
 	 * Get the schema for the SCF fields.
 	 *
-	 * @since 6.5.0
+	 * @since SCF 6.5.0
 	 *
 	 * @return array The schema for the SCF fields.
 	 */

--- a/includes/validation.php
+++ b/includes/validation.php
@@ -230,7 +230,7 @@ function acf_get_validation_errors() {
  * @type    function
  * @date    6/10/13
  * @since   ACF 5.0.0
- * @since   6.4.1 Added the $input parameter, which is required in the get_error method.
+ * @since   SCF 6.4.1 Added the $input parameter, which is required in the get_error method.
  *
  * @param   string $input name attribute of DOM element.
  *

--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -408,7 +408,7 @@ if ( ! class_exists( 'ACF' ) ) {
 			 */
 			do_action( 'acf/include_options_pages', ACF_MAJOR_VERSION );
 
-			// If we're on WP 6.5 or newer, load block bindings. This will move to an autoloader in SCF 6.3.
+			// If we're on WP 6.5 or newer, load block bindings. This will move to an autoloader in ACF 6.3.
 			if ( version_compare( get_bloginfo( 'version' ), '6.5-beta1', '>=' ) ) {
 				acf_include( 'includes/Blocks/Bindings.php' );
 				new ACF\Blocks\Bindings();


### PR DESCRIPTION
Fixes #6.

## What
This PR changes all the `@since` annotations and comments to specify they refer to SCF (or ACF for older versions), not WordPress.

## Why
This will help in two ways:
- For future releases, avoid confusion between ACF and SCF versions.
- For past releases, avoid LLMs mixing the version with a WordPress version. This is currently happening, and agents incorrectly assume `@since 6.5` refers to WordPress 6.5.

## Testing instructions
No specific testing needed, but if you are using AI agents, you can ask things like `When was [function] introduced?` and see the difference.