### PR TITLE
Blocks V3: Sidebar form disappeard when opened the modal.

### DIFF
--- a/assets/src/js/pro/blocks-v3/components/block-edit.js
+++ b/assets/src/js/pro/blocks-v3/components/block-edit.js
@@ -576,7 +576,6 @@ function BlockEditInner( props ) {
 
 			{ /* Render form via portal when container is available */ }
 			{ portalTarget &&
-				currentFormContainer &&
 				createPortal(
 					<>
 						<BlockForm


### PR DESCRIPTION
## What 

The sidebar fields were dissapearing when opening and closing the Expanded Editor.

Before:

https://github.com/user-attachments/assets/34c15613-ded8-45e4-968c-04dd8c2e2c13

After:
https://github.com/user-attachments/assets/f78de052-627d-4727-981e-ca915b65b43a
