### PR TITLE
Block Bindings: Add editor preview to acf-field source.

### DIFF
--- a/assets/src/js/bindings/index.js
+++ b/assets/src/js/bindings/index.js
@@ -1,0 +1,1 @@
+import './sources.js';

--- a/assets/src/js/bindings/sources.js
+++ b/assets/src/js/bindings/sources.js
@@ -51,10 +51,15 @@ registerBlockBindingsSource( {
 
 				const fieldValue = getFieldValue( fields, fieldName );
 				if ( typeof fieldValue === 'object' && fieldValue !== null ) {
-					result[ attribute ] =
-						( fieldValue[ attribute ] ??
-							( attribute === 'content' && fieldValue.url ) ) ||
-						'';
+					let value = '';
+
+					if ( fieldValue[ attribute ] ) {
+						value = fieldValue[ attribute ];
+					} else if ( attribute === 'content' && fieldValue.url ) {
+						value = fieldValue.url;
+					}
+
+					result[ attribute ] = value;
 				} else if ( typeof fieldValue === 'number' ) {
 					if ( attribute === 'content' ) {
 						result[ attribute ] = fieldValue.toString() || '';

--- a/assets/src/js/bindings/sources.js
+++ b/assets/src/js/bindings/sources.js
@@ -1,0 +1,79 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockBindingsSource } from '@wordpress/blocks';
+import { store as coreDataStore } from '@wordpress/core-data';
+
+/**
+ * Get the value of a specific field from the ACF fields.
+ *
+ * @param {Object} fields The ACF fields object.
+ * @param {string} fieldName The name of the field to retrieve.
+ * @returns {string} The value of the specified field, or undefined if not found.
+ */
+const getFieldValue = ( fields, fieldName ) => fields?.acf?.[ fieldName ];
+
+const resolveImageAttribute = ( imageObj, attribute ) => {
+	if ( ! imageObj ) return '';
+	switch ( attribute ) {
+		case 'url':
+		case 'content':
+			return imageObj.source_url;
+		case 'alt':
+			return imageObj.alt_text || '';
+		case 'title':
+			return imageObj.title?.rendered || '';
+		default:
+			return '';
+	}
+};
+
+registerBlockBindingsSource( {
+	name: 'acf/field',
+	label: 'SCF Fields',
+	getValues( { context, bindings, select } ) {
+		const { getEditedEntityRecord, getMedia } = select( coreDataStore );
+		let fields =
+			context?.postType && context?.postId
+				? getEditedEntityRecord(
+						'postType',
+						context.postType,
+						context.postId
+				  )
+				: undefined;
+		const result = {};
+		debugger;
+
+		Object.entries( bindings ).forEach(
+			( [ attribute, { args } = {} ] ) => {
+				const fieldName = args?.key;
+
+				const fieldValue = getFieldValue( fields, fieldName );
+				if ( typeof fieldValue === 'object' && fieldValue !== null ) {
+					result[ attribute ] =
+						( fieldValue[ attribute ] ??
+							( attribute === 'content' && fieldValue.url ) ) ||
+						'';
+				} else if ( typeof fieldValue === 'number' ) {
+					if ( attribute === 'content' ) {
+						result[ attribute ] = fieldValue.toString() || '';
+					} else {
+						const imageObj = getMedia( fieldValue );
+						result[ attribute ] = resolveImageAttribute(
+							imageObj,
+							attribute
+						);
+					}
+				} else {
+					result[ attribute ] = fieldValue || '';
+				}
+			}
+		);
+
+		return result;
+	},
+	canUserEditValue() {
+		return false;
+	},
+} );

--- a/assets/src/js/bindings/sources.js
+++ b/assets/src/js/bindings/sources.js
@@ -43,7 +43,6 @@ registerBlockBindingsSource( {
 				  )
 				: undefined;
 		const result = {};
-		debugger;
 
 		Object.entries( bindings ).forEach(
 			( [ attribute, { args } = {} ] ) => {

--- a/includes/Blocks/Bindings.php
+++ b/includes/Blocks/Bindings.php
@@ -37,6 +37,7 @@ class Bindings {
 				array(
 					'label'              => _x( 'SCF Fields', 'The core SCF block binding source name for fields on the current page', 'secure-custom-fields' ),
 					'get_value_callback' => array( $this, 'get_value' ),
+					'uses_context'       => array( 'postId', 'postType' ),
 				)
 			);
 		}
@@ -78,15 +79,42 @@ class Bindings {
 				}
 			}
 
-			$value = $field['value'];
+			switch ( $attribute_name ) {
+				case 'id':
+					// The value is the field value.
+					$value = $field['value']['id'] ?? '';
+					break;
+				case 'alt':
+					// The label is the field label.
+					$value = $field['value']['alt'] ?? '';
+					break;
+				case 'url':
+					// The URL is the field value.
+					$value = $field['value']['url'] ?? $field['value'] ?? '';
+					break;
+				case 'title':
+					// The title is the field value.
+					$value = $field['value']['title'] ?? '';
+					break;
+				case 'rel':
+					// Handle checkbox field for rel attribute by joining array values.
+					if ( is_array( $field['value'] ) ) {
+						$value = implode( ' ', $field['value'] );
+					} else {
+						$value = $field['value'] ?? '';
+					}
+					break;
+				default:
+					$value = $field['value'];
 
-			if ( is_array( $value ) ) {
-				$value = implode( ', ', $value );
-			}
+					if ( is_array( $value ) ) {
+						$value = wp_json_encode( $value );
+					}
 
-			// If we're not a scalar we'd throw an error, so return early for safety.
-			if ( ! is_scalar( $value ) ) {
-				$value = null;
+					// Ensure we're returning a scalar value.
+					if ( ! is_scalar( $value ) && null !== $value ) {
+						$value = '';
+					}
 			}
 		}
 

--- a/includes/Blocks/Bindings.php
+++ b/includes/Blocks/Bindings.php
@@ -81,20 +81,14 @@ class Bindings {
 
 			switch ( $attribute_name ) {
 				case 'id':
-					// The value is the field value.
-					$value = $field['value']['id'] ?? '';
-					break;
 				case 'alt':
-					// The label is the field label.
-					$value = $field['value']['alt'] ?? '';
+				case 'title':
+					// The value is in the field of the same name.
+					$value = $field['value'][ $attribute_name ] ?? '';
 					break;
 				case 'url':
 					// The URL is the field value.
 					$value = $field['value']['url'] ?? $field['value'] ?? '';
-					break;
-				case 'title':
-					// The title is the field value.
-					$value = $field['value']['title'] ?? '';
 					break;
 				case 'rel':
 					// Handle checkbox field for rel attribute by joining array values.

--- a/includes/Blocks/Bindings.php
+++ b/includes/Blocks/Bindings.php
@@ -103,10 +103,7 @@ class Bindings {
 
 					if ( is_array( $value ) ) {
 						$value = wp_json_encode( $value );
-					}
-
-					// Ensure we're returning a scalar value.
-					if ( ! is_scalar( $value ) && null !== $value ) {
+					} elseif ( ! is_scalar( $value ) && null !== $value ) {
 						$value = '';
 					}
 			}

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -189,6 +189,14 @@ if ( ! class_exists( 'ACF_Assets' ) ) :
 					'version'    => $version,
 					'in_footer'  => true,
 				),
+				'scf-bindings'            => array(
+					'handle'     => 'scf-bindings',
+					'src'        => acf_get_url( sprintf( $js_path_patterns['base'], 'scf-bindings' ) ),
+					'asset_file' => acf_get_path( sprintf( $asset_path_patterns['base'], 'scf-bindings' ) ),
+					'version'    => $version,
+					'deps'       => array(),
+					'in_footer'  => true,
+				),
 			);
 
 			// Define style registrations.
@@ -529,6 +537,7 @@ if ( ! class_exists( 'ACF_Assets' ) ) :
 				// @todo integrate into the above. Previously, they were simply hooked into the hook below.
 				wp_enqueue_script( 'acf-pro-input' );
 				wp_enqueue_script( 'acf-pro-ui-options-page' );
+				wp_enqueue_script( 'scf-bindings' );
 				wp_enqueue_style( 'acf-pro-input' );
 
 				/**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,8 @@ const commonConfig = {
 		'js/acf-internal-post-type':
 			'./assets/src/js/acf-internal-post-type.js',
 		'js/commands/scf-admin': './assets/src/js/commands/admin-commands.js',
-		'js/commands/scf-custom-post-types': './assets/src/js/commands/custom-post-type-commands.js',
+		'js/commands/scf-custom-post-types':
+			'./assets/src/js/commands/custom-post-type-commands.js',
 		'js/acf': './assets/src/js/acf.js',
 		'js/pro/acf-pro-blocks': './assets/src/js/pro/acf-pro-blocks.js',
 		'js/pro/acf-pro-field-group':
@@ -24,6 +25,7 @@ const commonConfig = {
 		'js/pro/acf-pro-input': './assets/src/js/pro/acf-pro-input.js',
 		'js/pro/acf-pro-ui-options-page':
 			'./assets/src/js/pro/acf-pro-ui-options-page.js',
+		'js/scf-bindings': './assets/src/js/bindings/index.js',
 
 		// CSS files
 		'css/acf-dark': './assets/src/sass/acf-dark.scss',


### PR DESCRIPTION
## What

Right now, the experience with block bindings in SCF is not the best. The image block binding is broken. There is an extra warning from array to string conversion, and all the block binding place holders are just the default placeholder. (With the SCF Fields name)

https://github.com/user-attachments/assets/b5cdaadf-831d-4591-9ec0-2ece8bcab864

This PR enhances the experience on the editor by using the new Editor APIs. Now only we use the getValues one. Preventing from edition, but https://github.com/WordPress/secure-custom-fields/pull/173 already allows to edit them too.

I need some more testing with different field types for editing. But with this PR, we cover all block bindings supported blocks and their attributes with field types like select, checkbox, url, text field, textareas and numbers.

## Why

To enhance the editor experience with block bindings and custom fields.

## Screenshare and how to test.

https://github.com/user-attachments/assets/555c592a-fcc4-4749-aee2-3afb9fe9aa0a

Create a custom post type, a field group, some fields.

Use the code to link those fields with their respective blocks, sharing an example so you can copy-paste:

**Heading**
```
<!-- wp:heading {"level":4,"metadata":{"bindings":{"content":{"source":"acf/field","args":{"key":"videogame_title"}}}}} -->
<h4 class="wp-block-heading"></h4>
<!-- /wp:heading -->
```

```
<!-- wp:heading {"level":4,"metadata":{"bindings":{"content":{"source":"acf/field","args":{"key":"hours_played"}}}}} -->
<h4 class="wp-block-heading"></h4>
<!-- /wp:heading -->
```

**Image**

```
<!-- wp:image {"metadata":{"bindings":{"id":{"source":"acf/field","args":{"key":"videogame_image"}},"url":{"source":"acf/field","args":{"key":"videogame_image"}},"alt":{"source":"acf/field","args":{"key":"videogame_image"}},"title":{"source":"acf/field","args":{"key":"videogame_image"}}}}} -->
<figure class="wp-block-image"><img src="#" alt=""/></figure>
<!-- /wp:image -->
```

**Button**
```
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"metadata":{"bindings":{"text":{"source":"acf/field","args":{"key":"text"}},"url":{"source":"acf/field","args":{"key":"igdb_url"}},"linkTarget":{"source":"acf/field","args":{"key":"igdb_target"}},"rel":{"source":"acf/field","args":{"key":"igdb_rel"}}}}} -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Binded Button</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```
