### PR TITLE
Bindings: Try to integrate SCF custom fields in the Attributes panel

### DIFF
--- a/includes/assets.php
+++ b/includes/assets.php
@@ -277,18 +277,14 @@ window.wp.blocks = new Proxy(originalBlocks, {
 		console.log("Intercepted getBlockBindingsSources", result);
 		if (result?.["acf/field"]) {
 				result["acf/field"]["getFieldsList"] = function() {
-					return {
-						isbn: {
-							label: "ISBN (SCF)",
-							value: "978-3-16-148410-0",
-							type: "string",
-						},
-						author: {
-							label: "Author (SCF)",
-							value: "John Doe",
-							type: "string",
-						},
-					};
+					return acf.getFields().reduce( (acc, { data, $el }) => {
+						acc[data.name] = {
+							label: $el.find("label").text(),
+							value: $el.find("input").val() || "",
+							type: data.type === "text" ? "string" : data.type,
+						};
+						return acc;
+					}, {} );
 				};
 		}
         return result;

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -265,6 +265,42 @@ if ( ! class_exists( 'ACF_Assets' ) ) :
 				)
 			);
 
+			wp_add_inline_script(
+				'wp-blocks',
+				'const originalBlocks = window.wp.blocks;
+
+window.wp.blocks = new Proxy(originalBlocks, {
+  get(target, prop, receiver) {
+    if (prop === "getBlockBindingsSources") {
+      return function(...args) {
+        const result = target.getBlockBindingsSources(...args);
+		console.log("Intercepted getBlockBindingsSources", result);
+		if (result?.["acf/field"]) {
+				result["acf/field"]["getFieldsList"] = function() {
+					return {
+						isbn: {
+							label: "ISBN (SCF)",
+							value: "978-3-16-148410-0",
+							type: "string",
+						},
+						author: {
+							label: "Author (SCF)",
+							value: "John Doe",
+							type: "string",
+						},
+					};
+				};
+		}
+        return result;
+      };
+    }
+
+    return Reflect.get(target, prop, receiver);
+  }
+});',
+				'after'
+			);
+
 			// Register styles.
 			foreach ( $styles as $style ) {
 				wp_register_style(

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -274,7 +274,6 @@ window.wp.blocks = new Proxy(originalBlocks, {
     if (prop === "getBlockBindingsSources") {
       return function(...args) {
         const result = target.getBlockBindingsSources(...args);
-		console.log("Intercepted getBlockBindingsSources", result);
 		if (result?.["acf/field"]) {
 				result["acf/field"]["getFieldsList"] = function() {
 					return acf.getFields().reduce( (acc, { data, $el }) => {


### PR DESCRIPTION
Related to https://github.com/WordPress/secure-custom-fields/issues/154.

This is a proof of concept that explores including registered custom SCF fields in the Attributes panel, which is currently limited to show only fields from the Post Meta binding source.

<img width="1684" alt="Screenshot 2025-05-23 at 14 45 34" src="https://github.com/user-attachments/assets/b0c6b70f-298a-4c45-a592-7b05673c392e" />

This change alone allows connecting in the editor fields registered with SCF with all core blocks that support Block Bindings.

## Approach

This prototype uses the [Proxy object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) to override the `getBlockBindingsSources` method in `wp.blocks` global. Proxy is necessary because properties inside `wp.blocks` are set as readonly, so that is an elegant way to tap into the existing system. 

I tried replicating the same Attributes panel by duplicating code from Gutenberg, but it uses some internal/private APIs that are difficult to mirror in a plugin. Therefore, I opted for an existing method that is used to construct the list of fields that can be connected with blocks. In the ideal world, some changes in Gutenberg would need to be applied to allow custom Block Bindings sources to define the list of fields to connect.

I haven’t explored that yet, but in the editor, users see the `SCF Fields` label in readonly mode without more details about the specific connected fields. It's probably caused by the fact that SCF Fields source is only registered on the server, so it doesn’t have the logic necessary to show something more specific like Post Meta does.

## Demo


https://github.com/user-attachments/assets/927f0e1e-eca0-4c07-8fe6-30b17bc1d618


