### PR TITLE
Documentation: Regenerate manifest

### DIFF
--- a/docs/bin/manifest.json
+++ b/docs/bin/manifest.json
@@ -244,10 +244,30 @@
         "parent": "features",
         "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/scf-api.md"
     },
+    "tutorials/first-custom-field": {
+        "slug": "first-custom-field",
+        "parent": "tutorials",
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/tutorials/first-custom-field.md"
+    },
+    "tutorials/first-options-page": {
+        "slug": "first-options-page",
+        "parent": "tutorials",
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/tutorials/first-options-page.md"
+    },
     "tutorials/first-post-type": {
         "slug": "first-post-type",
         "parent": "tutorials",
         "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/tutorials/first-post-type.md"
+    },
+    "tutorials/first-taxonomy": {
+        "slug": "first-taxonomy",
+        "parent": "tutorials",
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/tutorials/first-taxonomy.md"
+    },
+    "welcome/how-content-works": {
+        "slug": "how-content-works",
+        "parent": "welcome",
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/welcome/how-content-works.md"
     },
     "welcome/installation": {
         "slug": "installation",


### PR DESCRIPTION
Closes #218 

A few documentation pages were not being deployed because they were missing from the generated `manifest.json`. This PR regenerates the manifest to include all documentation pages, fixing the 404 errors.

The missing pages were:
- tutorials/first-custom-field
- tutorials/first-options-page
- tutorials/first-taxonomy
 - welcome/how-content-works