### PR TITLE
Blocks V3: Fix flexible content not working in sidebar - modal.

### DIFF
--- a/assets/src/js/_acf-validation.js
+++ b/assets/src/js/_acf-validation.js
@@ -1212,7 +1212,7 @@
 						// If errors were found
 						if ( hasError ) {
 							// Display an error notice
-							noticesDispatch.createErrorNotice(
+							notices.createErrorNotice(
 								acf.__(
 									'An ACF Block on this page requires attention before you can save.'
 								),

--- a/assets/src/js/_acf.js
+++ b/assets/src/js/_acf.js
@@ -882,7 +882,6 @@
 	 * Convert an object with numeric string keys to a sorted array.
 	 * Example: {"0": "one", "2": "three", "1": "two"} becomes ["one", "two", "three"]
 	 *
-	 * @date    14/01/25
 	 * @since   SCF 6.6.0
 	 *
 	 * @param   object obj The object to convert

--- a/assets/src/js/_acf.js
+++ b/assets/src/js/_acf.js
@@ -860,17 +860,18 @@
 	 * Used to detect objects that should be converted to arrays (e.g., checkbox values).
 	 *
 	 * @since   SCF 6.6.0
+	 * @private
 	 *
 	 * @param   object obj The object to check
 	 * @return  boolean True if all keys are numeric strings
 	 */
-	acf.hasOnlyNumericKeys = function ( obj ) {
-		var keys = Object.keys( obj );
+	const hasOnlyNumericKeys = function ( obj ) {
+		const keys = Object.keys( obj );
 		if ( keys.length === 0 ) {
 			return false;
 		}
 
-		for ( var i = 0; i < keys.length; i++ ) {
+		for ( let i = 0; i < keys.length; i++ ) {
 			if ( ! /^\d+$/.test( keys[ i ] ) ) {
 				return false;
 			}
@@ -883,13 +884,14 @@
 	 * Example: {"0": "one", "2": "three", "1": "two"} becomes ["one", "two", "three"]
 	 *
 	 * @since   SCF 6.6.0
+	 * @private
 	 *
 	 * @param   object obj The object to convert
 	 * @return  array The sorted array
 	 */
-	acf.numericObjectToArray = function ( obj ) {
-		var arr = [];
-		var keys = Object.keys( obj )
+	const numericObjectToArray = function ( obj ) {
+		const arr = [];
+		const keys = Object.keys( obj )
 			.map( function ( k ) {
 				return parseInt( k, 10 );
 			} )
@@ -897,7 +899,7 @@
 				return a - b;
 			} );
 
-		for ( var i = 0; i < keys.length; i++ ) {
+		for ( let i = 0; i < keys.length; i++ ) {
 			arr.push( obj[ keys[ i ].toString() ] );
 		}
 		return arr;
@@ -933,23 +935,22 @@
 	};
 
 	/**
-	 * Normalize flexible content data by converting objects to arrays.
-	 * Flexible content uses unique IDs (e.g., '69171156640b5') or row-X format as keys,
-	 * but validation expects array format with numeric indices.
+	 * Normalizes flexible content data structure by converting objects to arrays.
+	 * Private helper function.
 	 *
-	 * @since   SCF 6.6.0
+	 * @since 6.6.0
 	 *
-	 * @param   object obj The object to normalize
-	 * @return  object The normalized object
+	 * @param {Object} obj The object to normalize.
+	 * @return {Object|Array} The normalized data.
 	 */
-	acf.normalizeFlexibleContentData = function ( obj ) {
+	const normalizeFlexibleContentData = function ( obj ) {
 		if ( ! acf.isObject( obj ) ) {
 			return obj;
 		}
 
-		var result = {};
+		let result = {};
 
-		for ( var key in obj ) {
+		for ( let key in obj ) {
 			if ( ! obj.hasOwnProperty( key ) ) {
 				continue;
 			}
@@ -963,12 +964,10 @@
 			}
 
 			// Convert numeric-keyed objects to arrays (e.g., checkbox values)
-			if ( acf.hasOnlyNumericKeys( value ) ) {
-				result[ key ] = acf.numericObjectToArray( value );
+			if ( hasOnlyNumericKeys( value ) ) {
+				result[ key ] = numericObjectToArray( value );
 				continue;
-			}
-
-			// Convert flexible content to arrays
+			} // Convert flexible content to arrays
 			if ( acf.isFlexibleContentData( value ) ) {
 				var arr = [];
 				var keys = Object.keys( value );
@@ -981,20 +980,31 @@
 
 					var subvalue = value[ subkey ];
 					if ( acf.isObject( subvalue ) && subvalue.acf_fc_layout ) {
-						arr.push(
-							acf.normalizeFlexibleContentData( subvalue )
-						);
+						arr.push( normalizeFlexibleContentData( subvalue ) );
 					}
 				}
 
 				result[ key ] = arr;
 			} else {
 				// Recursively process nested objects
-				result[ key ] = acf.normalizeFlexibleContentData( value );
+				result[ key ] = normalizeFlexibleContentData( value );
 			}
 		}
 
 		return result;
+	};
+
+	/**
+	 * Public API wrapper for normalizeFlexibleContentData.
+	 * Normalizes flexible content data structure by converting objects to arrays.
+	 *
+	 * @since 6.6.0
+	 *
+	 * @param {Object} obj The object to normalize.
+	 * @return {Object|Array} The normalized data.
+	 */
+	acf.normalizeFlexibleContentData = function ( obj ) {
+		return normalizeFlexibleContentData( obj );
 	};
 
 	/**

--- a/assets/src/js/_acf.js
+++ b/assets/src/js/_acf.js
@@ -856,6 +856,149 @@
 	};
 
 	/**
+	 * Check if an object has only numeric string keys.
+	 * Used to detect objects that should be converted to arrays (e.g., checkbox values).
+	 *
+	 * @since   SCF 6.6.0
+	 *
+	 * @param   object obj The object to check
+	 * @return  boolean True if all keys are numeric strings
+	 */
+	acf.hasOnlyNumericKeys = function ( obj ) {
+		var keys = Object.keys( obj );
+		if ( keys.length === 0 ) {
+			return false;
+		}
+
+		for ( var i = 0; i < keys.length; i++ ) {
+			if ( ! /^\d+$/.test( keys[ i ] ) ) {
+				return false;
+			}
+		}
+		return true;
+	};
+
+	/**
+	 * Convert an object with numeric string keys to a sorted array.
+	 * Example: {"0": "one", "2": "three", "1": "two"} becomes ["one", "two", "three"]
+	 *
+	 * @date    14/01/25
+	 * @since   SCF 6.6.0
+	 *
+	 * @param   object obj The object to convert
+	 * @return  array The sorted array
+	 */
+	acf.numericObjectToArray = function ( obj ) {
+		var arr = [];
+		var keys = Object.keys( obj )
+			.map( function ( k ) {
+				return parseInt( k, 10 );
+			} )
+			.sort( function ( a, b ) {
+				return a - b;
+			} );
+
+		for ( var i = 0; i < keys.length; i++ ) {
+			arr.push( obj[ keys[ i ].toString() ] );
+		}
+		return arr;
+	};
+
+	/**
+	 * Check if a value looks like flexible content data.
+	 * Flexible content has objects with keys that contain 'acf_fc_layout' property.
+	 *
+	 * @since   SCF 6.6.0
+	 *
+	 * @param   object value The value to check
+	 * @return  boolean True if this looks like flexible content data
+	 */
+	acf.isFlexibleContentData = function ( value ) {
+		if ( ! acf.isObject( value ) ) {
+			return false;
+		}
+
+		var keys = Object.keys( value );
+		for ( var i = 0; i < keys.length; i++ ) {
+			var key = keys[ i ];
+			if ( key === 'acfcloneindex' ) {
+				continue;
+			}
+
+			var subvalue = value[ key ];
+			if ( acf.isObject( subvalue ) && subvalue.acf_fc_layout ) {
+				return true;
+			}
+		}
+		return false;
+	};
+
+	/**
+	 * Normalize flexible content data by converting objects to arrays.
+	 * Flexible content uses unique IDs (e.g., '69171156640b5') or row-X format as keys,
+	 * but validation expects array format with numeric indices.
+	 *
+	 * @since   SCF 6.6.0
+	 *
+	 * @param   object obj The object to normalize
+	 * @return  object The normalized object
+	 */
+	acf.normalizeFlexibleContentData = function ( obj ) {
+		if ( ! acf.isObject( obj ) ) {
+			return obj;
+		}
+
+		var result = {};
+
+		for ( var key in obj ) {
+			if ( ! obj.hasOwnProperty( key ) ) {
+				continue;
+			}
+
+			var value = obj[ key ];
+
+			// Primitives pass through unchanged
+			if ( ! acf.isObject( value ) ) {
+				result[ key ] = value;
+				continue;
+			}
+
+			// Convert numeric-keyed objects to arrays (e.g., checkbox values)
+			if ( acf.hasOnlyNumericKeys( value ) ) {
+				result[ key ] = acf.numericObjectToArray( value );
+				continue;
+			}
+
+			// Convert flexible content to arrays
+			if ( acf.isFlexibleContentData( value ) ) {
+				var arr = [];
+				var keys = Object.keys( value );
+
+				for ( var i = 0; i < keys.length; i++ ) {
+					var subkey = keys[ i ];
+					if ( subkey === 'acfcloneindex' ) {
+						continue;
+					}
+
+					var subvalue = value[ subkey ];
+					if ( acf.isObject( subvalue ) && subvalue.acf_fc_layout ) {
+						arr.push(
+							acf.normalizeFlexibleContentData( subvalue )
+						);
+					}
+				}
+
+				result[ key ] = arr;
+			} else {
+				// Recursively process nested objects
+				result[ key ] = acf.normalizeFlexibleContentData( value );
+			}
+		}
+
+		return result;
+	};
+
+	/**
 	 *  acf.serializeArray
 	 *
 	 *  Similar to $.serializeArray() but works with a parent wrapping element.

--- a/assets/src/js/_acf.js
+++ b/assets/src/js/_acf.js
@@ -859,6 +859,11 @@
 	 * Check if an object has only numeric string keys.
 	 * Used to detect objects that should be converted to arrays (e.g., checkbox values).
 	 *
+	 * Semantics:
+	 * - Accepts base-10, non-negative integer strings composed of digits only (e.g. "0", "12").
+	 * - Leading zeros are allowed (e.g. "0012") and treated as numeric by downstream logic.
+	 * - Negative ("-1"), decimal ("1.0"), and non-numeric keys are rejected.
+	 *
 	 * @since   SCF 6.6.0
 	 * @private
 	 *
@@ -880,34 +885,43 @@
 	};
 
 	/**
-	 * Convert an object with numeric string keys to a sorted array.
-	 * Example: {"0": "one", "2": "three", "1": "two"} becomes ["one", "two", "three"]
+	 * Convert an object with numeric string keys to a numerically sorted array.
+	 * Example: {"0": "one", "2": "three", "1": "two"} becomes ["one", "two", "three"].
+	 *
+	 * Notes on edge-cases:
+	 * - Leading zeros (e.g. "00123") are supported; order is based on the numeric value
+	 *   but the original string key is used to read the value to avoid lookup mismatches.
+	 * - Assumes {@link hasOnlyNumericKeys} has already gated out negatives/decimals.
 	 *
 	 * @since   SCF 6.6.0
 	 * @private
 	 *
 	 * @param   object obj The object to convert
-	 * @return  array The sorted array
+	 * @return  array The numerically sorted array of values
 	 */
 	const numericObjectToArray = function ( obj ) {
 		const arr = [];
-		const keys = Object.keys( obj )
+		// Pair each original key with its numeric value for stable lookup and sorting.
+		const entries = Object.keys( obj )
 			.map( function ( k ) {
-				return parseInt( k, 10 );
+				return { k: k, n: parseInt( k, 10 ) };
 			} )
 			.sort( function ( a, b ) {
-				return a - b;
+				return a.n - b.n;
 			} );
 
-		for ( let i = 0; i < keys.length; i++ ) {
-			arr.push( obj[ keys[ i ].toString() ] );
+		for ( let i = 0; i < entries.length; i++ ) {
+			arr.push( obj[ entries[ i ].k ] );
 		}
 		return arr;
 	};
 
 	/**
 	 * Check if a value looks like flexible content data.
-	 * Flexible content has objects with keys that contain 'acf_fc_layout' property.
+	 * Flexible content objects contain rows where each row object has an 'acf_fc_layout' property.
+	 * Keys for flexible rows are not guaranteed to be numeric: they are typically unique IDs
+	 * (e.g. '69171156640b5') or strings like 'row-0'. Therefore, flexible content detection does
+	 * not rely on numeric keys and is handled separately from numeric-keyed object normalization.
 	 *
 	 * @since   SCF 6.6.0
 	 *

--- a/assets/src/js/pro/blocks-v3/components/block-edit.js
+++ b/assets/src/js/pro/blocks-v3/components/block-edit.js
@@ -598,8 +598,13 @@ function BlockEditInner( props ) {
 									`acf-block_${ clientId }`
 								);
 								if ( serializedData ) {
+									// Normalize flexible content data for validation
+									const normalizedData =
+										acf.normalizeFlexibleContentData(
+											serializedData
+										);
 									setTheSerializedAcfData(
-										JSON.stringify( serializedData )
+										JSON.stringify( normalizedData )
 									);
 								}
 							} }

--- a/includes/forms/form-post.php
+++ b/includes/forms/form-post.php
@@ -84,6 +84,36 @@ if ( ! class_exists( 'ACF_Form_Post' ) ) :
 		}
 
 		/**
+		 * Checks if a field group is assigned to blocks.
+		 *
+		 * Block field groups should not be rendered as metaboxes because:
+		 * 1. They are managed by the block editor (blocks v3)
+		 * 2. They have their own validation system via AJAX
+		 * 3. Rendering them as metaboxes causes duplicate validation on post save
+		 *
+		 * @since   SCF 6.6.0
+		 *
+		 * @param   array $field_group The field group array.
+		 * @return  bool True if field group is for blocks, false otherwise.
+		 */
+		public function is_block_field_group( $field_group ) {
+			if ( empty( $field_group['location'] ) ) {
+				return false;
+			}
+
+			// Check each location group
+			foreach ( $field_group['location'] as $location_group ) {
+				foreach ( $location_group as $rule ) {
+					if ( isset( $rule['param'] ) && 'block' === $rule['param'] ) {
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+
+		/**
 		 *
 		 * Adds ACF metaboxes for the given $post_type and $post.
 		 *
@@ -110,6 +140,11 @@ if ( ! class_exists( 'ACF_Form_Post' ) ) :
 			// Loop over field groups.
 			if ( $field_groups ) {
 				foreach ( $field_groups as $field_group ) {
+					// Skip block field groups - they are managed by the block editor
+					if ( $this->is_block_field_group( $field_group ) ) {
+						continue;
+					}
+
 					$id       = esc_attr( "acf-{$field_group['key']}" );
 					$context  = esc_attr( $field_group['position'] );
 					$priority = 'high';

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"prepare": "husky",
 		"sort-package-json": "sort-package-json",
 		"test:e2e": "wp-scripts test-playwright",
-		"test:e2e:debug": "wp-scripts test-playwright --debug",
+		"test:e2e:debug": "wp-scripts test-playwright --debug --ui",
 		"test:unit": "wp-scripts test-unit-js",
 		"test:unit:watch": "wp-scripts test-unit-js --watch",
 		"watch": "webpack --watch"

--- a/tests/e2e/block-testimonial.spec.ts
+++ b/tests/e2e/block-testimonial.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const PLUGIN_SLUG = 'secure-custom-fields';
+const TEST_PLUGIN_SLUG = 'scf-test-plugin-testimonial-block';
+const BLOCK_NAME = 'scf/testimonial';
+
+test.describe( 'SCF Block > Testimonial', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin( PLUGIN_SLUG );
+		await requestUtils.activatePlugin( TEST_PLUGIN_SLUG );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin( TEST_PLUGIN_SLUG );
+		await requestUtils.deactivatePlugin( PLUGIN_SLUG );
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test( 'should use testimonial block with fields', async ( {
+		page,
+		admin,
+		editor,
+		requestUtils,
+	} ) => {
+		// The block and field group are already registered via the plugin
+		// No need to create anything in the UI
+
+		// Create a new post
+		const post = await requestUtils.createPost( {
+			title: 'Testimonial Test Post',
+			status: 'draft',
+		} );
+
+		// Navigate to edit post page
+		await admin.editPost( post.id );
+
+		// Add the testimonial block
+		await editor.insertBlock( { name: BLOCK_NAME } );
+
+		// Wait for the block fields to appear in the sidebar
+		await page.waitForSelector( '.acf-block-fields', {
+			state: 'visible',
+			timeout: 10000,
+		} );
+
+		// Fill in the quote field (in the sidebar)
+		const quoteField = page.locator(
+			'.acf-field[data-name="quote"] textarea'
+		);
+		await quoteField.fill(
+			'Amazing Quote'
+		);
+
+		// Wait for the preview to update
+		await page.waitForTimeout( 1000 );
+
+		// Fill in the author field
+		const authorField = page.locator(
+			'.acf-field[data-name="author"] input[type="text"]'
+		);
+		await authorField.fill( 'John Doe' );
+		// Blur to trigger update
+		await authorField.blur();
+
+		// Wait for the preview to update
+		await page.waitForTimeout( 500 );
+
+		// Fill in the role field
+		const roleField = page.locator(
+			'.acf-field[data-name="role"] input[type="text"]'
+		);
+		await roleField.fill( 'CEO, Example Company' );
+		// Blur to trigger update
+		await roleField.blur();
+
+		// Wait for block preview to update
+		await page.waitForTimeout( 1000 );
+
+		// Get the editor canvas (content is in an iframe in newer WordPress versions)
+		const canvas = await editor.canvas;
+
+		// Verify the preview shows the content (within the selected block in canvas)
+		const blockPreview = canvas.locator( '[data-type="scf/testimonial"] .testimonial__blockquote' );
+		await blockPreview.waitFor( { state: 'visible', timeout: 5000 } );
+		await expect( blockPreview ).toContainText(
+			'Amazing Quote'
+		);
+
+		// Author and role should appear in the attribution footer
+		const authorCite = canvas.locator( '[data-type="scf/testimonial"] .testimonial__author' );
+		await expect( authorCite ).toBeVisible();
+		await expect( authorCite ).toContainText( 'John Doe' );
+
+		const roleSpan = canvas.locator( '[data-type="scf/testimonial"] .testimonial__role' );
+		await expect( roleSpan ).toBeVisible();
+		await expect( roleSpan ).toContainText( 'CEO, Example Company' );
+
+		// Save the post
+		await page.click( '.editor-post-save-draft' );
+
+		// Wait for save to complete
+		const savedNotice = page.locator(
+			'.components-snackbar:has-text("Draft saved")'
+		);
+		await expect( savedNotice ).toBeVisible( { timeout: 5000 } );
+	} );
+
+	test( 'should validate required quote field in testimonial block', async ( {
+		page,
+		admin,
+		editor,
+		requestUtils,
+	} ) => {
+		// The block and field group are already registered via the plugin
+		// The quote field is already set as required in the plugin
+
+		// Create a new post
+		const post = await requestUtils.createPost( {
+			title: 'Testimonial Validation Test',
+			status: 'draft',
+		} );
+
+		// Navigate to edit post page
+		await admin.editPost( post.id );
+
+		// Add the testimonial block
+		await editor.insertBlock( { name: BLOCK_NAME } );
+
+		// Wait for the block fields to appear in the sidebar
+		await page.waitForSelector( '.acf-block-fields', {
+			state: 'visible',
+			timeout: 10000,
+		} );
+
+		// Clear the quote field to trigger validation
+		const quoteTextarea = page.locator(
+			'.acf-field[data-name="quote"] textarea'
+		);
+		await quoteTextarea.clear();
+		
+		// Blur to trigger field validation
+		await quoteTextarea.blur();
+		
+		// Wait a moment for blur validation
+		await page.waitForTimeout( 500 );
+
+		// Try to publish to trigger full validation
+		const publishToggle = page.locator( '.editor-post-publish-panel__toggle' );
+		await publishToggle.click();
+
+		// Wait for publish panel to open
+		await page.waitForTimeout( 500 );
+
+		// Click the actual publish button in the panel
+		const publishButton = page.locator( '.editor-post-publish-panel .editor-post-publish-button' );
+		await publishButton.click();
+
+		// Wait for validation to fully appear
+		await page.waitForTimeout( 1000 );
+
+		// Check that the field has error class
+		const quoteFieldWithError = page.locator(
+			'.acf-field[data-name="quote"].acf-error'
+		);
+		await expect( quoteFieldWithError ).toBeVisible();
+
+		// Check for the error message within the field
+		const errorMessage = page.locator(
+			'.acf-field[data-name="quote"] .acf-notice.-error'
+		);
+		await expect( errorMessage ).toBeVisible();
+		await expect( errorMessage ).toContainText( 'required' );
+	} );
+} );

--- a/tests/e2e/plugins/blocks/scf-testimonial-block/block.json
+++ b/tests/e2e/plugins/blocks/scf-testimonial-block/block.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "scf/testimonial",
+	"title": "SCF Testimonial",
+	"description": "A custom testimonial block with SCF fields for quote, author, and role.",
+	"category": "text",
+	"icon": "format-quote",
+	"keywords": [ "testimonial", "quote", "review" ],
+	"acf": {
+		"blockVersion": 3,
+		"mode": "preview",
+		"renderTemplate": "template.php"
+	},
+	"textdomain": "secure-custom-fields"
+}

--- a/tests/e2e/plugins/blocks/scf-testimonial-block/template.php
+++ b/tests/e2e/plugins/blocks/scf-testimonial-block/template.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Testimonial Block template.
+ *
+ * @package scf-test-plugins
+ *
+ * @param array  $block      The block settings and attributes.
+ * @param string $content    The block inner HTML (empty).
+ * @param bool   $is_preview True during backend preview render.
+ * @param int    $post_id    The post ID the block is rendering content against.
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Load values and assign defaults.
+$quote       = get_field( 'quote' );
+$author      = get_field( 'author' );
+$author_role = get_field( 'role' );
+// Build quote attribution.
+$quote_attribution = '';
+if ( $author ) {
+	$quote_attribution .= '<footer class="testimonial__attribution">';
+	$quote_attribution .= '<cite class="testimonial__author">' . esc_html( $author ) . '</cite>';
+
+	if ( $author_role ) {
+		$quote_attribution .= '<span class="testimonial__role">' . esc_html( $author_role ) . '</span>';
+	}
+
+	$quote_attribution .= '</footer><!-- .testimonial__attribution -->';
+}
+
+// Add a unique block ID for editor identification.
+$block_id = 'testimonial-' . $block['id'];
+?>
+
+<div class="testimonial" id="<?php echo esc_attr( $block_id ); ?>">
+	<div class="testimonial__col">
+		<blockquote class="testimonial__blockquote">
+			<?php echo esc_html( $quote ); ?>
+
+			<?php if ( ! empty( $quote_attribution ) ) : ?>
+				<?php echo wp_kses_post( $quote_attribution ); ?>
+			<?php endif; ?>
+		</blockquote>
+	</div>
+
+</div>

--- a/tests/e2e/plugins/blocks/scf-testimonial-block/template.php
+++ b/tests/e2e/plugins/blocks/scf-testimonial-block/template.php
@@ -33,7 +33,7 @@ if ( $author ) {
 }
 
 // Add a unique block ID for editor identification.
-$block_id = 'testimonial-' . $block['id'];
+$block_id = 'testimonial-' . ( isset( $block['id'] ) ? (string) $block['id'] : uniqid() );
 ?>
 
 <div class="testimonial" id="<?php echo esc_attr( $block_id ); ?>">

--- a/tests/e2e/plugins/scf-test-testimonial-block.php
+++ b/tests/e2e/plugins/scf-test-testimonial-block.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Plugin Name: SCF Test Plugin - Testimonial Block
+ * Description: Test plugin for SCF testimonial block with various field types
+ * Version: 1.0.0
+ * Author: SCF Test
+ * Text Domain: scf-test-plugin-testimonial-block
+ *
+ * @package scf-test-plugins
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the testimonial block.
+ */
+function scf_test_register_testimonial_block() {
+	register_block_type( __DIR__ . '/blocks/scf-testimonial-block' );
+}
+add_action( 'init', 'scf_test_register_testimonial_block' );
+
+/**
+ * Register field group for the testimonial block.
+ */
+function scf_test_register_testimonial_fields() {
+	// Check if ACF function exists.
+	if ( ! function_exists( 'acf_add_local_field_group' ) ) {
+		return;
+	}
+
+	acf_add_local_field_group(
+		array(
+			'key'                   => 'group_testimonial_block',
+			'title'                 => 'Testimonial Block Fields',
+			'fields'                => array(
+				array(
+					'key'         => 'field_testimonial_quote',
+					'label'       => 'Quote',
+					'name'        => 'quote',
+					'type'        => 'textarea',
+					'required'    => 1,
+					'placeholder' => 'Enter the testimonial quote...',
+					'rows'        => 4,
+				),
+				array(
+					'key'         => 'field_testimonial_author',
+					'label'       => 'Author',
+					'name'        => 'author',
+					'type'        => 'text',
+					'placeholder' => 'Author name',
+				),
+				array(
+					'key'         => 'field_testimonial_role',
+					'label'       => 'Role',
+					'name'        => 'role',
+					'type'        => 'text',
+					'placeholder' => 'Author role or title',
+				),
+			),
+			'location'              => array(
+				array(
+					array(
+						'param'    => 'block',
+						'operator' => '==',
+						'value'    => 'scf/testimonial',
+					),
+				),
+			),
+			'menu_order'            => 0,
+			'position'              => 'normal',
+			'style'                 => 'default',
+			'label_placement'       => 'top',
+			'instruction_placement' => 'label',
+			'hide_on_screen'        => '',
+			'active'                => true,
+			'description'           => '',
+			'show_in_rest'          => 0,
+		)
+	);
+}
+add_action( 'acf/init', 'scf_test_register_testimonial_fields' );

--- a/tests/php/includes/forms/test-form-post.php
+++ b/tests/php/includes/forms/test-form-post.php
@@ -142,4 +142,141 @@ class Test_Form_Post extends BaseTestCase {
 		// Cleanup
 		unset( $_POST['post_ID'] );
 	}
+
+	/**
+	 * Test is_block_field_group method with block location rules.
+	 */
+	public function test_is_block_field_group_with_block_location() {
+		$form_post = new ACF_Form_Post();
+
+		// Test field group with block location rule
+		$field_group_with_block = array(
+			'location' => array(
+				array(
+					array(
+						'param'    => 'block',
+						'operator' => '==',
+						'value'    => 'acf/testimonial',
+					),
+				),
+			),
+		);
+
+		$this->assertTrue(
+			$form_post->is_block_field_group( $field_group_with_block ),
+			'Field group with block location should be identified as block field group'
+		);
+	}
+
+	/**
+	 * Test is_block_field_group method with non-block location rules.
+	 */
+	public function test_is_block_field_group_with_non_block_location() {
+		$form_post = new ACF_Form_Post();
+
+		// Test field group with post type location rule
+		$field_group_with_post_type = array(
+			'location' => array(
+				array(
+					array(
+						'param'    => 'post_type',
+						'operator' => '==',
+						'value'    => 'post',
+					),
+				),
+			),
+		);
+
+		$this->assertFalse(
+			$form_post->is_block_field_group( $field_group_with_post_type ),
+			'Field group with only post_type location should not be identified as block field group'
+		);
+	}
+
+	/**
+	 * Test is_block_field_group method with empty location.
+	 */
+	public function test_is_block_field_group_with_empty_location() {
+		$form_post = new ACF_Form_Post();
+
+		// Test field group with no location
+		$field_group_empty_location = array(
+			'location' => array(),
+		);
+
+		$this->assertFalse(
+			$form_post->is_block_field_group( $field_group_empty_location ),
+			'Field group with empty location should not be identified as block field group'
+		);
+
+		// Test field group with missing location key
+		$field_group_no_location = array();
+
+		$this->assertFalse(
+			$form_post->is_block_field_group( $field_group_no_location ),
+			'Field group without location key should not be identified as block field group'
+		);
+	}
+
+	/**
+	 * Test is_block_field_group method with multiple location groups.
+	 */
+	public function test_is_block_field_group_with_multiple_location_groups() {
+		$form_post = new ACF_Form_Post();
+
+		// Test field group with multiple location groups, one containing block
+		$field_group_multiple_groups = array(
+			'location' => array(
+				array(
+					array(
+						'param'    => 'post_type',
+						'operator' => '==',
+						'value'    => 'post',
+					),
+				),
+				array(
+					array(
+						'param'    => 'block',
+						'operator' => '==',
+						'value'    => 'acf/testimonial',
+					),
+				),
+			),
+		);
+
+		$this->assertTrue(
+			$form_post->is_block_field_group( $field_group_multiple_groups ),
+			'Field group with block location in any group should be identified as block field group'
+		);
+	}
+
+	/**
+	 * Test is_block_field_group method with mixed rules in same group.
+	 */
+	public function test_is_block_field_group_with_mixed_rules() {
+		$form_post = new ACF_Form_Post();
+
+		// Test field group with block AND post_type in same group
+		$field_group_mixed_rules = array(
+			'location' => array(
+				array(
+					array(
+						'param'    => 'block',
+						'operator' => '==',
+						'value'    => 'acf/testimonial',
+					),
+					array(
+						'param'    => 'post_type',
+						'operator' => '==',
+						'value'    => 'post',
+					),
+				),
+			),
+		);
+
+		$this->assertTrue(
+			$form_post->is_block_field_group( $field_group_mixed_rules ),
+			'Field group with block location among other rules should be identified as block field group'
+		);
+	}
 }


### PR DESCRIPTION
## What

The new V3 Blocks allow to edit the content in the sidebar and in a modal. Flexible content is not working, if you set it as required.

https://github.com/user-attachments/assets/3427bc81-eda6-4976-ac71-d73e784f36b3

## Fix

To fix it, it needs to:
 - Skip server validation if is on a block - sidebar. Although block data is still validated, sanitized, with nonce and capability checks.
 - Serialize flexible content data to be validated on the editor.

## Screenshare

https://github.com/user-attachments/assets/ec60711b-e83b-415f-a091-1c7cc4eda746




