### PR TITLE
GitHub Actions: Warn if docs manifest possibly outdated

### DIFF
--- a/.github/workflows/docs-manifest.yml
+++ b/.github/workflows/docs-manifest.yml
@@ -1,0 +1,39 @@
+name: Keep docs manifest up to date
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - trunk
+    paths:
+      - docs/**/*.md
+
+jobs:
+  check-docs-manifest:
+    name: Check docs manifest for staleness
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.4'
+        tools: composer:v2
+
+    - name: Install dependencies
+      run: composer install
+
+    - name: Regenerate manifest
+      run: composer run docs:manifest
+
+    - name: Check whether manifest has been updated
+      env:
+        MANIFEST_PATH: docs/bin/manifest.json
+      run: |
+        if ! git diff --quiet -- "$MANIFEST_PATH"; then
+          echo "There are documentation changes in this branch that require that the docs manifest be regenerated."
+          echo
+          echo "Please run 'composer run docs:manifest' and commit $MANIFEST_PATH"
+          exit 1
+        fi

--- a/.github/workflows/docs-manifest.yml
+++ b/.github/workflows/docs-manifest.yml
@@ -1,11 +1,10 @@
 name: Keep docs manifest up to date
 on:
   pull_request:
-    types: [opened, synchronize]
     branches:
       - trunk
     paths:
-      - docs/**/*.md
+      - docs/**
 
 jobs:
   check-docs-manifest:

--- a/.github/workflows/docs-manifest.yml
+++ b/.github/workflows/docs-manifest.yml
@@ -20,9 +20,6 @@ jobs:
         php-version: '8.4'
         tools: composer:v2
 
-    - name: Install dependencies
-      run: composer install
-
     - name: Regenerate manifest
       run: composer run docs:manifest
 


### PR DESCRIPTION
Feel free to close if useless!

Noticing the problem in #220, I drew inspiration from [one of Gutenberg's workflows](https://github.com/WordPress/gutenberg/blob/trunk/.github/workflows/check-components-changelog.yml) to add a workflow that will fail if `docs/bin/manifest.json` needs to be regenerated.

It does this by running the `docs:manifest` composer script and verifying that the manifest has not changed. If it has, something is wrong with the branch, and the developer is told to manually generate the docs. I prefered the manual approach for several reasons, one of which is to avoid "magic" and instead teaching/reminding the developer of processes.

I attempted to fit into the style and practices of this repo's other workflows, but I may be wildly wrong. I'll also let you folks label this as you see fit. :)