### PR TITLE
Fix – Blocks registered via acf_register_block_type() with a `parent` value of `null` no longer fail to register

### DIFF
--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -414,6 +414,16 @@ function acf_validate_block_type( $block ) {
 		$block['supports']['jsx'] = $block['supports']['__experimental_jsx'];
 	}
 
+	// Normalize block 'parent' setting.
+	if ( array_key_exists( 'parent', $block ) ) {
+		// As of WP 6.8, parent must be an array.
+		if ( null === $block['parent'] ) {
+			unset( $block['parent'] );
+		} elseif ( is_string( $block['parent'] ) ) {
+			$block['parent'] = array( $block['parent'] );
+		}
+	}
+
 	// Return block.
 	return $block;
 }


### PR DESCRIPTION
## What

If you register a block like this one.

```php
add_action('acf/init', 'my_acf_blocks_init');
function my_acf_blocks_init() {

    // Check function exists.
    if( function_exists('acf_register_block_type') ) {

        // Register a testimonial block.
        acf_register_block_type(array(
            'name'              => 'testimonial',
            'title'             => __('Testimonial 2'),
            'description'       => __('A custom testimonial block. 2'),
            'render_callback'   => function(){ echo 'hello from plugin';},
            'category'          => 'formatting',
	    'parent' => null
        ));
    }
}
```

Without the PR you get:
![Screenshot 2025-06-19 at 14 46 31](https://github.com/user-attachments/assets/8e4743d8-3051-43ea-acb3-1ad7cd94978e)

Applying the patch you get the block as expected.
![Screenshot 2025-06-19 at 14 47 09](https://github.com/user-attachments/assets/e11bdc5b-d4b5-4ca3-a943-f639349f8f97)

