### PR TITLE
JSON Schemas: Add missing internal `not_registered` property

### DIFF
--- a/schemas/internal-fields.schema.json
+++ b/schemas/internal-fields.schema.json
@@ -15,12 +15,16 @@
 				},
 				"_valid": {
 					"type": "boolean",
-					"description": "Validation cache flag . Indicates whether the entity passed validation."
+					"description": "Validation cache flag. Indicates whether the entity passed validation."
 				},
 				"local": {
 					"type": "string",
 					"enum": ["json"],
 					"description": "Source indicator. Present only if entity is locally-defined (e.g., from local JSON files). Stripped during export."
+				},
+				"not_registered": {
+					"type": "boolean",
+					"description": "Flag indicating that this post entity could not be registered because another one with the same key already exists. Present only when registration was skipped."
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
## What
Adds a `not_registerd` property to the internal entity subschema.

## Why
When listing a SCF entity through the abilities that is not actually registered (e.g., due to a duplicated slug), the entity is returned with the `not_registered` property, and the schema validation fails.

## Steps to reproduce
1. Duplicate a post type so that it has the same slug and a different SCF key, so that the copy will not be registered
2. Use the Ability to list post types; it will fail on trunk but work on this branch