### PR TITLE
Get the `formatted_value` from the original field value

### DIFF
--- a/includes/rest-api/class-acf-rest-api.php
+++ b/includes/rest-api/class-acf-rest-api.php
@@ -232,10 +232,10 @@ class ACF_Rest_Api {
 
 				// Format the field value according to the request params.
 				$format = $request->get_param( 'acf_format' ) ?: acf_get_setting( 'rest_api_format' );
-				$value  = acf_format_value_for_rest( $value, $post_id, $field, $format );
+				$rest_value  = acf_format_value_for_rest( $value, $post_id, $field, $format );
 
 				// We keep this one for backward compatibility with existing code that expects the field value to be.
-				$fields[ $field['name'] ]             = $value;
+				$fields[ $field['name'] ]             = $rest_value;
 				$fields[ $field['name'] . '_source' ] = array(
 					'label'           => $field['label'],
 					'type'            => $field['type'],

--- a/includes/rest-api/class-acf-rest-api.php
+++ b/includes/rest-api/class-acf-rest-api.php
@@ -231,8 +231,8 @@ class ACF_Rest_Api {
 				}
 
 				// Format the field value according to the request params.
-				$format = $request->get_param( 'acf_format' ) ?: acf_get_setting( 'rest_api_format' );
-				$rest_value  = acf_format_value_for_rest( $value, $post_id, $field, $format );
+				$format     = $request->get_param( 'acf_format' ) ?: acf_get_setting( 'rest_api_format' );
+				$rest_value = acf_format_value_for_rest( $value, $post_id, $field, $format );
 
 				// We keep this one for backward compatibility with existing code that expects the field value to be.
 				$fields[ $field['name'] ]             = $rest_value;

--- a/includes/rest-api/class-acf-rest-api.php
+++ b/includes/rest-api/class-acf-rest-api.php
@@ -231,7 +231,7 @@ class ACF_Rest_Api {
 				}
 
 				// Format the field value according to the request params.
-				$format     = $request->get_param( 'acf_format' ) ?: acf_get_setting( 'rest_api_format' );
+				$format     = $request->get_param( 'acf_format' ) ? $request->get_param( 'acf_format' ) : acf_get_setting( 'rest_api_format' );
 				$rest_value = acf_format_value_for_rest( $value, $post_id, $field, $format );
 
 				// We keep this one for backward compatibility with existing code that expects the field value to be.


### PR DESCRIPTION
The `formatted_value` property of the $field['name'] . '_source' should come from the original value, not the REST value. Other plugins might change the REST value using the filter `acf/rest/format_value_for_rest`, which can cause the `formatted_value` to be incorrect.