### PR TITLE
Command Palette: Use `@wordpress/icons` instead of Dashicons

### DIFF
--- a/assets/src/js/commands/admin-commands.js
+++ b/assets/src/js/commands/admin-commands.js
@@ -16,6 +16,7 @@ import { createElement } from '@wordpress/element';
 import { Icon } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
+import { layout, plus, postList, category, settings, tool, upload, download } from '@wordpress/icons';
 
 /**
  * Register admin commands for SCF
@@ -34,7 +35,7 @@ const registerAdminCommands = () => {
 			label: __( 'Field Groups', 'secure-custom-fields' ),
 			url: 'edit.php',
 			urlArgs: { post_type: 'acf-field-group' },
-			icon: 'layout',
+			icon: layout,
 			description: __(
 				'SCF: View and manage custom field groups',
 				'secure-custom-fields'
@@ -51,7 +52,7 @@ const registerAdminCommands = () => {
 			label: __( 'Create New Field Group', 'secure-custom-fields' ),
 			url: 'post-new.php',
 			urlArgs: { post_type: 'acf-field-group' },
-			icon: 'plus',
+			icon: plus,
 			description: __(
 				'SCF: Create a new field group to organize custom fields',
 				'secure-custom-fields'
@@ -69,7 +70,7 @@ const registerAdminCommands = () => {
 			label: __( 'Post Types', 'secure-custom-fields' ),
 			url: 'edit.php',
 			urlArgs: { post_type: 'acf-post-type' },
-			icon: 'admin-post',
+			icon: postList,
 			description: __(
 				'SCF: Manage custom post types',
 				'secure-custom-fields'
@@ -81,7 +82,7 @@ const registerAdminCommands = () => {
 			label: __( 'Create New Post Type', 'secure-custom-fields' ),
 			url: 'post-new.php',
 			urlArgs: { post_type: 'acf-post-type' },
-			icon: 'plus',
+			icon: plus,
 			description: __(
 				'SCF: Create a new custom post type',
 				'secure-custom-fields'
@@ -93,7 +94,7 @@ const registerAdminCommands = () => {
 			label: __( 'Taxonomies', 'secure-custom-fields' ),
 			url: 'edit.php',
 			urlArgs: { post_type: 'acf-taxonomy' },
-			icon: 'category',
+			icon: category,
 			description: __(
 				'SCF: Manage custom taxonomies for organizing content',
 				'secure-custom-fields'
@@ -105,7 +106,7 @@ const registerAdminCommands = () => {
 			label: __( 'Create New Taxonomy', 'secure-custom-fields' ),
 			url: 'post-new.php',
 			urlArgs: { post_type: 'acf-taxonomy' },
-			icon: 'plus',
+			icon: plus,
 			description: __(
 				'SCF: Create a new custom taxonomy',
 				'secure-custom-fields'
@@ -124,7 +125,7 @@ const registerAdminCommands = () => {
 			label: __( 'Options Pages', 'secure-custom-fields' ),
 			url: 'edit.php',
 			urlArgs: { post_type: 'acf-ui-options-page' },
-			icon: 'admin-settings',
+			icon: settings,
 			description: __(
 				'SCF: Manage custom options pages for global settings',
 				'secure-custom-fields'
@@ -136,7 +137,7 @@ const registerAdminCommands = () => {
 			label: __( 'Create New Options Page', 'secure-custom-fields' ),
 			url: 'post-new.php',
 			urlArgs: { post_type: 'acf-ui-options-page' },
-			icon: 'plus',
+			icon: plus,
 			description: __(
 				'SCF: Create a new custom options page',
 				'secure-custom-fields'
@@ -148,7 +149,7 @@ const registerAdminCommands = () => {
 			label: __( 'SCF Tools', 'secure-custom-fields' ),
 			url: 'admin.php',
 			urlArgs: { page: 'acf-tools' },
-			icon: 'admin-tools',
+			icon: tool,
 			description: __(
 				'SCF: Access SCF utility tools',
 				'secure-custom-fields'
@@ -160,7 +161,7 @@ const registerAdminCommands = () => {
 			label: __( 'Import SCF Data', 'secure-custom-fields' ),
 			url: 'admin.php',
 			urlArgs: { page: 'acf-tools', tool: 'import' },
-			icon: 'upload',
+			icon: upload,
 			description: __(
 				'SCF: Import field groups, post types, taxonomies, and options pages',
 				'secure-custom-fields'
@@ -172,7 +173,7 @@ const registerAdminCommands = () => {
 			label: __( 'Export SCF Data', 'secure-custom-fields' ),
 			url: 'admin.php',
 			urlArgs: { page: 'acf-tools', tool: 'export' },
-			icon: 'download',
+			icon: download,
 			description: __(
 				'SCF: Export field groups, post types, taxonomies, and options pages',
 				'secure-custom-fields'

--- a/assets/src/js/commands/custom-post-type-commands.js
+++ b/assets/src/js/commands/custom-post-type-commands.js
@@ -19,6 +19,7 @@ import { createElement } from '@wordpress/element';
 import { Icon } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
+import { page, plus, edit } from '@wordpress/icons';
 
 /**
  * Register custom post type commands
@@ -46,7 +47,7 @@ const registerPostTypeCommands = () => {
 		commandStore.registerCommand( {
 			name: `scf/cpt-${ postType.name }`,
 			label: postType.all_items,
-			icon: createElement( Icon, { icon: 'admin-page' } ),
+			icon: createElement( Icon, { icon: page } ),
 			context: 'admin',
 			description: postType.all_items,
 			keywords: [
@@ -68,7 +69,7 @@ const registerPostTypeCommands = () => {
 		commandStore.registerCommand( {
 			name: `scf/new-${ postType.name }`,
 			label: postType.add_new_item,
-			icon: createElement( Icon, { icon: 'plus' } ),
+			icon: createElement( Icon, { icon: plus } ),
 			context: 'admin',
 			description: postType.add_new_item,
 			keywords: [
@@ -91,7 +92,7 @@ const registerPostTypeCommands = () => {
 		commandStore.registerCommand( {
 			name: `scf/edit-${ postType.name }`,
 			label: sprintf(__('Edit post type: %s', 'secure-custom-fields'), postType.label),
-			icon: createElement( Icon, { icon: 'edit' } ),
+			icon: createElement( Icon, { icon: edit } ),
 			context: 'admin',
 			description: sprintf(__('Edit the %s post type settings', 'secure-custom-fields'), postType.label),
 			keywords: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@babel/preset-react": "^7.25.7",
         "@wordpress/dependency-extraction-webpack-plugin": "^6.20.0",
         "@wordpress/e2e-test-utils-playwright": "^1.20.0",
+        "@wordpress/icons": "^10.26.0",
         "@wordpress/prettier-config": "^4.22.0",
         "@wordpress/priority-queue": "^3.22.0",
         "@wordpress/scripts": "^30.14.0",
@@ -4006,6 +4007,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/qs": {
       "version": "6.9.18",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
@@ -4019,6 +4027,27 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
+      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
@@ -4900,6 +4929,51 @@
         "@playwright/test": ">=1"
       }
     },
+    "node_modules/@wordpress/element": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.26.0.tgz",
+      "integrity": "sha512-IlzQE7oVG4fuwRA5N7vhnr57kvf1HS08kwJwP+EC/olREnFEi8XOIeDa7rAEVXNAx2xeoLKQ6+K7Banp7+c6GA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "7.25.7",
+        "@types/react": "^18.2.79",
+        "@types/react-dom": "^18.2.25",
+        "@wordpress/escape-html": "^3.26.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/element/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@wordpress/escape-html": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.26.0.tgz",
+      "integrity": "sha512-SQfSmUOMP32duStoxvrkydCtD/ELyNXpAwkE414swo8AQAKxBJMQDYE3PZy1uZ6YCtbSX7EHHAX9G1EeoHUzgg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "7.25.7"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/eslint-plugin": {
       "version": "22.7.0",
       "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.7.0.tgz",
@@ -4990,6 +5064,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@wordpress/icons": {
+      "version": "10.26.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.26.0.tgz",
+      "integrity": "sha512-7XPcJbvy4s8USfcuMxdVE6qTaEYzRv0+TZa6Epbe61HFrvaMl9X0Mr+jcCyQ7qBp4jKHfHInWfywNeYOxc5SMg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "7.25.7",
+        "@wordpress/element": "^6.26.0",
+        "@wordpress/primitives": "^4.26.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/jest-console": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.21.0.tgz",
@@ -5071,6 +5161,25 @@
       },
       "peerDependencies": {
         "prettier": ">=3"
+      }
+    },
+    "node_modules/@wordpress/primitives": {
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.26.0.tgz",
+      "integrity": "sha512-vmqKlqQxyv9XDKeIntd70SpRJeU0uXWj6iQDZmmbsOcDWL3UNIOFeN5dB25vDeyoseQ+r+JNnoU+hq7cpQa/8Q==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "7.25.7",
+        "@wordpress/element": "^6.26.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/priority-queue": {
@@ -7730,6 +7839,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -8464,6 +8583,13 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
     },
@@ -17342,7 +17468,6 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -18118,7 +18243,6 @@
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/preset-react": "^7.25.7",
     "@wordpress/dependency-extraction-webpack-plugin": "^6.20.0",
     "@wordpress/e2e-test-utils-playwright": "^1.20.0",
+    "@wordpress/icons": "^10.26.0",
     "@wordpress/prettier-config": "^4.22.0",
     "@wordpress/priority-queue": "^3.22.0",
     "@wordpress/scripts": "^30.14.0",


### PR DESCRIPTION
Closes #188 

Replaces the Dashicons in the SCF Commands with `@wordpress/icons` for visual consistency.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/100718d0-b191-452b-b8dc-5b1fb7128b24) | ![image](https://github.com/user-attachments/assets/bb994971-88f5-4dde-be2d-4a9b50434294) |