### PR TITLE
Allow binding Date block to `date_picker` fields

### DIFF
--- a/assets/src/js/bindings/block-editor.js
+++ b/assets/src/js/bindings/block-editor.js
@@ -39,6 +39,9 @@ const BLOCK_BINDINGS_CONFIG = {
 		linkTarget: [ 'text', 'checkbox', 'select' ],
 		rel: [ 'text', 'checkbox', 'select' ],
 	},
+	'core/post-date': {
+		datetime: [ 'date_picker' ],
+	},
 };
 
 /**


### PR DESCRIPTION
As of https://github.com/WordPress/gutenberg/pull/70585, the Date block can be used with Block Bindings.

This PR allows connecting it to SCF's `date_picker` field.

![date-block-binding-scf](https://github.com/user-attachments/assets/7e4e6a4c-c6fa-45af-b181-bfec2021a960)
