### PR TITLE
Do not show the panel if there are no attributes (V3 blocks)

### DIFF
--- a/assets/src/js/bindings/block-editor.js
+++ b/assets/src/js/bindings/block-editor.js
@@ -210,6 +210,10 @@ const withCustomControls = createHigherOrderComponent( ( BlockEdit ) => {
 			return <BlockEdit { ...props } />;
 		}
 
+		if ( bindableAttributes.length === 0 ) {
+			return <BlockEdit { ...props } />;
+		}
+
 		return (
 			<>
 				<InspectorControls { ...props }>
@@ -303,8 +307,8 @@ const withCustomControls = createHigherOrderComponent( ( BlockEdit ) => {
 	};
 }, 'withCustomControls' );
 
-// addFilter(
-// 	'editor.BlockEdit',
-// 	'secure-custom-fields/with-custom-controls',
-// 	withCustomControls
-// );
+addFilter(
+	'editor.BlockEdit',
+	'secure-custom-fields/with-custom-controls',
+	withCustomControls
+);


### PR DESCRIPTION
## What

I commented the "Connect Field" sidebar option cause it was interfering with the new v3 blocks interface.

<img width="1306" height="395" alt="Screenshot 2025-11-14 at 16 23 03" src="https://github.com/user-attachments/assets/55ae4688-704b-41b0-a628-dbe1ab664d41" />

With the fix applied, if there are no bindable attributes, is not displayed on non compatible blocks.

Not showing on a v3 block:
<img width="1296" height="426" alt="Screenshot 2025-11-14 at 16 23 55" src="https://github.com/user-attachments/assets/5c88f5df-cef0-4c36-900e-e91ed98676e6" />

Showing in a paragraph block:
<img width="1303" height="515" alt="Screenshot 2025-11-14 at 16 24 01" src="https://github.com/user-attachments/assets/d790e446-59cc-45a4-a338-909d779e5e05" />
