### PR TITLE
Add the `.serena` folder to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,8 @@ assets/build/**/*.php
 # Claude settings
 **/.claude/settings.local.json
 
+# Serena MCP
+/.serena/
+
 # Release folder
 release/


### PR DESCRIPTION
Adds the [Serena Agent Toolkit](https://github.com/oraios/serena) file to the ignore list.

Ideally, the `.serena` folder should be committed as an evolving documentation (similar to the `AGENTS.md` file), but since I'm the only one starting to test it and we are not ready to commit to Serena (no pun intended), it's best to ignore the folder.