### PR TITLE
Bug: Fix repeater inner fields not showing in Field Group admin page.

### DIFF
--- a/includes/acf-hook-functions.php
+++ b/includes/acf-hook-functions.php
@@ -106,7 +106,7 @@ function _acf_apply_hook_variations() {
 		}
 
 		// Apply filters.
-		if ( 'filters' === $type ) {
+		if ( 'filter' === $type ) {
 			$args[0] = apply_filters_ref_array( "$filter/$variation=$value", $args );
 
 			// Or do action.


### PR DESCRIPTION
## What

A small typo was breaking the repeater field, it was not showing the fields.

Before:
![Screenshot 2025-05-14 at 19 07 56](https://github.com/user-attachments/assets/c9ddfa78-97af-4d5b-a65f-dfc07d202684)

After:
![Screenshot 2025-05-14 at 19 09 56](https://github.com/user-attachments/assets/b27a62db-0c8d-4679-ab0e-b812d6d23d7c)


I will work on an E2E test as soon as possible. Bug was introduced in 93c1c8b4a77465922e57f062e09e10bb40f35f3f