### PR TITLE
Code Quality: Remove filename WPCS rule to be able to use PSR-4 autoload.

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -8,22 +8,29 @@
 	<exclude-pattern>/lang/*</exclude-pattern>
 
 	<!-- How to scan -->
-	<arg value="sp"/> <!-- Show sniff and progress -->
+	<arg value="sp"/>
+	<!-- Show sniff and progress -->
 	<arg name="colors"/>
 	<arg name="extensions" value="php"/>
 
 	<!-- Rules: WordPress Coding Standards -->
 	<config name="minimum_supported_wp_version" value="6.0"/>
 	<rule ref="WordPress">
-		<exclude name="WordPress.NamingConventions.ValidHookName.UseUnderscores" /> <!-- 'acf/hookname' is used throughout. -->
-		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" /> <!-- This is trivial and not really useful today. -->
-		<exclude name="WordPress.Files.FileName.InvalidClassFileName" /> <!-- Refactoring of this scale is not in scope yet.-->
+		<exclude name="WordPress.NamingConventions.ValidHookName.UseUnderscores" />
+		<!-- 'acf/hookname' is used throughout. -->
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
+		<!-- This is trivial and not really useful today. -->
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+		<!-- Refactoring of this scale is not in scope yet.-->
+		<exclude name="WordPress.Files.FileName" />
+		<!-- Exclude the entire filename rule -->
 	</rule>
 
 	<rule ref="WordPress.Security.EscapeOutput">
 		<properties>
 			<property name="customEscapingFunctions" type="array">
-				<element value="acf_esc_attrs" /> <!-- This function takes an associated array and escapes both the attr title and attr value. -->
+				<element value="acf_esc_attrs" />
+				<!-- This function takes an associated array and escapes both the attr title and attr value. -->
 				<element value="acf_esc_html" />
 			</property>
 		</properties>


### PR DESCRIPTION
## What

WordPress Coding Standards recommends that filenames should be all lowercase with hyphens as word separators, meanwhile, PSR-4 requires that class names match the file names, where class names should be PascalCase.

SCF is moving to PSR-4, so in order to make future SCF integrations much easier to follow, let's ignore that rule.

WordPress Coding Standards should be updated in a future to include widely used PHP standards like PSR-4.