### PR TITLE
Backport: Update SCF to include all 6.4.3 fixes.

### DIFF
--- a/assets/src/js/_acf-condition-types.js
+++ b/assets/src/js/_acf-condition-types.js
@@ -71,7 +71,7 @@
 		const template = function ( selection ) {
 			return (
 				`<span class="acf-${ typeAttr }-select-name acf-conditional-select-name">` +
-				acf.escHtml( selection.text ) +
+				acf.strEscape( selection.text ) +
 				'</span>'
 			);
 		};
@@ -84,7 +84,7 @@
 				'<span class="' +
 				classes +
 				'">' +
-				acf.escHtml( results.text ) +
+				acf.strEscape( results.text ) +
 				'</span>' +
 				`<span class="acf-${ typeAttr }-select-id acf-conditional-select-id">` +
 				( results.id ? results.id : '' ) +
@@ -558,16 +558,14 @@
 		type: 'hasPostObject',
 		operator: '==',
 		label: __( 'Post is equal to' ),
-		fieldTypes: [
-			'post_object',
-		],
+		fieldTypes: [ 'post_object' ],
 		match: function ( rule, field ) {
 			return isEqualToNumber( rule.value, field.val() );
 		},
 		choices: function ( fieldObject ) {
 			return conditionalSelect2( fieldObject, 'post_object' );
 		},
-	});
+	} );
 
 	acf.registerConditionType( HasPostObject );
 
@@ -580,16 +578,14 @@
 		type: 'hasPostObjectNotEqual',
 		operator: '!==',
 		label: __( 'Post is not equal to' ),
-		fieldTypes: [
-			'post_object',
-		],
+		fieldTypes: [ 'post_object' ],
 		match: function ( rule, field ) {
 			return ! isEqualToNumber( rule.value, field.val() );
 		},
 		choices: function ( fieldObject ) {
 			return conditionalSelect2( fieldObject, 'post_object' );
 		},
-	});
+	} );
 
 	acf.registerConditionType( HasPostObjectNotEqual );
 
@@ -602,9 +598,7 @@
 		type: 'containsPostObject',
 		operator: '==contains',
 		label: __( 'Posts contain' ),
-		fieldTypes: [
-			'post_object',
-		],
+		fieldTypes: [ 'post_object' ],
 		match: function ( rule, field ) {
 			const val = field.val();
 			const ruleVal = rule.value;
@@ -620,7 +614,7 @@
 		choices: function ( fieldObject ) {
 			return conditionalSelect2( fieldObject, 'post_object' );
 		},
-	});
+	} );
 
 	acf.registerConditionType( containsPostObject );
 
@@ -633,16 +627,14 @@
 		type: 'containsNotPostObject',
 		operator: '!=contains',
 		label: __( 'Posts do not contain' ),
-		fieldTypes: [
-			'post_object',
-		],
+		fieldTypes: [ 'post_object' ],
 		match: function ( rule, field ) {
 			const val = field.val();
 			const ruleVal = rule.value;
 
 			let match = true;
 			if ( val instanceof Array ) {
-				match = ! val.includes( ruleVal );	
+				match = ! val.includes( ruleVal );
 			} else {
 				match = val !== ruleVal;
 			}
@@ -651,7 +643,7 @@
 		choices: function ( fieldObject ) {
 			return conditionalSelect2( fieldObject, 'post_object' );
 		},
-	});
+	} );
 
 	acf.registerConditionType( containsNotPostObject );
 
@@ -664,20 +656,18 @@
 		type: 'hasAnyPostObject',
 		operator: '!=empty',
 		label: __( 'Has any post selected' ),
-		fieldTypes: [
-			'post_object',
-		],
+		fieldTypes: [ 'post_object' ],
 		match: function ( rule, field ) {
 			let val = field.val();
 			if ( val instanceof Array ) {
 				val = val.length;
 			}
-			return !!val;
+			return !! val;
 		},
 		choices: function () {
 			return '<input type="text" disabled />';
 		},
-	});
+	} );
 
 	acf.registerConditionType( HasAnyPostObject );
 
@@ -690,20 +680,18 @@
 		type: 'hasNoPostObject',
 		operator: '==empty',
 		label: __( 'Has no post selected' ),
-		fieldTypes: [
-			'post_object',
-		],
+		fieldTypes: [ 'post_object' ],
 		match: function ( rule, field ) {
 			let val = field.val();
 			if ( val instanceof Array ) {
 				val = val.length;
 			}
-			return !val;
+			return ! val;
 		},
 		choices: function () {
 			return '<input type="text" disabled />';
 		},
-	});
+	} );
 
 	acf.registerConditionType( HasNoPostObject );
 

--- a/assets/src/js/_acf-screen.js
+++ b/assets/src/js/_acf-screen.js
@@ -298,36 +298,23 @@
 
 				// Create postbox if doesn't exist.
 				if ( ! postbox ) {
-					var wpMinorVersion = parseFloat( acf.get( 'wp_version' ) );
-					if ( wpMinorVersion >= 5.5 ) {
-						var postboxHeader = [
-							'<div class="postbox-header">',
-							'<h2 class="hndle ui-sortable-handle">',
-							'<span>' + acf.escHtml( result.title ) + '</span>',
-							'</h2>',
-							'<div class="handle-actions hide-if-no-js">',
-							'<button type="button" class="handlediv" aria-expanded="true">',
-							'<span class="screen-reader-text">Toggle panel: ' +
-								acf.escHtml( result.title ) +
-								'</span>',
-							'<span class="toggle-indicator" aria-hidden="true"></span>',
-							'</button>',
-							'</div>',
-							'</div>',
-						].join( '' );
-					} else {
-						var postboxHeader = [
-							'<button type="button" class="handlediv" aria-expanded="true">',
-							'<span class="screen-reader-text">Toggle panel: ' +
-								acf.escHtml( result.title ) +
-								'</span>',
-							'<span class="toggle-indicator" aria-hidden="true"></span>',
-							'</button>',
-							'<h2 class="hndle ui-sortable-handle">',
-							'<span>' + acf.escHtml( result.title ) + '</span>',
-							'</h2>',
-						].join( '' );
-					}
+					var postboxHeader = [
+						'<div class="postbox-header">',
+						'<h2 class="hndle ui-sortable-handle">',
+						'<span>' + result.title + '</span>',
+						'</h2>',
+						'<div class="handle-actions hide-if-no-js">',
+						'<button type="button" class="handlediv" aria-expanded="true">',
+						'<span class="screen-reader-text">' +
+							acf.__( 'Toggle panel' ) +
+							': ' +
+							result.title +
+							'</span>',
+						'<span class="toggle-indicator" aria-hidden="true"></span>',
+						'</button>',
+						'</div>',
+						'</div>',
+					].join( '' );
 
 					// Ensure result.classes is set.
 					if ( ! result.classes ) result.classes = '';
@@ -515,13 +502,7 @@
 			acf.unload.disable();
 
 			// Refresh metaboxes since WP 5.3.
-			var wpMinorVersion = parseFloat( acf.get( 'wp_version' ) );
-			if ( wpMinorVersion >= 5.3 ) {
-				this.addAction(
-					'refresh_post_screen',
-					this.onRefreshPostScreen
-				);
-			}
+			this.addAction( 'refresh_post_screen', this.onRefreshPostScreen );
 
 			// Trigger "refresh" after WP has moved metaboxes into place.
 			wp.domReady( acf.refresh );
@@ -532,11 +513,11 @@
 			var attributes = [ 'template', 'parent', 'format' ];
 
 			// Append taxonomy attribute names to this list.
-			( wp.data.select( 'core' ).getTaxonomies() || [] ).map( function (
-				taxonomy
-			) {
-				attributes.push( taxonomy.rest_base );
-			} );
+			( wp.data.select( 'core' ).getTaxonomies() || [] ).map(
+				function ( taxonomy ) {
+					attributes.push( taxonomy.rest_base );
+				}
+			);
 
 			// Get relevant current post edits.
 			var _postEdits = wp.data.select( 'core/editor' ).getPostEdits();
@@ -614,7 +595,6 @@
 		 * @return	void
 		 */
 		onRefreshPostScreen: function ( data ) {
-
 			// Extract vars.
 			var select = wp.data.select( 'core/edit-post' );
 			var dispatch = wp.data.dispatch( 'core/edit-post' );
@@ -622,9 +602,8 @@
 			// Load current metabox locations and data.
 			var locations = {};
 			select.getActiveMetaBoxLocations().map( function ( location ) {
-				locations[ location ] = select.getMetaBoxesPerLocation(
-					location
-				);
+				locations[ location ] =
+					select.getMetaBoxesPerLocation( location );
 			} );
 
 			// Generate flat array of existing ids.

--- a/assets/src/js/_acf.js
+++ b/assets/src/js/_acf.js
@@ -149,7 +149,9 @@
 			}
 			if ( reqWidth > seed.length ) {
 				// so short we pad
-				return Array( 1 + ( reqWidth - seed.length ) ).join( '0' ) + seed;
+				return (
+					Array( 1 + ( reqWidth - seed.length ) ).join( '0' ) + seed
+				);
 			}
 			return seed;
 		};
