### PR TITLE
Playwright: use `wp-env.json` settings for its base URL, if available

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,6 +24,10 @@ if ( ! process.env.WP_BASE_URL ) {
 const config = defineConfig( {
 	...baseConfig,
 	testDir: './tests/e2e',
+	use: {
+		...baseConfig.use,
+		baseURL: process.env.WP_BASE_URL,
+	},
 	webServer: undefined, // wp-env is already running, no need to start it again
 } );
 export default config;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,29 @@
 import { defineConfig } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
 
 const baseConfig = require( '@wordpress/scripts/config/playwright.config.js' );
+
+// Read port and host from wp-env config if not already set via environment variable
+if ( ! process.env.WP_BASE_URL ) {
+	const wpEnvConfig = JSON.parse(
+		fs.readFileSync( path.resolve( process.cwd(), '.wp-env.json' ), 'utf8' )
+	);
+
+	const baseUrl = new URL( baseConfig.use.baseURL );
+	const testsPort =
+		process.env.WP_ENV_TESTS_PORT || wpEnvConfig.testsPort || baseUrl.port;
+	const testsHost =
+		process.env.WP_ENV_TESTS_HOST ||
+		wpEnvConfig.testsHost ||
+		baseUrl.hostname;
+
+	process.env.WP_BASE_URL = `http://${ testsHost }:${ testsPort }`;
+}
+
 const config = defineConfig( {
-  ...baseConfig,
-  testDir: './tests/e2e',
+	...baseConfig,
+	testDir: './tests/e2e',
+	webServer: undefined, // wp-env is already running, no need to start it again
 } );
 export default config;


### PR DESCRIPTION
## What
Configure Playwright to read `wp-env` port and host from `.wp-env.json` or environment variables.

## Why
- Playwright was hardcoded to connect to port 8889 instead of the actual `wp-env` test port, which causes conflicts if you are running multiple projects in parallel (like Gutenberg).
- BaseConfig's `webServer` was attempting to start wp-env automatically, which is unnecessary since GH actions already to it.

## How
- Reading port and host from environment variables (`WP_BASE_URL`, `WP_ENV_TESTS_PORT`, `WP_ENV_TESTS_HOST`) if set
- Otherwise, reading `testsPort` and `testsHost` from `.wp-env.json` file
- Overriding `use.baseURL` with the configured URL
- Setting `webServer: undefined` to disable automatic server startup

## Testing Instructions

**Using .wp-env.json**
1. Change the `testsPort` in wp-env and start it
2. Run tests: `npm run test:e2e`

**Using environment variables**
1. Set custom URL: `WP_BASE_URL=http://localhost:9999 npm run test:e2e`