### PR TITLE
Continuous Integration: Add Codecov settings

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,36 @@
+# Codecov Configuration
+# Reference: https://docs.codecov.com/docs/codecovyml-reference
+
+coverage:
+    status:
+        project:
+            default:
+                target: auto
+                threshold: 5%
+                if_ci_failed: ignore
+
+        patch:
+            default:
+                target: auto
+                threshold: 5%
+                if_ci_failed: ignore
+
+        changes:
+            default:
+                target: auto
+                threshold: 5%
+                if_ci_failed: ignore
+
+ignore:
+    - '*.min.css'
+    - '*.min.js'
+    - '.wp-env'
+    - 'build'
+    - 'dist'
+    - 'docs'
+    - 'node_modules'
+    - 'tests'
+    - 'vendor'
+
+comment:
+    layout: 'condensed_header, condensed_files, condensed_footer'

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -31,6 +31,3 @@ ignore:
     - 'node_modules'
     - 'tests'
     - 'vendor'
-
-comment:
-    layout: 'condensed_header, condensed_files, condensed_footer'


### PR DESCRIPTION
## What
Adds Codecov settings.

## Why
To tune the code coverage part of CI and adapt it to SCF. In particular, the current coverage is still low and it's likely that backport PRs will lower the coverage in a high proportion, so we shouldn't block those PRs, code coverage should be informative.