### PR TITLE
Remove the word 'New' from default `add-new*` label values

### DIFF
--- a/includes/admin/views/acf-post-type/advanced-settings.php
+++ b/includes/admin/views/acf-post-type/advanced-settings.php
@@ -205,12 +205,12 @@ foreach ( acf_get_combined_post_type_settings_tabs() as $tab_key => $tab_label )
 					'value'        => $acf_post_type['labels']['add_new_item'],
 					'data'         => array(
 						/* translators: %s Singular form of post type name */
-						'label'   => __( 'Add New %s', 'secure-custom-fields' ),
+						'label'   => __( 'Add %s', 'secure-custom-fields' ),
 						'replace' => 'singular',
 					),
 					'label'        => __( 'Add New Item', 'secure-custom-fields' ),
 					'instructions' => __( 'At the top of the editor screen when adding a new item.', 'secure-custom-fields' ),
-					'placeholder'  => __( 'Add New Post', 'secure-custom-fields' ),
+					'placeholder'  => __( 'Add Post', 'secure-custom-fields' ),
 				),
 				'div',
 				'field'
@@ -225,12 +225,12 @@ foreach ( acf_get_combined_post_type_settings_tabs() as $tab_key => $tab_label )
 					'value'        => $acf_post_type['labels']['add_new'],
 					'data'         => array(
 						/* translators: %s Singular form of post type name */
-						'label'   => __( 'Add New %s', 'secure-custom-fields' ),
+						'label'   => __( 'Add %s', 'secure-custom-fields' ),
 						'replace' => 'singular',
 					),
 					'label'        => __( 'Add New', 'secure-custom-fields' ),
 					'instructions' => __( 'In the post type submenu in the admin dashboard.', 'secure-custom-fields' ),
-					'placeholder'  => __( 'Add New Post', 'secure-custom-fields' ),
+					'placeholder'  => __( 'Add Post', 'secure-custom-fields' ),
 				),
 				'div',
 				'field'


### PR DESCRIPTION
Closes #193 by removing the word `New` from default `add_new*` label values.

![image](https://github.com/user-attachments/assets/6b2cd915-9f7b-48bd-96dd-6446da9d9a31)