@@ -208,7 +210,10 @@
 			? matches
 					.map( function ( s, i ) {
 						var c = s.charAt( 0 );
-						return ( i === 0 ? c.toLowerCase() : c.toUpperCase() ) + s.slice( 1 );
+						return (
+							( i === 0 ? c.toLowerCase() : c.toUpperCase() ) +
+							s.slice( 1 )
+						);
 					} )
 					.join( '' )
 			: '';
@@ -576,9 +581,12 @@
 			'&quot;': '"',
 			'&#39;': "'",
 		};
-		return ( '' + string ).replace( /&amp;|&lt;|&gt;|&quot;|&#39;/g, function ( entity ) {
-			return htmlUnescapes[ entity ];
-		} );
+		return ( '' + string ).replace(
+			/&amp;|&lt;|&gt;|&quot;|&#39;/g,
+			function ( entity ) {
+				return htmlUnescapes[ entity ];
+			}
+		);
 	};
 
 	// Tests.
@@ -603,14 +611,48 @@
 	 *
 	 * @date	08/06/2020
 	 * @since	ACF 5.9.0
+	 * @since   ACF 6.4.3 - Use DOMPurify for better security.
 	 *
 	 * @param	string string The input string.
 	 * @return	string
 	 */
+
 	acf.escHtml = function ( string ) {
-		return ( '' + string ).replace( /<script|<\/script/g, function ( html ) {
-			return acf.strEscape( html );
+		string = '' + string; // Convert to string if not already.
+		const DOMPurify = require( 'dompurify' );
+		if ( DOMPurify === undefined || ! DOMPurify.isSupported ) {
+			console.warn(
+				'ACF: DOMPurify not loaded or not supported. Falling back to basic HTML escaping for security.'
+			);
+			return acf.strEscape( string ); // Fallback to basic escaping.
+		}
+		const options = acf.applyFilters( 'esc_html_dompurify_config', {
+			USE_PROFILES: { html: true },
+			ADD_TAGS: [ 'audio', 'video' ],
+			ADD_ATTR: [ 'controls', 'loop', 'muted', 'preload' ],
+			FORBID_TAGS: [
+				'script',
+				'style',
+				'iframe',
+				'object',
+				'embed',
+				'base',
+				'meta',
+				'form',
+			],
+			FORBID_ATTR: [
+				'style',
+				'srcset',
+				'action',
+				'background',
+				'dynsrc',
+				'lowsrc',
+				'on*',
+			],
+			ALLOW_DATA_ATTR: false,
+			ALLOW_ARIA_ATTR: false,
 		} );
+		return DOMPurify.sanitize( string, options );
 	};
 
 	// Tests.
@@ -1221,7 +1263,11 @@
 		var style = $el.attr( 'style' ) + ''; // needed to copy
 
 		// wrap
-		$el.wrap( '<div class="acf-temp-remove" style="height:' + outerHeight + 'px"></div>' );
+		$el.wrap(
+			'<div class="acf-temp-remove" style="height:' +
+				outerHeight +
+				'px"></div>'
+		);
 		var $wrap = $el.parent();
 
 		// set pos
@@ -1268,7 +1314,11 @@
 
 		// create dummy td
 		var $td = $(
-			'<td class="acf-temp-remove" style="padding:0; height:' + height + 'px" colspan="' + children + '"></td>'
+			'<td class="acf-temp-remove" style="padding:0; height:' +
+				height +
+				'px" colspan="' +
+				children +
+				'"></td>'
 		);
 
 		// fade away tr
@@ -1355,7 +1405,8 @@
 				target: $el2,
 				search: args.search,
 				replace: args.replace,
-				replacer: typeof args.rename === 'function' ? args.rename : null,
+				replacer:
+					typeof args.rename === 'function' ? args.rename : null,
 			} );
 		}
 
@@ -1373,7 +1424,10 @@
 				'id',
 				$( this )
 					.prop( 'id' )
-					.replace( 'acf_fields', acf.uniqid( 'duplicated_' ) + '_acf_fields' )
+					.replace(
+						'acf_fields',
+						acf.uniqid( 'duplicated_' ) + '_acf_fields'
+					)
 			);
 		} );
 
@@ -1460,15 +1514,28 @@
 
 		// Destructive Replace.
 		if ( args.destructive ) {
-			var html = acf.strReplace( args.search, args.replace, $el.outerHTML() );
+			var html = acf.strReplace(
+				args.search,
+				args.replace,
+				$el.outerHTML()
+			);
 			$el.replaceWith( html );
 
 			// Standard Replace.
 		} else {
 			$el.attr( 'data-id', args.replace );
-			$el.find( '[id*="' + args.search + '"]' ).attr( 'id', withReplacer( 'id' ) );
-			$el.find( '[for*="' + args.search + '"]' ).attr( 'for', withReplacer( 'for' ) );
-			$el.find( '[name*="' + args.search + '"]' ).attr( 'name', withReplacer( 'name' ) );
+			$el.find( '[id*="' + args.search + '"]' ).attr(
+				'id',
+				withReplacer( 'id' )
+			);
+			$el.find( '[for*="' + args.search + '"]' ).attr(
+				'for',
+				withReplacer( 'for' )
+			);
+			$el.find( '[name*="' + args.search + '"]' ).attr(
+				'name',
+				withReplacer( 'name' )
+			);
 		}
 
 		// return
