### PR TITLE
Bug fix: Prevent fatal if class does not exist on Beta Features.

### DIFF
--- a/includes/admin/beta-features.php
+++ b/includes/admin/beta-features.php
@@ -47,6 +47,10 @@ if ( ! class_exists( 'SCF_Admin_Beta_Features' ) ) :
 		 * @return  void
 		 */
 		public function register_beta_feature( $beta_feature ) {
+			if ( ! class_exists( $beta_feature ) ) {
+				return;
+			}
+
 			$instance                               = new $beta_feature();
 			$this->beta_features[ $instance->name ] = $instance;
 		}

--- a/tests/e2e/plugin-activation.spec.ts
+++ b/tests/e2e/plugin-activation.spec.ts
@@ -23,8 +23,8 @@ test.describe( 'Plugin Activation', () => {
 		// Navigate to plugins page
 		await admin.visitAdminPage( 'plugins.php' );
 
-		// Check if our plugin is active
-		const pluginRow = page.locator( `tr[data-plugin="${ PLUGIN_PATH }"]` );
+		// Check if our plugin is active (exclude update notification rows)
+		const pluginRow = page.locator( `tr[data-plugin="${ PLUGIN_PATH }"]:not(.plugin-update-tr)` );
 		await expect( pluginRow ).toBeVisible();
 
 		// Check if plugin is activated
@@ -38,9 +38,9 @@ test.describe( 'Plugin Activation', () => {
 		// Navigate to plugins page
 		await admin.visitAdminPage( 'plugins.php' );
 
-		// Check plugin name
+		// Check plugin name (exclude update notification rows)
 		const pluginName = page.locator(
-			`tr[data-plugin="${ PLUGIN_PATH }"] .plugin-title strong`
+			`tr[data-plugin="${ PLUGIN_PATH }"]:not(.plugin-update-tr) .plugin-title strong`
 		);
 		await expect( pluginName ).toHaveText( 'Secure Custom Fields' );
 	} );


### PR DESCRIPTION
Closes #198 and prevents from happening again due to a beta feature trying to load a non existent class.