### PR TITLE
Set coverage target to 70% in codecov configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,13 +11,13 @@ coverage:
 
         patch:
             default:
-                target: auto
+                target: 70%
                 threshold: 5%
                 if_ci_failed: ignore
 
         changes:
             default:
-                target: auto
+                target: 70%
                 threshold: 5%
                 if_ci_failed: ignore
 


### PR DESCRIPTION
I've seen in new PRs that Codecov expects new patches to have 100% coverage by default, resulting in PR actions failing even with 80% coverage.

Let's set a more realistic target of 70% for new patches and keep adjusting.