@@ -1537,7 +1604,9 @@
 	 */
 
 	acf.showLoading = function ( $el ) {
-		$el.append( '<div class="acf-loading-overlay"><i class="acf-loading"></i></div>' );
+		$el.append(
+			'<div class="acf-loading-overlay"><i class="acf-loading"></i></div>'
+		);
 	};
 
 	acf.hideLoading = function ( $el ) {
@@ -1905,7 +1974,9 @@
 		};
 
 		// modern browsers
-		var file = $input[ 0 ].files.length ? acf.isget( $input[ 0 ].files, 0 ) : false;
+		var file = $input[ 0 ].files.length
+			? acf.isget( $input[ 0 ].files, 0 )
+			: false;
 		if ( file ) {
 			// update data
 			data.size = file.size;
@@ -2043,7 +2114,11 @@
 				//  optgroup
 				if ( item.children ) {
 					itemsHtml +=
-						'<optgroup label="' + acf.escAttr( text ) + '">' + crawl( item.children ) + '</optgroup>';
+						'<optgroup label="' +
+						acf.escAttr( text ) +
+						'">' +
+						crawl( item.children ) +
+						'</optgroup>';
 
 					// option
 				} else {
@@ -2157,7 +2232,12 @@
 	 *  @return	bool
 	 */
 	acf.isGutenberg = function () {
-		return !! ( window.wp && wp.data && wp.data.select && wp.data.select( 'core/editor' ) );
+		return !! (
+			window.wp &&
+			wp.data &&
+			wp.data.select &&
+			wp.data.select( 'core/editor' )
+		);
 	};
 
 	/**
@@ -2170,7 +2250,12 @@
 	 *  @return	bool
 	 */
 	acf.isGutenbergPostEditor = function () {
-		return !! ( window.wp && wp.data && wp.data.select && wp.data.select( 'core/edit-post' ) );
+		return !! (
+			window.wp &&
+			wp.data &&
+			wp.data.select &&
+			wp.data.select( 'core/edit-post' )
+		);
 	};
 
 	/**
@@ -2257,8 +2342,11 @@
 			rect.top !== rect.bottom &&
 			rect.top >= 0 &&
 			rect.left >= 0 &&
-			rect.bottom <= ( window.innerHeight || document.documentElement.clientHeight ) &&
-			rect.right <= ( window.innerWidth || document.documentElement.clientWidth )
+			rect.bottom <=
+				( window.innerHeight ||
+					document.documentElement.clientHeight ) &&
+			rect.right <=
+				( window.innerWidth || document.documentElement.clientWidth )
 		);
 	};
 
@@ -2295,7 +2383,9 @@
 		var push = function ( el, callback ) {
 			// Add event listener.
 			if ( ! items.length ) {
-				$( window ).on( 'scroll resize', debounced ).on( 'acfrefresh orientationchange', check );
+				$( window )
+					.on( 'scroll resize', debounced )
+					.on( 'acfrefresh orientationchange', check );
 			}
 
 			// Append to list.
@@ -2311,7 +2401,9 @@
 
 			// Clean up listener.
 			if ( ! items.length ) {
-				$( window ).off( 'scroll resize', debounced ).off( 'acfrefresh orientationchange', check );
+				$( window )
+					.off( 'scroll resize', debounced )
+					.off( 'acfrefresh orientationchange', check );
 			}
 		};
 

--- a/assets/src/js/_acf.js
+++ b/assets/src/js/_acf.js
@@ -611,7 +611,7 @@
 	 *
 	 * @date	08/06/2020
 	 * @since	ACF 5.9.0
-	 * @since   ACF 6.4.3 - Use DOMPurify for better security.
+	 * @since	ACF 6.4.3 - Use DOMPurify for better security.
 	 *
 	 * @param	string string The input string.
 	 * @return	string

--- a/assets/src/js/_acf.js
+++ b/assets/src/js/_acf.js
@@ -924,7 +924,7 @@
 	}
 */
 
-	acf.addAction = function ( action, callback, priority, context ) {
+	acf.addAction = function () {
 		//action = prefixAction(action);
 		acf.hooks.addAction.apply( this, arguments );
 		return this;
@@ -942,7 +942,7 @@
 	 *  @return	this
 	 */
 
-	acf.removeAction = function ( action, callback ) {
+	acf.removeAction = function () {
 		//action = prefixAction(action);
 		acf.hooks.removeAction.apply( this, arguments );
 		return this;
@@ -1038,7 +1038,7 @@
 	 *  @return	this
 	 */
 
-	acf.addFilter = function ( action ) {
+	acf.addFilter = function () {
 		//action = prefixAction(action);
 		acf.hooks.addFilter.apply( this, arguments );
 		return this;
@@ -1056,7 +1056,7 @@
 	 *  @return	this
 	 */
 
-	acf.removeFilter = function ( action ) {
+	acf.removeFilter = function () {
 		//action = prefixAction(action);
 		acf.hooks.removeFilter.apply( this, arguments );
 		return this;
@@ -1074,7 +1074,7 @@
 	 *  @return	this
 	 */
 
-	acf.applyFilters = function ( action ) {
+	acf.applyFilters = function () {
 		//action = prefixAction(action);
 		return acf.hooks.applyFilters.apply( this, arguments );
 	};

--- a/assets/src/js/_field-group-field.js
+++ b/assets/src/js/_field-group-field.js
@@ -11,7 +11,8 @@
 			'click .copyable': 'onClickCopy',
 			'click .handle': 'onClickEdit',
 			'click .close-field': 'onClickEdit',
-			'click a[data-key="acf_field_settings_tabs"]': 'onChangeSettingsTab',
+			'click a[data-key="acf_field_settings_tabs"]':
+				'onChangeSettingsTab',
 			'click .delete-field': 'onClickDelete',
 			'click .duplicate-field': 'duplicate',
 			'click .move-field': 'move',
@@ -82,7 +83,9 @@
 		},
 
 		$setting: function ( name ) {
-			return this.$( '.acf-field-settings:first .acf-field-setting-' + name );
+			return this.$(
+				'.acf-field-settings:first .acf-field-setting-' + name
+			);
 		},
 
 		$fieldTypeSelect: function () {
@@ -237,7 +240,12 @@
 		},
 
 		makeCopyable: function ( text ) {
-			if ( ! navigator.clipboard ) return '<span class="copyable copy-unsupported">' + text + '</span>';
+			if ( ! navigator.clipboard )
+				return (
+					'<span class="copyable copy-unsupported">' +
+					text +
+					'</span>'
+				);
 			return '<span class="copyable">' + text + '</span>';
 		},
 
@@ -271,8 +279,14 @@
 				suppressFilters: true,
 				dropdownCssClass: 'field-type-select-results',
 				templateResult: function ( selection ) {
-					if ( selection.loading || ( selection.element && selection.element.nodeName === 'OPTGROUP' ) ) {
-						var $selection = $( '<span class="acf-selection"></span>' );
+					if (
+						selection.loading ||
+						( selection.element &&
+							selection.element.nodeName === 'OPTGROUP' )
+					) {
+						var $selection = $(
+							'<span class="acf-selection"></span>'
+						);
 						$selection.html( acf.strEscape( selection.text ) );
 					} else {
 						var $selection = $(
@@ -300,20 +314,26 @@
 			} );
 
 			this.fieldTypeSelect2.on( 'select2:open', function () {
-				$( '.field-type-select-results input.select2-search__field' ).attr(
-					'placeholder',
-					acf.__( 'Type to search...' )
-				);
+				$(
+					'.field-type-select-results input.select2-search__field'
+				).attr( 'placeholder', acf.__( 'Type to search...' ) );
 			} );
 
 			this.fieldTypeSelect2.on( 'change', function ( e ) {
-				$( e.target ).parents( 'ul:first' ).find( 'button.browse-fields' ).prop( 'disabled', true );
+				$( e.target )
+					.parents( 'ul:first' )
+					.find( 'button.browse-fields' )
+					.prop( 'disabled', true );
 			} );
 
 			// When typing happens on the li element above the select2.
 			this.fieldTypeSelect2.$el
 				.parent()
-				.on( 'keydown', '.select2-selection.select2-selection--single', this.onKeyDownSelect );
+				.on(
+					'keydown',
+					'.select2-selection.select2-selection--single',
+					this.onKeyDownSelect
+				);
 		},
 
 		addProFields: function () {
@@ -330,14 +350,23 @@
 			const PROFieldTypes = acf.get( 'PROFieldTypes' );
 			if ( typeof PROFieldTypes !== 'object' ) return;
 
-			const $layoutGroup = $fieldTypeSelect.find( 'optgroup option[value="group"]' ).parent();
+			const $layoutGroup = $fieldTypeSelect
+				.find( 'optgroup option[value="group"]' )
+				.parent();
 
-			const $contentGroup = $fieldTypeSelect.find( 'optgroup option[value="image"]' ).parent();
+			const $contentGroup = $fieldTypeSelect
+				.find( 'optgroup option[value="image"]' )
+				.parent();
 
 			for ( const [ name, field ] of Object.entries( PROFieldTypes ) ) {
-				const $useGroup = field.category === 'content' ? $contentGroup : $layoutGroup;
-				const $existing = $useGroup.children( '[value="' + name + '"]' );
-				const label = `${ acf.strEscape( field.label ) } (${ acf.strEscape( acf.__( 'PRO Only' ) ) })`;
+				const $useGroup =
+					field.category === 'content' ? $contentGroup : $layoutGroup;
+				const $existing = $useGroup.children(
+					'[value="' + name + '"]'
+				);
+				const label = `${ acf.strEscape(
+					field.label
+				) } (${ acf.strEscape( acf.__( 'PRO Only' ) ) })`;
 
 				if ( $existing.length ) {
 					// Already added by pro, update existing option.
@@ -349,7 +378,9 @@
 					}
 				} else {
 					// Append new disabled option.
-					$useGroup.append( `<option value="null" disabled="disabled">${ label }</option>` );
+					$useGroup.append(
+						`<option value="null" disabled="disabled">${ label }</option>`
+					);
 				}
 			}
 
@@ -360,7 +391,7 @@
 			// vars
 			var $handle = this.$( '.handle:first' );
 			var menu_order = this.prop( 'menu_order' );
-			var label = this.getLabel();
+			var label = acf.strEscape( this.getLabel() );
 			var name = this.prop( 'name' );
 			var type = this.getTypeLabel();
 			var key = this.prop( 'key' );
@@ -378,7 +409,9 @@
 			$handle.find( '.li-field-label strong a' ).html( label );
 
 			// update name
-			$handle.find( '.li-field-name' ).html( this.makeCopyable( acf.strSanitize( name ) ) );
+			$handle
+				.find( '.li-field-name' )
+				.html( this.makeCopyable( acf.strSanitize( name ) ) );
 
 			// update type
 			const iconName = acf.strSlugify( this.getType() );
@@ -418,7 +451,9 @@
 			navigator.clipboard.writeText( copyValue ).then( () => {
 				$( e.target ).closest( '.copyable' ).addClass( 'copied' );
 				setTimeout( function () {
-					$( e.target ).closest( '.copyable' ).removeClass( 'copied' );
+					$( e.target )
+						.closest( '.copyable' )
+						.removeClass( 'copied' );
 				}, 2000 );
 			} );
 		},
@@ -426,7 +461,10 @@
 		onClickEdit: function ( e ) {
 			const $target = $( e.target );
 
-			if ( $target.parent().hasClass( 'row-options' ) && ! $target.hasClass( 'edit-field' ) ) {
+			if (
+				$target.parent().hasClass( 'row-options' ) &&
+				! $target.hasClass( 'edit-field' )
+			) {
 				return;
 			}
 
@@ -442,7 +480,9 @@
 		 * Adds 'active' class to row options nearest to the target.
 		 */
 		onFocusEdit: function ( e ) {
-			var $rowOptions = $( e.target ).closest( 'li' ).find( '.row-options' );
+			var $rowOptions = $( e.target )
+				.closest( 'li' )
+				.find( '.row-options' );
 			$rowOptions.addClass( 'active' );
 		},
 
@@ -451,11 +491,15 @@
 		 */
 		onBlurEdit: function ( e ) {
 			var focusDelayMilliseconds = 50;
-			var $rowOptionsBlurElement = $( e.target ).closest( 'li' ).find( '.row-options' );
+			var $rowOptionsBlurElement = $( e.target )
+				.closest( 'li' )
+				.find( '.row-options' );
 
 			// Timeout so that `activeElement` gives the new element in focus instead of the body.
 			setTimeout( function () {
-				var $rowOptionsFocusElement = $( document.activeElement ).closest( 'li' ).find( '.row-options' );
+				var $rowOptionsFocusElement = $( document.activeElement )
+					.closest( 'li' )
+					.find( '.row-options' );
 				if ( ! $rowOptionsBlurElement.is( $rowOptionsFocusElement ) ) {
 					$rowOptionsBlurElement.removeClass( 'active' );
 				}
@@ -490,14 +534,17 @@
 				! (
 					( e.which >= 186 && e.which <= 222 ) || // punctuation and special characters
 					[
-						8, 9, 13, 16, 17, 18, 19, 20, 27, 32, 33, 34, 35, 36, 37, 38, 39, 40, 45, 46, 91, 92, 93, 144,
-						145,
+						8, 9, 13, 16, 17, 18, 19, 20, 27, 32, 33, 34, 35, 36,
+						37, 38, 39, 40, 45, 46, 91, 92, 93, 144, 145,
 					].includes( e.which ) || // Special keys
 					( e.which >= 112 && e.which <= 123 )
 				)
 			) {
 				// Function keys
-				$( this ).closest( '.select2-container' ).siblings( 'select:enabled' ).select2( 'open' );
+				$( this )
+					.closest( '.select2-container' )
+					.siblings( 'select:enabled' )
+					.select2( 'open' );
 				return;
 			}
 		},
@@ -598,7 +645,16 @@
 			}
 
 			// render
-			if ( [ 'menu_order', 'label', 'required', 'name', 'type', 'key' ].indexOf( name ) > -1 ) {
+			if (
+				[
+					'menu_order',
+					'label',
+					'required',
+					'name',
+					'type',
+					'key',
+				].indexOf( name ) > -1
+			) {
 				this.render();
 			}
 
@@ -609,12 +665,16 @@
 		onChangeLabel: function ( e, $el ) {
 			// set
 			const label = $el.val();
-			const safeLabel = acf.encode( label );
+			const safeLabel = acf.strEscape( label );
 			this.set( 'label', safeLabel );
 
 			// render name
 			if ( this.prop( 'name' ) == '' ) {
-				var name = acf.applyFilters( 'generate_field_object_name', acf.strSanitize( label ), this );
+				var name = acf.applyFilters(
+					'generate_field_object_name',
+					acf.strSanitize( label ),
+					this
+				);
 				this.prop( 'name', name );
 			}
 		},
@@ -626,7 +686,11 @@
 			this.set( 'name', sanitizedName );
 
 			if ( sanitizedName.startsWith( 'field_' ) ) {
-				alert( acf.__( 'The string "field_" may not be used at the start of a field name' ) );
+				alert(
+					acf.__(
+						'The string "field_" may not be used at the start of a field name'
+					)
+				);
 			}
 		},
 
@@ -825,7 +889,11 @@
 
 			// bail early if changed
 			if ( changed ) {
-				alert( acf.__( 'This field cannot be moved until its changes have been saved' ) );
+				alert(
+					acf.__(
+						'This field cannot be moved until its changes have been saved'
+					)
+				);
 				return;
 			}
 
@@ -895,7 +963,10 @@
 				popup.content( html );
 
 				if ( wp.a11y && wp.a11y.speak && acf.__ ) {
-					wp.a11y.speak( acf.__( 'Field moved to other group' ), 'polite' );
+					wp.a11y.speak(
+						acf.__( 'Field moved to other group' ),
+						'polite'
+					);
 				}
 
 				popup.$( '.acf-close-popup' ).focus();
@@ -947,7 +1018,9 @@
 			const $oldSettings = {};
 
 			this.$el
-				.find( '.acf-field-settings:first > .acf-field-settings-main > .acf-field-type-settings' )
+				.find(
+					'.acf-field-settings:first > .acf-field-settings-main > .acf-field-type-settings'
+				)
 				.each( function () {
 					let tab = $( this ).data( 'parent-tab' );
 					let $tabSettings = $( this ).children().removeData();
@@ -972,7 +1045,11 @@
 			const $loading = $(
 				'<div class="acf-field"><div class="acf-input"><div class="acf-loading"></div></div></div>'
 			);
-			this.$el.find( '.acf-field-settings-main-general .acf-field-type-settings' ).before( $loading );
+			this.$el
+				.find(
+					'.acf-field-settings-main-general .acf-field-type-settings'
+				)
+				.before( $loading );
 
 			const ajaxData = {
 				action: 'acf/field_group/render_field_settings',
@@ -1016,11 +1093,15 @@
 
 			tabs.forEach( ( tab ) => {
 				const $tab = self.$el.find(
-					'.acf-field-settings-main-' + tab.replace( '_', '-' ) + ' .acf-field-type-settings'
+					'.acf-field-settings-main-' +
+						tab.replace( '_', '-' ) +
+						' .acf-field-type-settings'
 				);
 				let tabContent = '';
 
-				if ( [ 'object', 'string' ].includes( typeof settings[ tab ] ) ) {
+				if (
+					[ 'object', 'string' ].includes( typeof settings[ tab ] )
+				) {
 					tabContent = settings[ tab ];
 				}
 
@@ -1047,12 +1128,18 @@
 
 		hideEmptyTabs: function () {
 			const $settings = this.$settings();
-			const $tabs = $settings.find( '.acf-field-settings:first > .acf-field-settings-main' );
+			const $tabs = $settings.find(
+				'.acf-field-settings:first > .acf-field-settings-main'
+			);
 
 			$tabs.each( function () {
 				const $tabContent = $( this );
-				const tabName = $tabContent.find( '.acf-field-type-settings:first' ).data( 'parentTab' );
-				const $tabLink = $settings.find( '.acf-settings-type-' + tabName ).first();
+				const tabName = $tabContent
+					.find( '.acf-field-type-settings:first' )
+					.data( 'parentTab' );
+				const $tabLink = $settings
+					.find( '.acf-settings-type-' + tabName )
+					.first();
 
 				if ( $.trim( $tabContent.text() ) === '' ) {
 					$tabLink.hide();

--- a/assets/src/js/_field-group.js
+++ b/assets/src/js/_field-group.js
@@ -43,7 +43,8 @@
 			field,
 			instance
 		) {
-			if ( field?.data?.( 'key' ) !== 'bidirectional_target' ) return args;
+			if ( field?.data?.( 'key' ) !== 'bidirectional_target' )
+				return args;
 
 			args.dropdownCssClass = 'field-type-select-results';
 
@@ -72,7 +73,7 @@
 						selection.element.nodeName === 'OPTGROUP' )
 				) {
 					var $selection = $( '<span class="acf-selection"></span>' );
-					$selection.html( acf.escHtml( selection.text ) );
+					$selection.html( acf.strEscape( selection.text ) );
 					return $selection;
 				}
 
@@ -86,13 +87,13 @@
 
 				var $selection = $(
 					'<i title="' +
-						acf.escHtml( selection.human_field_type ) +
+						acf.escAttr( selection.human_field_type ) +
 						'" class="field-type-icon field-type-icon-' +
-						acf.escHtml(
+						acf.strEscape(
 							selection.field_type.replaceAll( '_', '-' )
 						) +
 						'"></i><span class="acf-selection has-icon">' +
-						acf.escHtml( selection.text ) +
+						acf.strEscape( selection.text ) +
 						'</span>'
 				);
 				if ( selection.this_field ) {

--- a/assets/src/js/pro/_acf-setting-flexible-content.js
+++ b/assets/src/js/pro/_acf-setting-flexible-content.js
@@ -35,7 +35,11 @@
 		},
 
 		getInputId: function () {
-			return this.fieldObject.getInputId() + '-layouts-' + this.field.get( 'id' );
+			return (
+				this.fieldObject.getInputId() +
+				'-layouts-' +
+				this.field.get( 'id' )
+			);
 		},
 
 		// get all sub fields
@@ -83,13 +87,17 @@
 			const label = this.get( 'layoutLabel' );
 			const name = this.get( 'layoutName' );
 
-			const $layoutHeaderLabelText = this.$el.find( '> .acf-label .acf-fc-layout-label' );
+			const $layoutHeaderLabelText = this.$el.find(
+				'> .acf-label .acf-fc-layout-label'
+			);
 
 			if ( label ) {
 				$layoutHeaderLabelText.text( acf.decode( label ) );
 			}
 
-			const $layoutHeaderNameText = this.$el.find( '> .acf-label .acf-fc-layout-name span' );
+			const $layoutHeaderNameText = this.$el.find(
+				'> .acf-label .acf-fc-layout-name span'
+			);
 
 			if ( name ) {
 				$layoutHeaderNameText.text( name );
@@ -171,7 +179,7 @@
 
 		onChangeLabel: function ( e, $el ) {
 			let label = $el.val();
-			const safeLabel = acf.encode( label );
+			const safeLabel = acf.strEscape( label );
 
 			this.set( 'layoutLabel', safeLabel );
 			this.$el.attr( 'data-layout-label', safeLabel );
@@ -217,7 +225,9 @@
 					$el2.attr( 'data-layout-label', '' );
 					$el2.attr( 'data-layout-name', '' );
 					$el2.find( '.acf-fc-meta input' ).val( '' );
-					$el2.find( 'label.acf-fc-layout-label' ).html( acf.__( 'Layout' ) );
+					$el2.find( 'label.acf-fc-layout-label' ).html(
+						acf.__( 'Layout' )
+					);
 				},
 			} );
 
@@ -226,7 +236,9 @@
 
 			// update hidden input
 			layout.$input( 'key' ).val( newKey );
-			! this.isOpen() ? this.open( layout.$el, true ) : layout.$el.find( '.layout-label' ).trigger( 'focus' );
+			! this.isOpen()
+				? this.open( layout.$el, true )
+				: layout.$el.find( '.layout-label' ).trigger( 'focus' );
 
 			// save
 			this.fieldObject.save();
@@ -264,7 +276,12 @@
 				} );
 
 				// action
-				acf.doAction( 'duplicate_field_objects', children, this.fieldObject, this.fieldObject );
+				acf.doAction(
+					'duplicate_field_objects',
+					children,
+					this.fieldObject,
+					this.fieldObject
+				);
 			}
 
 			// get layout
@@ -307,7 +324,9 @@
 
 			// update hidden input
 			layout.$input( 'key' ).val( newKey );
-			! this.isOpen() ? this.open( layout.$el, true ) : layout.$el.find( '.layout-label' ).trigger( 'focus' );
+			! this.isOpen()
+				? this.open( layout.$el, true )
+				: layout.$el.find( '.layout-label' ).trigger( 'focus' );
 			// save
 			this.fieldObject.save();
 		},
@@ -341,7 +360,9 @@
 
 			// validate
 			if ( ! $siblings.length ) {
-				alert( acf.__( 'Flexible Content requires at least 1 layout' ) );
+				alert(
+					acf.__( 'Flexible Content requires at least 1 layout' )
+				);
 				return false;
 			}
 
@@ -390,7 +411,9 @@
 			}
 
 			// get layout
-			var $layout = fieldObject.$el.closest( '.acf-field-setting-fc_layout' );
+			var $layout = fieldObject.$el.closest(
+				'.acf-field-setting-fc_layout'
+			);
 			var layout = acf.getFieldSetting( $layout );
 
 			// check if previous prop exists

--- a/bin/remove-installed-versions.php
+++ b/bin/remove-installed-versions.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Remove Composer\InstalledVersions from autoload_static.php
+ *
+ * This script removes any references to Composer\InstalledVersions
+ * from the autoload_static.php file to prevent conflicts.
+ *
+ * @package secure-custom-fields
+ */
+
+$autoload_file = __DIR__ . '/../vendor/composer/autoload_static.php';
+
+if ( ! file_exists( $autoload_file ) ) {
+	echo 'Autoload file not found: ' . esc_html( $autoload_file ) . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	exit( 0 );
+}
+
+// phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+$content          = file_get_contents( $autoload_file );
+$original_content = $content;
+
+// Remove any lines containing InstalledVersions
+$patterns = array(
+	// Remove full class mapping lines with InstalledVersions.
+	'/^\s*\'Composer\\\\InstalledVersions\'\s*=>\s*__DIR__\s*\.\s*[^,\n]*,?\s*\n/m',
+	// Remove any other references to InstalledVersions.php.
+	'/.*InstalledVersions\.php.*\n/',
+);
+
+foreach ( $patterns as $pattern ) {
+	$content = preg_replace( $pattern, '', $content );
+}
+
+// Clean up any trailing commas that might be left.
+$content = preg_replace( '/,(\s*\)\s*;)/m', '$1', $content );
+
+// Only write if content changed.
+if ( $content !== $original_content ) {
+	// phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+	file_put_contents( $autoload_file, $content );
+	echo "Removed InstalledVersions references from autoload_static.php\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+} else {
+	echo "No InstalledVersions references found in autoload_static.php\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+}

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
 		"post-install-cmd": "WorDBless\\Composer\\InstallDropin::copy",
 		"post-update-cmd": "WorDBless\\Composer\\InstallDropin::copy",
 		"post-autoload-dump": [
-			"sed -i '' \"/InstalledVersions.php/d\" vendor/composer/autoload_static.php"
+			"php bin/remove-installed-versions.php"
 		],
 		"docs": [
 			"@docs:parse",

--- a/composer.json
+++ b/composer.json
@@ -42,11 +42,16 @@
 		},
 		"platform": {
 			"php": "7.4"
-		}
+		},
+		"optimize-autoloader": true,
+		"classmap-authoritative": true
 	},
 	"scripts": {
 		"post-install-cmd": "WorDBless\\Composer\\InstallDropin::copy",
 		"post-update-cmd": "WorDBless\\Composer\\InstallDropin::copy",
+		"post-autoload-dump": [
+			"sed -i '' \"/InstalledVersions.php/d\" vendor/composer/autoload_static.php"
+		],
 		"docs": [
 			"@docs:parse",
 			"@docs:links",

--- a/includes/acf-field-functions.php
+++ b/includes/acf-field-functions.php
@@ -825,7 +825,7 @@ acf_add_action_variations( 'acf/render_field', array( 'type', 'name', 'key' ), 0
 function acf_render_field_label( $field ) {
 
 	// Get label.
-	$label = esc_html( acf_get_field_label( $field ) );
+	$label = acf_get_field_label( $field );
 
 	// Output label.
 	if ( $label ) {
@@ -848,10 +848,10 @@ function acf_render_field_label( $field ) {
 function acf_get_field_label( $field, $context = '' ) {
 
 	// Get label.
-	$label = $field['label'];
+	$label = esc_html( $field['label'] );
 
 	// Display empty text when editing field.
-	if ( $context == 'admin' && $label === '' ) {
+	if ( 'admin' === $context && '' === $label ) {
 		$label = __( '(no label)', 'secure-custom-fields' );
 	}
 

--- a/includes/acf-field-functions.php
+++ b/includes/acf-field-functions.php
@@ -825,7 +825,7 @@ acf_add_action_variations( 'acf/render_field', array( 'type', 'name', 'key' ), 0
 function acf_render_field_label( $field ) {
 
 	// Get label.
-	$label = acf_get_field_label( $field );
+	$label = esc_html( acf_get_field_label( $field ) );
 
 	// Output label.
 	if ( $label ) {

--- a/includes/admin/admin-internal-post-type-list.php
+++ b/includes/admin/admin-internal-post-type-list.php
@@ -546,8 +546,8 @@ if ( ! class_exists( 'ACF_Admin_Internal_Post_Type_List' ) ) :
 				foreach ( $activated as $activated_id ) {
 					$links[] = sprintf(
 						'<a href="%1$s">%2$s</a>',
-						get_edit_post_link( $activated_id ),
-						get_the_title( $activated_id )
+						esc_url( get_edit_post_link( $activated_id ) ),
+						esc_html( get_the_title( $activated_id ) )
 					);
 				}
 
@@ -616,8 +616,8 @@ if ( ! class_exists( 'ACF_Admin_Internal_Post_Type_List' ) ) :
 				foreach ( $deactivated as $deactivated_id ) {
 					$links[] = sprintf(
 						'<a href="%1$s">%2$s</a>',
-						get_edit_post_link( $deactivated_id ),
-						get_the_title( $deactivated_id )
+						esc_url( get_edit_post_link( $deactivated_id ) ),
+						esc_html( get_the_title( $deactivated_id ) )
 					);
 				}
 
@@ -685,8 +685,8 @@ if ( ! class_exists( 'ACF_Admin_Internal_Post_Type_List' ) ) :
 				foreach ( $duplicated as $duplicated_id ) {
 					$links[] = sprintf(
 						'<a href="%1$s">%2$s</a>',
-						get_edit_post_link( $duplicated_id ),
-						get_the_title( $duplicated_id )
+						esc_url( get_edit_post_link( $duplicated_id ) ),
+						esc_html( get_the_title( $duplicated_id ) )
 					);
 				}
 
@@ -752,8 +752,8 @@ if ( ! class_exists( 'ACF_Admin_Internal_Post_Type_List' ) ) :
 				foreach ( $synced as $synced_id ) {
 					$links[] = sprintf(
 						'<a href="%1$s">%2$s</a>',
-						get_edit_post_link( $synced_id ),
-						get_the_title( $synced_id )
+						esc_url( get_edit_post_link( $synced_id ) ),
+						esc_html( get_the_title( $synced_id ) )
 					);
 				}
 

--- a/includes/admin/admin.php
+++ b/includes/admin/admin.php
@@ -235,7 +235,6 @@ if ( ! class_exists( 'ACF_Admin' ) ) :
 					/* translators: %1$s - Plugin name, %2$s URL to documentation */
 					__( '%1$s We have detected that this website is configured to use v3 of the Select2 jQuery library, which has been deprecated in favor of v4 and will be removed in a future version of SCF. <a href="%2$s" target="_blank">Learn more</a>.', 'secure-custom-fields' ),
 					$acf_plugin_name,
-					acf_add_url_utm_tags( 'https://www.advancedcustomfields.com/resources/select2-v3-deprecation/', 'docs', 'select2-deprecation-notice' ),
 				);
 
 				acf_add_admin_notice( $text, 'warning', false );

--- a/includes/admin/admin.php
+++ b/includes/admin/admin.php
@@ -20,6 +20,7 @@ if ( ! class_exists( 'ACF_Admin' ) ) :
 			add_filter( 'admin_body_class', array( $this, 'admin_body_class' ) );
 			add_action( 'current_screen', array( $this, 'current_screen' ) );
 			add_action( 'admin_notices', array( $this, 'maybe_show_escaped_html_notice' ) );
+			add_action( 'admin_notices', array( $this, 'maybe_show_select2_v3_deprecation_notice' ) );
 			add_action( 'admin_init', array( $this, 'dismiss_escaped_html_notice' ) );
 			add_action( 'admin_init', array( $this, 'clear_escaped_html_log' ) );
 			add_filter( 'parent_file', array( $this, 'ensure_menu_selection' ) );
@@ -217,6 +218,33 @@ if ( ! class_exists( 'ACF_Admin' ) ) :
 
 			wp_safe_redirect( remove_query_arg( 'acf-clear-esc-html-log' ) );
 			exit;
+		}
+
+		/**
+		 * Notifies the user that Select2 v3 has been deprecated and will be removed.
+		 *
+		 * @since ACF 6.4.3
+		 *
+		 * @return void
+		 */
+		public function maybe_show_select2_v3_deprecation_notice() {
+			// Only show to editors and above.
+			if ( ! current_user_can( 'edit_others_posts' ) ) {
+				return;
+			}
+
+			if ( 3 === acf_get_setting( 'select2_version' ) ) {
+				$acf_plugin_name = '<strong>SCF &mdash;</strong>';
+
+				$text = sprintf(
+					/* translators: %1$s - Plugin name, %2$s URL to documentation */
+					__( '%1$s We have detected that this website is configured to use v3 of the Select2 jQuery library, which has been deprecated in favor of v4 and will be removed in a future version of SCF. <a href="%2$s" target="_blank">Learn more</a>.', 'secure-custom-fields' ),
+					$acf_plugin_name,
+					acf_add_url_utm_tags( 'https://www.advancedcustomfields.com/resources/select2-v3-deprecation/', 'docs', 'select2-deprecation-notice' ),
+				);
+
+				acf_add_admin_notice( $text, 'warning', false );
+			}
 		}
 
 		/**

--- a/includes/admin/admin.php
+++ b/includes/admin/admin.php
@@ -79,13 +79,8 @@ if ( ! class_exists( 'ACF_Admin' ) ) :
 		public function admin_body_class( $classes ) {
 			global $wp_version;
 
-			// Determine body class version.
-			$wp_minor_version = floatval( $wp_version );
-			if ( $wp_minor_version >= 5.3 ) {
-				$classes .= ' acf-admin-5-3';
-			} else {
-				$classes .= ' acf-admin-3-8';
-			}
+			// Add body class.
+			$classes .= ' acf-admin-5-3';
 
 			// Add browser for specific CSS.
 			$classes .= ' acf-browser-' . esc_attr( acf_get_browser() );

--- a/includes/admin/class-acf-admin-options-page.php
+++ b/includes/admin/class-acf-admin-options-page.php
@@ -195,7 +195,7 @@ if ( ! class_exists( 'acf_admin_options_page' ) ) :
 					$priority = apply_filters( 'acf/input/meta_box_priority', $priority, $field_group );
 
 					// add meta box
-					add_meta_box( $id, acf_esc_html( $title ), array( $this, 'postbox_acf' ), 'acf_options_page', $context, $priority, $args );
+					add_meta_box( $id, esc_html( $title ), array( $this, 'postbox_acf' ), 'acf_options_page', $context, $priority, $args );
 				}
 				// foreach
 			}

--- a/includes/admin/tools/class-acf-admin-tool-import.php
+++ b/includes/admin/tools/class-acf-admin-tool-import.php
@@ -208,7 +208,7 @@ if ( ! class_exists( 'ACF_Admin_Tool_Import' ) ) :
 			// Add links to text.
 			$links = array();
 			foreach ( $ids as $id ) {
-				$links[] = '<a href="' . get_edit_post_link( $id ) . '">' . get_the_title( $id ) . '</a>';
+				$links[] = '<a href="' . esc_url( get_edit_post_link( $id ) ) . '">' . esc_html( get_the_title( $id ) ) . '</a>';
 			}
 			$text .= ' ' . implode( ', ', $links );
 
@@ -277,7 +277,7 @@ if ( ! class_exists( 'ACF_Admin_Tool_Import' ) ) :
 				// Add links to text.
 				$links = array();
 				foreach ( $imported as $id ) {
-					$links[] = '<a href="' . get_edit_post_link( $id ) . '">' . get_the_title( $id ) . '</a>';
+					$links[] = '<a href="' . esc_url( get_edit_post_link( $id ) ) . '">' . esc_html( get_the_title( $id ) ) . '</a>';
 				}
 
 				$text .= ' ' . implode( ', ', $links );

--- a/includes/ajax/class-acf-ajax-check-screen.php
+++ b/includes/ajax/class-acf-ajax-check-screen.php
@@ -51,14 +51,14 @@ if ( ! class_exists( 'ACF_Ajax_Check_Screen' ) ) :
 
 					// vars
 					$item = array(
-						'id'       => 'acf-' . $field_group['key'],
-						'key'      => $field_group['key'],
-						'title'    => $field_group['title'],
-						'position' => $field_group['position'],
+						'id'       => esc_attr( 'acf-' . $field_group['key'] ),
+						'key'      => esc_attr( $field_group['key'] ),
+						'title'    => esc_html( $field_group['title'] ),
+						'position' => esc_attr( $field_group['position'] ),
 						'classes'  => postbox_classes( 'acf-' . $field_group['key'], $args['screen'] ),
-						'style'    => $field_group['style'],
-						'label'    => $field_group['label_placement'],
-						'edit'     => acf_get_field_group_edit_link( $field_group['ID'] ),
+						'style'    => esc_attr( $field_group['style'] ),
+						'label'    => esc_attr( $field_group['label_placement'] ),
+						'edit'     => esc_url( acf_get_field_group_edit_link( $field_group['ID'] ) ),
 						'html'     => '',
 					);
 
@@ -67,6 +67,8 @@ if ( ! class_exists( 'ACF_Ajax_Check_Screen' ) ) :
 					if ( is_array( $hidden_metaboxes ) && in_array( $item['id'], $hidden_metaboxes ) ) {
 						$item['classes'] = trim( $item['classes'] . ' hide-if-js' );
 					}
+
+					$item['classes'] = esc_attr( $item['classes'] );
 
 					// append html if doesnt already exist on page
 					if ( ! in_array( $field_group['key'], $args['exists'] ) ) {

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -519,6 +519,8 @@ if ( ! class_exists( 'ACF_Assets' ) ) :
 						// Unload
 						'The changes you made will be lost if you navigate away from this page' => __( 'The changes you made will be lost if you navigate away from this page', 'secure-custom-fields' ),
 
+						// Metaboxes
+						'Toggle panel'                => __( 'Toggle panel', 'secure-custom-fields' ),
 						// Validation
 						'Validation successful'       => __( 'Validation successful', 'secure-custom-fields' ),
 						'Validation failed'           => __( 'Validation failed', 'secure-custom-fields' ),

--- a/includes/fields/class-acf-field-page_link.php
+++ b/includes/fields/class-acf-field-page_link.php
@@ -54,7 +54,7 @@ if ( ! class_exists( 'acf_field_page_link' ) ) :
 				return $choices;
 			}
 			if ( ! empty( $rule_value ) ) {
-				$post_title = get_the_title( $rule_value );
+				$post_title = esc_html( get_the_title( $rule_value ) );
 				$choices    = array( $rule_value => $post_title );
 			}
 			return $choices;

--- a/includes/fields/class-acf-field-post_object.php
+++ b/includes/fields/class-acf-field-post_object.php
@@ -50,7 +50,7 @@ if ( ! class_exists( 'acf_field_post_object' ) ) :
 				return $choices;
 			}
 			if ( ! empty( $rule_value ) ) {
-				$post_title = get_the_title( $rule_value );
+				$post_title = esc_html( get_the_title( $rule_value ) );
 				$choices    = array( $rule_value => $post_title );
 			}
 			return $choices;

--- a/includes/fields/class-acf-field-relationship.php
+++ b/includes/fields/class-acf-field-relationship.php
@@ -53,7 +53,7 @@ if ( ! class_exists( 'acf_field_relationship' ) ) :
 				return $choices;
 			}
 			if ( ! empty( $rule_value ) ) {
-				$post_title = get_the_title( $rule_value );
+				$post_title = esc_html( get_the_title( $rule_value ) );
 				$choices    = array( $rule_value => $post_title );
 			}
 			return $choices;
@@ -319,7 +319,7 @@ if ( ! class_exists( 'acf_field_relationship' ) ) :
 			}
 
 			// vars
-			$title = acf_get_post_title( $post, $is_search );
+			$title = esc_html( acf_get_post_title( $post, $is_search ) );
 
 			// featured_image
 			if ( acf_in_array( 'featured_image', $field['elements'] ) ) {

--- a/includes/forms/WC_Order.php
+++ b/includes/forms/WC_Order.php
@@ -104,7 +104,7 @@ class WC_Order {
 				// Add the meta box.
 				add_meta_box(
 					$id,
-					acf_esc_html( $title ),
+					esc_html( $title ),
 					array( $this, 'render_meta_box' ),
 					$screen,
 					$context,

--- a/includes/forms/form-post.php
+++ b/includes/forms/form-post.php
@@ -112,10 +112,10 @@ if ( ! class_exists( 'ACF_Form_Post' ) ) :
 				foreach ( $field_groups as $field_group ) {
 
 					// vars
-					$id       = "acf-{$field_group['key']}";          // acf-group_123
-					$title    = $field_group['title'];             // Group 1
-					$context  = $field_group['position'];        // normal, side, acf_after_title
-					$priority = 'high';                         // high, core, default, low
+					$id       = esc_attr( "acf-{$field_group['key']}" );
+					$title    = esc_html( $field_group['title'] );
+					$context  = esc_attr( $field_group['position'] );
+					$priority = 'high';
 
 					// Reduce priority for sidebar metaboxes for best position.
 					if ( 'side' === $context ) {
@@ -136,14 +136,14 @@ if ( ! class_exists( 'ACF_Form_Post' ) ) :
 					// Localize data
 					$postboxes[] = array(
 						'id'    => $id,
-						'key'   => $field_group['key'],
-						'style' => $field_group['style'],
-						'label' => $field_group['label_placement'],
-						'edit'  => acf_get_field_group_edit_link( $field_group['ID'] ),
+						'key'   => esc_attr( $field_group['key'] ),
+						'style' => esc_attr( $field_group['style'] ),
+						'label' => esc_attr( $field_group['label_placement'] ),
+						'edit'  => esc_url( acf_get_field_group_edit_link( $field_group['ID'] ) ),
 					);
 
 					// Add the meta box.
-					add_meta_box( $id, acf_esc_html( $title ), array( $this, 'render_meta_box' ), $post_type, $context, $priority, array( 'field_group' => $field_group ) );
+					add_meta_box( $id, $title, array( $this, 'render_meta_box' ), $post_type, $context, $priority, array( 'field_group' => $field_group ) );
 				}
 
 				// Set style from first field group.

--- a/includes/third-party.php
+++ b/includes/third-party.php
@@ -101,7 +101,7 @@ if ( ! class_exists( 'acf_third_party' ) ) :
 					$title = 'ACF: ' . $field_group['title'];
 
 					// add meta box
-					add_meta_box( $id, acf_esc_html( $title ), '__return_true', $post_type );
+					add_meta_box( $id, esc_html( $title ), '__return_true', $post_type );
 				}
 			}
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@wordpress/icons": "^10.26.0",
+        "dompurify": "^3.2.6",
         "md5": "^2.3.0"
       },
       "devDependencies": {
@@ -4134,6 +4135,13 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/uglify-js": {
       "version": "3.17.5",
@@ -9166,6 +9174,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@wordpress/icons": "^10.26.0",
+    "dompurify": "^3.2.6",
     "md5": "^2.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Apply all changes done in 6.4.3, including:

– Unsafe HTML in field group labels is now correctly escaped for conditionally loaded field groups, resolving a JS execution vulnerability in the classic editor
– HTML is now escaped from field group labels when output in the ACF admin
– Bidirectional and Conditional Logic Select2 elements no longer render HTML in field labels or post titles
– The acf.escHtml function now uses the third party DOMPurify library to ensure all unsafe HTML is removed. A new esc_html_dompurify_config JS filter can be used to modify the default behaviour
– Post titles are now correctly escaped whenever they are output by ACF code. Thanks to Shogo Kumamaru of LAC Co., Ltd. for the responsible disclosure
– An admin notice is now displayed when version 3 of the Select2 library is used, as it has now been deprecated in favor of version 4

