### PR TITLE
Bugfix: ensure the update post type ability doesn't create new posts instead

### DIFF
--- a/includes/abilities/class-scf-post-type-abilities.php
+++ b/includes/abilities/class-scf-post-type-abilities.php
@@ -274,6 +274,11 @@ class SCF_Post_Type_Abilities {
 	 * @since 6.6.0
 	 */
 	private function register_update_post_type_ability() {
+
+		// For updates, only ID is required, everything else is optional
+		$input_schema             = $this->get_post_type_with_internal_fields_schema();
+		$input_schema['required'] = array( 'ID' );
+
 		wp_register_ability(
 			'scf/update-post-type',
 			array(
@@ -293,7 +298,7 @@ class SCF_Post_Type_Abilities {
 					),
 				),
 				'permission_callback' => 'scf_current_user_has_capability',
-				'input_schema'        => $this->get_post_type_schema(),
+				'input_schema'        => $input_schema,
 				'output_schema'       => $this->get_post_type_with_internal_fields_schema(),
 			)
 		);
@@ -513,10 +518,13 @@ class SCF_Post_Type_Abilities {
 	 * @return array|WP_Error The post type data on success, WP_Error on failure.
 	 */
 	public function update_post_type_callback( $input ) {
-		// Check if post type exists.
-		if ( ! acf_get_post_type( $input['key'] ) ) {
+		$existing_post_type = acf_get_post_type( $input['ID'] );
+		if ( ! $existing_post_type ) {
 			return new WP_Error( 'post_type_not_found', __( 'Post type not found.', 'secure-custom-fields' ) );
 		}
+
+		// Merge input with existing post type data to preserve unmodified fields.
+		$input = array_merge( $existing_post_type, $input );
 
 		$post_type = acf_update_post_type( $input );
 


### PR DESCRIPTION
## What
Fixes the update post ability to require the ID, preventing the creation of new posts instead.

## Why
Previously, the ability required either an ID, a key, or a slug. However, the internal `acf_update_post_type` creates a new post if not provided with the ID it needs to update, so updates could result in new posts.

## How
- Schema change: Modified `register_update_post_type_ability()` to use `get_post_type_with_internal_fields_schema()` with only `ID` marked as required, making all other fields optional.
- Callback enhancement: Updated `update_post_type_callback()` to merge incoming input with existing post type data, ensuring that only specified fields are updated while preserving original values for the rest.