### PR TITLE
Simplify PHPStan settings to eliminate environment-specific errors

### DIFF
--- a/acf.php
+++ b/acf.php
@@ -13,7 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( is_admin() ) {
-	/** @phpstan-ignore-next-line */ // phpcs:ignore
 	include_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 	// Network activations first since is_plugin_active will return true for network activated plugins, whereas this won't for single.

--- a/bin/baseline.neon
+++ b/bin/baseline.neon
@@ -90,29 +90,6 @@ parameters:
 			count: 1
 			path: ../includes/admin/views/upgrade/notice.php
 
-		-
-			message: '#^Path in include_once\(\) "\./wp\-admin/includes/plugin\.php" is not a file or it does not exist\.$#'
-			identifier: includeOnce.fileNotFound
-			count: 1
-			path: ../includes/api/api-helpers.php
-
-		-
-			message: '#^Path in require_once\(\) "\.//wp\-admin/includes/file\.php" is not a file or it does not exist\.$#'
-			identifier: requireOnce.fileNotFound
-			count: 1
-			path: ../includes/api/api-helpers.php
-
-		-
-			message: '#^Path in require_once\(\) "\.//wp\-admin/includes/image\.php" is not a file or it does not exist\.$#'
-			identifier: requireOnce.fileNotFound
-			count: 1
-			path: ../includes/api/api-helpers.php
-
-		-
-			message: '#^Path in require_once\(\) "\.//wp\-admin/includes/media\.php" is not a file or it does not exist\.$#'
-			identifier: requireOnce.fileNotFound
-			count: 1
-			path: ../includes/api/api-helpers.php
 
 		-
 			message: '#^Offset ''thumb'' on array\{alt\: string, author\: string, authorName\: string, caption\: string, compat\: array, context\: string, date\: int, dateFormatted\: string, \.\.\.\}\|null in isset\(\) does not exist\.$#'
@@ -120,11 +97,6 @@ parameters:
 			count: 1
 			path: ../includes/fields/class-acf-field-gallery.php
 
-		-
-			message: '#^Path in require\(\) "\./wp\-admin/includes/media\.php" is not a file or it does not exist\.$#'
-			identifier: require.fileNotFound
-			count: 1
-			path: ../includes/fields/class-acf-field-wysiwyg.php
 
 		-
 			message: '#^Undefined variable\: \$method$#'

--- a/includes/api/api-helpers.php
+++ b/includes/api/api-helpers.php
@@ -2879,9 +2879,9 @@ function acf_get_valid_terms( $terms = false, $taxonomy = 'category' ) {
  *
  * @since   ACF 5.2.3
  *
- * @param   $attachment (array) attachment data. Changes based on context
- * @param   $field (array) field settings containing restrictions
- * @param   context (string)                                     $file is different when uploading / preparing
+ * @param   array  $attachment attachment data. Changes based on context.
+ * @param   array  $field field settings containing restrictions.
+ * @param   string $context context is different when uploading / preparing.
  * @return  $errors (array)
  */
 function acf_validate_attachment( $attachment, $field, $context = 'prepare' ) {
@@ -3277,7 +3277,7 @@ function acf_is_ajax( $action = '' ) {
 	$is_ajax = false;
 
 	// check if is doing ajax
-	if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+	if ( wp_doing_ajax() ) {
 		$is_ajax = true;
 	}
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,9 @@ includes:
 	- bin/baseline.neon
 parameters:
 	level: 1
+	reportUnmatchedIgnoredErrors: false
+	ignoreErrors:
+		- '#^Path in (include_once|require_once|require)\(\) ".*wp-admin/includes/.*" is not a file#'
 	paths:
 		- .
 	excludePaths:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,5 +13,6 @@ parameters:
 		- wordpress (?)
 		- includes/forms/WC_Order.php
 	bootstrapFiles:
+		- vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
 		- vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php
 		- bin/phpstan-bootstrap.php

--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -853,7 +853,6 @@ if ( ! function_exists( 'scf_deactivate_other_instances' ) ) {
 		} elseif ( is_plugin_active( 'advanced-custom-fields/acf.php' ) ) {
 			// Check if the plugin to deactivate is 'advanced-custom-fields/acf.php' but the title is 'Secure Custom Fields'.
 			if ( ! function_exists( 'get_plugin_data' ) ) {
-				/** @phpstan-ignore-next-line */ // phpcs:ignore
 				require_once ABSPATH . 'wp-admin/includes/plugin.php';
 			}
 			$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin_to_deactivate );


### PR DESCRIPTION
## What
 Eliminate environment-specific PHPStan failures between local developmentand CI and improve static analysis configuration.

  ## How
  - Configuring `reportUnmatchedIgnoredErrors: false ` so that CI errors we are ignoring are not reported as errors when running locally.
  - Cleaning up outdated ignore rules and documentation issues, both in the baseline and in`@phpstan-ignore-next-line` comments, replacing all with a single ignore pattern.
  - Replacing `DOING_AJAX` constant with `wp_doing_ajax()` function call
  - Add WordPress stubs to PHPStan configuration for better type checking
  - Fix PHPDoc parameter formatting to meet coding standards

  ## Testing Instructions
  1. Run `composer test:phpstan` to verify no PHPStan errors