### PR TITLE
Fix: SCF Blocks are now forced into preview mode when editing a synced pattern.

### DIFF
--- a/assets/src/js/pro/_acf-blocks.js
+++ b/assets/src/js/pro/_acf-blocks.js
@@ -110,7 +110,7 @@ const md5 = require( 'md5' );
 	 * @return boolean
 	 */
 	function isSiteEditor() {
-		return typeof pagenow === 'string' && pagenow === 'site-editor';
+		return document.querySelectorAll( 'iframe[name="editor-canvas"]' ).length > 0;
 	}
 
 	/**
@@ -758,9 +758,7 @@ const md5 = require( 'md5' );
 
 			if (
 				isBlockInQueryLoop( clientId ) ||
-				isSiteEditor() ||
-				isiFramedMobileDevicePreview() ||
-				isEditingTemplate()
+				isSiteEditor()
 			) {
 				restrictMode( [ 'preview' ] );
 			} else {
@@ -783,9 +781,7 @@ const md5 = require( 'md5' );
 			const blockType = getBlockType( name );
 			const forcePreview =
 				isBlockInQueryLoop( clientId ) ||
-				isSiteEditor() ||
-				isiFramedMobileDevicePreview() ||
-				isEditingTemplate();
+				isSiteEditor();
 			let { mode } = attributes;
 
 			if ( forcePreview ) {


### PR DESCRIPTION
## What

Before this PR. SCF blocks could be on "edit" mode inside synced patterns. Now they are forced to be in preview mode, which is the block that the user will see both in editor and in frontend.

ACF 6.4.1 backport.

## How to test
Before:

https://github.com/user-attachments/assets/13844576-5139-4191-80f0-b34a5c02af1c

After:

https://github.com/user-attachments/assets/a2ba2436-2eb5-411c-bb0e-62fcb7c6fcbe



