### PR TITLE
Post Type Schemas: add internal fields and use in appropriate abilities 

### DIFF
--- a/includes/abilities/class-scf-post-type-abilities.php
+++ b/includes/abilities/class-scf-post-type-abilities.php
@@ -88,25 +88,29 @@ class SCF_Post_Type_Abilities {
 	}
 
 	/**
-	 * Get the post type schema extended with internal fields for GET/LIST operations.
+	 * Get the internal fields schema (ID, _valid, local).
+	 *
+	 * @since 6.6.0
+	 * @return array The internal fields schema.
+	 */
+	private function get_internal_fields_schema() {
+		$validator = new SCF_JSON_Schema_Validator();
+		$schema    = $validator->load_schema( 'internal-fields' );
+
+		return json_decode( wp_json_encode( $schema->definitions->internalFields ), true );
+	}
+
+	/**
+	 * Get the post type schema extended with internal fields for GET/LIST/CREATE/UPDATE/IMPORT/DUPLICATE operations.
 	 *
 	 * @since 6.6.0
 	 *
 	 * @return array The extended post type schema with internal fields.
 	 */
 	private function get_post_type_with_internal_fields_schema() {
-		$schema = $this->get_post_type_schema();
-
-		// Add internal WordPress/SCF fields that appear in GET/LIST but not EXPORT.
-		$schema['properties']['ID'] = array(
-			'type'        => 'integer',
-			'description' => __( 'WordPress post ID (internal field, present in GET/LIST operations only).', 'secure-custom-fields' ),
-		);
-
-		$schema['properties']['_valid'] = array(
-			'type'        => 'boolean',
-			'description' => __( 'SCF validation cache flag (internal field, present in GET/LIST operations only).', 'secure-custom-fields' ),
-		);
+		$schema               = $this->get_post_type_schema();
+		$internal_fields      = $this->get_internal_fields_schema();
+		$schema['properties'] = array_merge( $schema['properties'], $internal_fields['properties'] );
 
 		return $schema;
 	}
@@ -259,7 +263,7 @@ class SCF_Post_Type_Abilities {
 				),
 				'permission_callback' => 'scf_current_user_has_capability',
 				'input_schema'        => $input_schema,
-				'output_schema'       => $this->get_post_type_schema(),
+				'output_schema'       => $this->get_post_type_with_internal_fields_schema(),
 			)
 		);
 	}
@@ -290,7 +294,7 @@ class SCF_Post_Type_Abilities {
 				),
 				'permission_callback' => 'scf_current_user_has_capability',
 				'input_schema'        => $this->get_post_type_schema(),
-				'output_schema'       => $this->get_post_type_schema(),
+				'output_schema'       => $this->get_post_type_with_internal_fields_schema(),
 			)
 		);
 	}
@@ -371,7 +375,7 @@ class SCF_Post_Type_Abilities {
 					),
 					'required'   => array( 'identifier' ),
 				),
-				'output_schema'       => $this->get_post_type_schema(),
+				'output_schema'       => $this->get_post_type_with_internal_fields_schema(),
 			)
 		);
 	}
@@ -419,8 +423,6 @@ class SCF_Post_Type_Abilities {
 	 * @since 6.6.0
 	 */
 	private function register_import_post_type_ability() {
-		$post_type_schema = $this->get_post_type_schema();
-
 		wp_register_ability(
 			'scf/import-post-type',
 			array(
@@ -440,8 +442,8 @@ class SCF_Post_Type_Abilities {
 					),
 				),
 				'permission_callback' => 'scf_current_user_has_capability',
-				'input_schema'        => $this->get_post_type_schema(),
-				'output_schema'       => $this->get_post_type_schema(),
+				'input_schema'        => $this->get_post_type_with_internal_fields_schema(),
+				'output_schema'       => $this->get_post_type_with_internal_fields_schema(),
 			)
 		);
 	}

--- a/schemas/internal-fields.schema.json
+++ b/schemas/internal-fields.schema.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://raw.githubusercontent.com/WordPress/secure-custom-fields/trunk/schemas/internal-fields.schema.json",
+	"title": "SCF Internal Fields",
+	"description": "Internal fields present in SCF entities (post types, taxonomies, field groups, options pages). These fields are managed by the system and appear in GET/LIST/CREATE/UPDATE/IMPORT/DUPLICATE outputs, but are stripped during EXPORT.",
+	"definitions": {
+		"internalFields": {
+			"type": "object",
+			"description": "Internal system-managed fields that appear in entity responses",
+			"properties": {
+				"ID": {
+					"type": "integer",
+					"minimum": 1,
+					"description": "WordPress post ID. Present in GET/LIST/CREATE/UPDATE/IMPORT/DUPLICATE outputs. Optional in IMPORT input - if provided, updates existing entity; if omitted, creates new entity."
+				},
+				"_valid": {
+					"type": "boolean",
+					"description": "Validation cache flag . Indicates whether the entity passed validation."
+				},
+				"local": {
+					"type": "string",
+					"enum": ["json"],
+					"description": "Source indicator. Present only if entity is locally-defined (e.g., from local JSON files). Stripped during export."
+				}
+			},
+			"additionalProperties": false
+		}
+	}
+}


### PR DESCRIPTION
  ## What
  Adds a schema for internal fields that SCF uses for its entities and applies it to Post Type abilities's output schemas where required.

  ## Why
  - Output schemas for CREATE/UPDATE/DUPLICATE/IMPORT were missing internal fields (ID, _valid, local) that are actually returned.
  - It applies to Post Types, but it will be reused for other entities
  - Importing also supports the ID to overwrite an existing Post Type

  ## Testing Instructions
  1. Run `composer test:php` to verify schema validation tests pass
  2. Run post type abilities and verify they now don't return an error