### PR TITLE
Set the Escaped HTML warning notice disabled by default

### DIFF
--- a/includes/admin/admin-internal-post-type.php
+++ b/includes/admin/admin-internal-post-type.php
@@ -45,7 +45,6 @@ if ( ! class_exists( 'ACF_Admin_Internal_Post_Type' ) ) :
 			add_action( 'current_screen', array( $this, 'current_screen' ) );
 			add_action( 'save_post_' . $this->post_type, array( $this, 'save_post' ), 10, 2 );
 			add_action( 'wp_ajax_acf/link_field_groups', array( $this, 'ajax_link_field_groups' ) );
-			add_filter( 'post_updated_messages', array( $this, 'post_updated_messages' ) );
 			add_filter( 'use_block_editor_for_post_type', array( $this, 'use_block_editor_for_post_type' ), 10, 2 );
 		}
 
@@ -92,6 +91,7 @@ if ( ! class_exists( 'ACF_Admin_Internal_Post_Type' ) ) :
 			acf_enqueue_scripts();
 
 			add_filter( 'admin_body_class', array( $this, 'admin_body_class' ) );
+			add_filter( 'post_updated_messages', array( $this, 'post_updated_messages' ) );
 			add_action( 'acf/input/admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 			add_action( 'acf/input/admin_head', array( $this, 'admin_head' ) );
 			add_action( 'acf/input/form_data', array( $this, 'form_data' ) );

--- a/includes/admin/views/global/navigation.php
+++ b/includes/admin/views/global/navigation.php
@@ -108,16 +108,18 @@ function acf_print_menu_section( $menu_items, $section = '' ) {
 	$section_html = '';
 
 	foreach ( $menu_items as $menu_item ) {
-		$class    = ! empty( $menu_item['class'] ) ? $menu_item['class'] : $menu_item['text'];
-		$target   = ! empty( $menu_item['target'] ) ? ' target="' . esc_attr( $menu_item['target'] ) . '"' : '';
-		$li_class = ! empty( $menu_item['li_class'] ) ? esc_attr( $menu_item['li_class'] ) : '';
+		$class      = ! empty( $menu_item['class'] ) ? $menu_item['class'] : $menu_item['text'];
+		$target     = ! empty( $menu_item['target'] ) ? ' target="' . esc_attr( $menu_item['target'] ) . '"' : '';
+		$aria_label = ! empty( $menu_item['aria-label'] ) ? ' aria-label="' . esc_attr( $menu_item['aria-label'] ) . '"' : '';
+		$li_class   = ! empty( $menu_item['li_class'] ) ? esc_attr( $menu_item['li_class'] ) : '';
 
 		$html = sprintf(
-			'<a class="acf-tab%s %s" href="%s"%s><i class="acf-icon"></i>%s</a>',
+			'<a class="acf-tab%s %s" href="%s"%s%s><i class="acf-icon"></i>%s</a>',
 			! empty( $menu_item['is_active'] ) ? ' is-active' : '',
 			'acf-header-tab-' . esc_attr( acf_slugify( $class ) ),
 			esc_url( $menu_item['url'] ),
 			$target,
+			$aria_label,
 			acf_esc_html( $menu_item['text'] )
 		);
 
@@ -138,7 +140,7 @@ function acf_print_menu_section( $menu_items, $section = '' ) {
 <div class="acf-admin-toolbar">
 	<div class="acf-admin-toolbar-inner">
 		<div class="acf-nav-wrap">
-			<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=acf-field-group' ) ); ?>" class="acf-logo">
+			<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=acf-field-group' ) ); ?>" class="acf-logo" aria-label="<?php esc_attr_e( 'Edit SCF Field Groups', 'secure-custom-fields' ); ?>">
 				<img src="<?php echo esc_url( acf_get_url( 'assets/images/scf-logo.svg' ) ); ?>" alt="<?php esc_attr_e( 'Secure Custom Fields logo', 'secure-custom-fields' ); ?>">
 			</a>
 

--- a/includes/api/api-template.php
+++ b/includes/api/api-template.php
@@ -142,7 +142,7 @@ function the_field( $selector, $post_id = false, $format_value = true ) {
  */
 function _acf_log_escaped_html( $function, $selector, $field, $post_id ) {
 	// If the notice isn't shown, no use in logging the errors.
-	if ( apply_filters( 'acf/admin/prevent_escaped_html_notice', false ) ) {
+	if ( apply_filters( 'acf/admin/prevent_escaped_html_notice', true ) ) {
 		return;
 	}
 


### PR DESCRIPTION
## What

This notice was introduced in ACF 6.2.5. Since 6.4.1 has been disabled by default. To maintain upstream compatibility we are doing the same here.

## Extra

Added a couple of aria-labels.