### PR TITLE
Bug: Changing a field type enables the “Allow Access to Value in Editor UI”  setting.

### DIFF
--- a/includes/fields/class-acf-field.php
+++ b/includes/fields/class-acf-field.php
@@ -347,7 +347,7 @@ if ( ! class_exists( 'acf_field' ) ) :
 
 			// This field setting has a unique behaviour. If the value isn't defined on the field object, it defaults to true, but for new fields, it defaults to off.
 			if ( ! isset( $field['allow_in_bindings'] ) ) {
-				if ( empty( $field['ID'] ) ) {
+				if ( empty( $field['ID'] ) || doing_action( 'wp_ajax_acf/field_group/render_field_settings' ) ) {
 					$field['allow_in_bindings'] = false;
 				} else {
 					$field['allow_in_bindings'] = true;


### PR DESCRIPTION
## What

When the user changes the field type of a field. The setting "Allow Access to Value in Editor UI" is enabled, not respecting the previous user's decision.

## Before


https://github.com/user-attachments/assets/24cb6691-7923-4275-b09b-1b0200e1e0a4

## After

https://github.com/user-attachments/assets/c6b9c4a7-0269-40ec-bee2-f2ba387badd5


