### PR TITLE
Fix: Validate required JSON schemas before registering abilities 

### DIFF
--- a/includes/abilities/class-scf-post-type-abilities.php
+++ b/includes/abilities/class-scf-post-type-abilities.php
@@ -13,606 +13,614 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Include the validator class for static analysis.
-if ( ! class_exists( 'SCF_JSON_Schema_Validator' ) ) {
-	require_once ACF_PATH . 'includes/class-scf-json-schema-validator.php';
-}
-
-/**
- * SCF Post Type Abilities class.
- *
- * Registers and handles all post type management abilities for the
- * WordPress Abilities API integration. Provides programmatic access
- * to SCF post type operations.
- *
- * @since 6.6.0
- */
-class SCF_Post_Type_Abilities {
+if ( ! class_exists( 'SCF_Post_Type_Abilities' ) ) :
 
 	/**
-	 * Post type schema to reuse across ability registrations.
+	 * SCF Post Type Abilities class.
 	 *
-	 * @var object|null
-	 */
-	private $post_type_schema = null;
-
-	/**
-	 * SCF identifier schema to reuse across ability registrations.
-	 *
-	 * @var object|null
-	 */
-	private $scf_identifier_schema = null;
-
-	/**
-	 * Constructor.
+	 * Registers and handles all post type management abilities for the
+	 * WordPress Abilities API integration. Provides programmatic access
+	 * to SCF post type operations.
 	 *
 	 * @since 6.6.0
 	 */
-	public function __construct() {
-		add_action( 'wp_abilities_api_categories_init', array( $this, 'register_categories' ) );
-		add_action( 'wp_abilities_api_init', array( $this, 'register_abilities' ) );
-	}
+	class SCF_Post_Type_Abilities {
 
-	/**
-	 * Get the SCF post type schema, loading it once and caching for reuse.
-	 *
-	 * @since 6.6.0
-	 * @return array The post type schema definition.
-	 */
-	private function get_post_type_schema() {
-		if ( null === $this->post_type_schema ) {
-			$validator = new SCF_JSON_Schema_Validator();
-			$schema    = $validator->load_schema( 'post-type' );
+		/**
+		 * Post type schema to reuse across ability registrations.
+		 *
+		 * @var object|null
+		 */
+		private $post_type_schema = null;
 
-			$this->post_type_schema = json_decode( wp_json_encode( $schema->definitions->postType ), true );
+		/**
+		 * SCF identifier schema to reuse across ability registrations.
+		 *
+		 * @var object|null
+		 */
+		private $scf_identifier_schema = null;
+
+		/**
+		 * Constructor.
+		 *
+		 * @since 6.6.0
+		 */
+		public function __construct() {
+			$validator = acf_get_instance( 'SCF_JSON_Schema_Validator' );
+
+			// Only register abilities if schemas are available
+			if ( ! $validator->validate_required_schemas() ) {
+				return;
+			}
+
+			add_action( 'wp_abilities_api_categories_init', array( $this, 'register_categories' ) );
+			add_action( 'wp_abilities_api_init', array( $this, 'register_abilities' ) );
 		}
 
-		return $this->post_type_schema;
-	}
+		/**
+		 * Get the SCF post type schema, loading it once and caching for reuse.
+		 *
+		 * @since 6.6.0
+		 * @return array The post type schema definition.
+		 */
+		private function get_post_type_schema() {
+			if ( null === $this->post_type_schema ) {
+				$validator = new SCF_JSON_Schema_Validator();
+				$schema    = $validator->load_schema( 'post-type' );
 
-	/**
-	 * Get the SCF identifier schema, loading it once and caching for reuse.
-	 *
-	 * @since 6.6.0
-	 *
-	 * @return array The SCF identifier schema definition.
-	 */
-	private function get_scf_identifier_schema() {
-		if ( null === $this->scf_identifier_schema ) {
-			$validator = new SCF_JSON_Schema_Validator();
+				$this->post_type_schema = json_decode( wp_json_encode( $schema->definitions->postType ), true );
+			}
 
-			$this->scf_identifier_schema = json_decode( wp_json_encode( $validator->load_schema( 'scf-identifier' ) ), true );
+			return $this->post_type_schema;
 		}
 
-		return $this->scf_identifier_schema;
-	}
+		/**
+		 * Get the SCF identifier schema, loading it once and caching for reuse.
+		 *
+		 * @since 6.6.0
+		 *
+		 * @return array The SCF identifier schema definition.
+		 */
+		private function get_scf_identifier_schema() {
+			if ( null === $this->scf_identifier_schema ) {
+				$validator = new SCF_JSON_Schema_Validator();
 
-	/**
-	 * Get the internal fields schema (ID, _valid, local).
-	 *
-	 * @since 6.6.0
-	 * @return array The internal fields schema.
-	 */
-	private function get_internal_fields_schema() {
-		$validator = new SCF_JSON_Schema_Validator();
-		$schema    = $validator->load_schema( 'internal-fields' );
+				$this->scf_identifier_schema = json_decode( wp_json_encode( $validator->load_schema( 'scf-identifier' ) ), true );
+			}
 
-		return json_decode( wp_json_encode( $schema->definitions->internalFields ), true );
-	}
+			return $this->scf_identifier_schema;
+		}
 
-	/**
-	 * Get the post type schema extended with internal fields for GET/LIST/CREATE/UPDATE/IMPORT/DUPLICATE operations.
-	 *
-	 * @since 6.6.0
-	 *
-	 * @return array The extended post type schema with internal fields.
-	 */
-	private function get_post_type_with_internal_fields_schema() {
-		$schema               = $this->get_post_type_schema();
-		$internal_fields      = $this->get_internal_fields_schema();
-		$schema['properties'] = array_merge( $schema['properties'], $internal_fields['properties'] );
+		/**
+		 * Get the internal fields schema (ID, _valid, local).
+		 *
+		 * @since 6.6.0
+		 * @return array The internal fields schema.
+		 */
+		private function get_internal_fields_schema() {
+			$validator = new SCF_JSON_Schema_Validator();
+			$schema    = $validator->load_schema( 'internal-fields' );
 
-		return $schema;
-	}
+			return json_decode( wp_json_encode( $schema->definitions->internalFields ), true );
+		}
 
-	/**
-	 * Register SCF ability categories.
-	 *
-	 * @since 6.6.0
-	 */
-	public function register_categories() {
-		wp_register_ability_category(
-			'scf-post-types',
-			array(
-				'label'       => __( 'SCF Post Types', 'secure-custom-fields' ),
-				'description' => __( 'Abilities for managing Secure Custom Fields post types.', 'secure-custom-fields' ),
-			)
-		);
-	}
+		/**
+		 * Get the post type schema extended with internal fields for GET/LIST/CREATE/UPDATE/IMPORT/DUPLICATE operations.
+		 *
+		 * @since 6.6.0
+		 *
+		 * @return array The extended post type schema with internal fields.
+		 */
+		private function get_post_type_with_internal_fields_schema() {
+			$schema               = $this->get_post_type_schema();
+			$internal_fields      = $this->get_internal_fields_schema();
+			$schema['properties'] = array_merge( $schema['properties'], $internal_fields['properties'] );
 
-	/**
-	 * Register all post type abilities.
-	 *
-	 * @since 6.6.0
-	 */
-	public function register_abilities() {
-		$this->register_list_post_types_ability();
-		$this->register_get_post_type_ability();
-		$this->register_create_post_type_ability();
-		$this->register_update_post_type_ability();
-		$this->register_delete_post_type_ability();
-		$this->register_duplicate_post_type_ability();
-		$this->register_export_post_type_ability();
-		$this->register_import_post_type_ability();
-	}
+			return $schema;
+		}
 
-	/**
-	 * Register the list post types ability.
-	 *
-	 * @since 6.6.0
-	 */
-	private function register_list_post_types_ability() {
-		wp_register_ability(
-			'scf/list-post-types',
-			array(
-				'label'               => __( 'List Post Types', 'secure-custom-fields' ),
-				'description'         => __( 'Retrieves a list of all SCF post types with optional filtering.', 'secure-custom-fields' ),
-				'category'            => 'scf-post-types',
-				'execute_callback'    => array( $this, 'list_post_types_callback' ),
-				'meta'                => array(
-					'show_in_rest' => true,
-					'mcp'          => array(
-						'public' => true,
+		/**
+		 * Register SCF ability categories.
+		 *
+		 * @since 6.6.0
+		 */
+		public function register_categories() {
+			wp_register_ability_category(
+				'scf-post-types',
+				array(
+					'label'       => __( 'SCF Post Types', 'secure-custom-fields' ),
+					'description' => __( 'Abilities for managing Secure Custom Fields post types.', 'secure-custom-fields' ),
+				)
+			);
+		}
+
+		/**
+		 * Register all post type abilities.
+		 *
+		 * @since 6.6.0
+		 */
+		public function register_abilities() {
+			$this->register_list_post_types_ability();
+			$this->register_get_post_type_ability();
+			$this->register_create_post_type_ability();
+			$this->register_update_post_type_ability();
+			$this->register_delete_post_type_ability();
+			$this->register_duplicate_post_type_ability();
+			$this->register_export_post_type_ability();
+			$this->register_import_post_type_ability();
+		}
+
+		/**
+		 * Register the list post types ability.
+		 *
+		 * @since 6.6.0
+		 */
+		private function register_list_post_types_ability() {
+			wp_register_ability(
+				'scf/list-post-types',
+				array(
+					'label'               => __( 'List Post Types', 'secure-custom-fields' ),
+					'description'         => __( 'Retrieves a list of all SCF post types with optional filtering.', 'secure-custom-fields' ),
+					'category'            => 'scf-post-types',
+					'execute_callback'    => array( $this, 'list_post_types_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array(
+							'public' => true,
+						),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => true,
+						),
 					),
-					'annotations'  => array(
-						'readonly'    => false,
-						'destructive' => false,
-						'idempotent'  => true,
-					),
-				),
-				'permission_callback' => 'scf_current_user_has_capability',
-				'input_schema'        => array(
-					'type'       => 'object',
-					'properties' => array(
-						'filter' => array(
-							'type'        => 'object',
-							'description' => __( 'Optional filters to apply to the post type list.', 'secure-custom-fields' ),
-							'properties'  => array(
-								'active' => array(
-									'type'        => 'boolean',
-									'description' => __( 'Filter by active status.', 'secure-custom-fields' ),
-								),
-								'search' => array(
-									'type'        => 'string',
-									'description' => __( 'Search term to filter post types.', 'secure-custom-fields' ),
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'filter' => array(
+								'type'        => 'object',
+								'description' => __( 'Optional filters to apply to the post type list.', 'secure-custom-fields' ),
+								'properties'  => array(
+									'active' => array(
+										'type'        => 'boolean',
+										'description' => __( 'Filter by active status.', 'secure-custom-fields' ),
+									),
+									'search' => array(
+										'type'        => 'string',
+										'description' => __( 'Search term to filter post types.', 'secure-custom-fields' ),
+									),
 								),
 							),
 						),
 					),
-				),
-				'output_schema'       => array(
-					'type'  => 'array',
-					'items' => $this->get_post_type_with_internal_fields_schema(),
-				),
-			)
-		);
-	}
+					'output_schema'       => array(
+						'type'  => 'array',
+						'items' => $this->get_post_type_with_internal_fields_schema(),
+					),
+				)
+			);
+		}
 
-	/**
-	 * Register the get post type ability.
-	 *
-	 * @since 6.6.0
-	 */
-	private function register_get_post_type_ability() {
-		wp_register_ability(
-			'scf/get-post-type',
-			array(
-				'label'               => __( 'Get Post Type', 'secure-custom-fields' ),
-				'description'         => __( 'Retrieves a specific SCF post type configuration by ID or key.', 'secure-custom-fields' ),
-				'category'            => 'scf-post-types',
-				'execute_callback'    => array( $this, 'get_post_type_callback' ),
-				'meta'                => array(
-					'show_in_rest' => true,
-					'mcp'          => array(
-						'public' => true,
-					),
-					'annotations'  => array(
-						'readonly'    => false,
-						'destructive' => false,
-						'idempotent'  => true,
-					),
-				),
-				'permission_callback' => 'scf_current_user_has_capability',
-				'input_schema'        => array(
-					'type'       => 'object',
-					'properties' => array(
-						'identifier' => $this->get_scf_identifier_schema(),
-					),
-					'required'   => array( 'identifier' ),
-				),
-				'output_schema'       => $this->get_post_type_with_internal_fields_schema(),
-			)
-		);
-	}
-
-	/**
-	 * Register the create post type ability.
-	 *
-	 * @since 6.6.0
-	 */
-	private function register_create_post_type_ability() {
-		$input_schema = $this->get_post_type_schema();
-
-		wp_register_ability(
-			'scf/create-post-type',
-			array(
-				'label'               => __( 'Create Post Type', 'secure-custom-fields' ),
-				'description'         => __( 'Creates a new custom post type in SCF with the provided configuration.', 'secure-custom-fields' ),
-				'category'            => 'scf-post-types',
-				'execute_callback'    => array( $this, 'create_post_type_callback' ),
-				'meta'                => array(
-					'show_in_rest' => true,
-					'mcp'          => array(
-						'public' => true,
-					),
-					'annotations'  => array(
-						'readonly'    => false,
-						'destructive' => false,
-						'idempotent'  => false,
-					),
-				),
-				'permission_callback' => 'scf_current_user_has_capability',
-				'input_schema'        => $input_schema,
-				'output_schema'       => $this->get_post_type_with_internal_fields_schema(),
-			)
-		);
-	}
-
-	/**
-	 * Register the update post type ability.
-	 *
-	 * @since 6.6.0
-	 */
-	private function register_update_post_type_ability() {
-
-		// For updates, only ID is required, everything else is optional
-		$input_schema             = $this->get_post_type_with_internal_fields_schema();
-		$input_schema['required'] = array( 'ID' );
-
-		wp_register_ability(
-			'scf/update-post-type',
-			array(
-				'label'               => __( 'Update Post Type', 'secure-custom-fields' ),
-				'description'         => __( 'Updates an existing SCF post type with new configuration.', 'secure-custom-fields' ),
-				'category'            => 'scf-post-types',
-				'execute_callback'    => array( $this, 'update_post_type_callback' ),
-				'meta'                => array(
-					'show_in_rest' => true,
-					'mcp'          => array(
-						'public' => true,
-					),
-					'annotations'  => array(
-						'readonly'    => false,
-						'destructive' => false,
-						'idempotent'  => true,
-					),
-				),
-				'permission_callback' => 'scf_current_user_has_capability',
-				'input_schema'        => $input_schema,
-				'output_schema'       => $this->get_post_type_with_internal_fields_schema(),
-			)
-		);
-	}
-
-	/**
-	 * Register the delete post type ability.
-	 *
-	 * @since 6.6.0
-	 */
-	private function register_delete_post_type_ability() {
-		wp_register_ability(
-			'scf/delete-post-type',
-			array(
-				'label'               => __( 'Delete Post Type', 'secure-custom-fields' ),
-				'description'         => __( 'Permanently deletes an SCF post type. This action cannot be undone.', 'secure-custom-fields' ),
-				'category'            => 'scf-post-types',
-				'execute_callback'    => array( $this, 'delete_post_type_callback' ),
-				'meta'                => array(
-					'show_in_rest' => true,
-					'mcp'          => array(
-						'public' => true,
-					),
-					'annotations'  => array(
-						'readonly'    => false,
-						'destructive' => true,
-						'idempotent'  => true,
-					),
-				),
-				'permission_callback' => 'scf_current_user_has_capability',
-				'input_schema'        => array(
-					'type'       => 'object',
-					'properties' => array(
-						'identifier' => $this->get_scf_identifier_schema(),
-					),
-					'required'   => array( 'identifier' ),
-				),
-				'output_schema'       => array(
-					'type'        => 'boolean',
-					'description' => __( 'True if post type was successfully deleted.', 'secure-custom-fields' ),
-				),
-			)
-		);
-	}
-
-	/**
-	 * Register the duplicate post type ability.
-	 *
-	 * @since 6.6.0
-	 */
-	private function register_duplicate_post_type_ability() {
-		wp_register_ability(
-			'scf/duplicate-post-type',
-			array(
-				'label'               => __( 'Duplicate Post Type', 'secure-custom-fields' ),
-				'description'         => __( 'Creates a copy of an existing SCF post type with optional modifications.', 'secure-custom-fields' ),
-				'category'            => 'scf-post-types',
-				'execute_callback'    => array( $this, 'duplicate_post_type_callback' ),
-				'meta'                => array(
-					'show_in_rest' => true,
-					'mcp'          => array(
-						'public' => true,
-					),
-					'annotations'  => array(
-						'readonly'    => false,
-						'destructive' => false,
-						'idempotent'  => false,
-					),
-				),
-				'permission_callback' => 'scf_current_user_has_capability',
-				'input_schema'        => array(
-					'type'       => 'object',
-					'properties' => array(
-						'identifier'  => $this->get_scf_identifier_schema(),
-						'new_post_id' => array(
-							'type'        => 'integer',
-							'description' => __( 'Optional new post ID for the duplicated post type.', 'secure-custom-fields' ),
+		/**
+		 * Register the get post type ability.
+		 *
+		 * @since 6.6.0
+		 */
+		private function register_get_post_type_ability() {
+			wp_register_ability(
+				'scf/get-post-type',
+				array(
+					'label'               => __( 'Get Post Type', 'secure-custom-fields' ),
+					'description'         => __( 'Retrieves a specific SCF post type configuration by ID or key.', 'secure-custom-fields' ),
+					'category'            => 'scf-post-types',
+					'execute_callback'    => array( $this, 'get_post_type_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array(
+							'public' => true,
+						),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => true,
 						),
 					),
-					'required'   => array( 'identifier' ),
-				),
-				'output_schema'       => $this->get_post_type_with_internal_fields_schema(),
-			)
-		);
-	}
-
-	/**
-	 * Register the export post type ability.
-	 *
-	 * @since 6.6.0
-	 */
-	private function register_export_post_type_ability() {
-		wp_register_ability(
-			'scf/export-post-type',
-			array(
-				'label'               => __( 'Export Post Type', 'secure-custom-fields' ),
-				'description'         => __( 'Exports an SCF post type configuration as JSON for backup or transfer.', 'secure-custom-fields' ),
-				'category'            => 'scf-post-types',
-				'execute_callback'    => array( $this, 'export_post_type_callback' ),
-				'meta'                => array(
-					'show_in_rest' => true,
-					'mcp'          => array(
-						'public' => true,
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'identifier' => $this->get_scf_identifier_schema(),
+						),
+						'required'   => array( 'identifier' ),
 					),
-					'annotations'  => array(
-						'readonly'    => true,
-						'destructive' => false,
-						'idempotent'  => true,
+					'output_schema'       => $this->get_post_type_with_internal_fields_schema(),
+				)
+			);
+		}
+
+		/**
+		 * Register the create post type ability.
+		 *
+		 * @since 6.6.0
+		 */
+		private function register_create_post_type_ability() {
+			$input_schema = $this->get_post_type_schema();
+
+			wp_register_ability(
+				'scf/create-post-type',
+				array(
+					'label'               => __( 'Create Post Type', 'secure-custom-fields' ),
+					'description'         => __( 'Creates a new custom post type in SCF with the provided configuration.', 'secure-custom-fields' ),
+					'category'            => 'scf-post-types',
+					'execute_callback'    => array( $this, 'create_post_type_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array(
+							'public' => true,
+						),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => false,
+						),
 					),
-				),
-				'permission_callback' => 'scf_current_user_has_capability',
-				'input_schema'        => array(
-					'type'       => 'object',
-					'properties' => array(
-						'identifier' => $this->get_scf_identifier_schema(),
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => $input_schema,
+					'output_schema'       => $this->get_post_type_with_internal_fields_schema(),
+				)
+			);
+		}
+
+		/**
+		 * Register the update post type ability.
+		 *
+		 * @since 6.6.0
+		 */
+		private function register_update_post_type_ability() {
+
+			// For updates, only ID is required, everything else is optional
+			$input_schema             = $this->get_post_type_with_internal_fields_schema();
+			$input_schema['required'] = array( 'ID' );
+
+			wp_register_ability(
+				'scf/update-post-type',
+				array(
+					'label'               => __( 'Update Post Type', 'secure-custom-fields' ),
+					'description'         => __( 'Updates an existing SCF post type with new configuration.', 'secure-custom-fields' ),
+					'category'            => 'scf-post-types',
+					'execute_callback'    => array( $this, 'update_post_type_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array(
+							'public' => true,
+						),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => true,
+						),
 					),
-					'required'   => array( 'identifier' ),
-				),
-				'output_schema'       => $this->get_post_type_schema(),
-			)
-		);
-	}
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => $input_schema,
+					'output_schema'       => $this->get_post_type_with_internal_fields_schema(),
+				)
+			);
+		}
 
-	/**
-	 * Register the import post type ability.
-	 *
-	 * @since 6.6.0
-	 */
-	private function register_import_post_type_ability() {
-		wp_register_ability(
-			'scf/import-post-type',
-			array(
-				'label'               => __( 'Import Post Type', 'secure-custom-fields' ),
-				'description'         => __( 'Imports an SCF post type from JSON configuration data.', 'secure-custom-fields' ),
-				'category'            => 'scf-post-types',
-				'execute_callback'    => array( $this, 'import_post_type_callback' ),
-				'meta'                => array(
-					'show_in_rest' => true,
-					'mcp'          => array(
-						'public' => true,
+		/**
+		 * Register the delete post type ability.
+		 *
+		 * @since 6.6.0
+		 */
+		private function register_delete_post_type_ability() {
+			wp_register_ability(
+				'scf/delete-post-type',
+				array(
+					'label'               => __( 'Delete Post Type', 'secure-custom-fields' ),
+					'description'         => __( 'Permanently deletes an SCF post type. This action cannot be undone.', 'secure-custom-fields' ),
+					'category'            => 'scf-post-types',
+					'execute_callback'    => array( $this, 'delete_post_type_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array(
+							'public' => true,
+						),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => true,
+							'idempotent'  => true,
+						),
 					),
-					'annotations'  => array(
-						'readonly'    => false,
-						'destructive' => false,
-						'idempotent'  => false,
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'identifier' => $this->get_scf_identifier_schema(),
+						),
+						'required'   => array( 'identifier' ),
 					),
-				),
-				'permission_callback' => 'scf_current_user_has_capability',
-				'input_schema'        => $this->get_post_type_with_internal_fields_schema(),
-				'output_schema'       => $this->get_post_type_with_internal_fields_schema(),
-			)
-		);
+					'output_schema'       => array(
+						'type'        => 'boolean',
+						'description' => __( 'True if post type was successfully deleted.', 'secure-custom-fields' ),
+					),
+				)
+			);
+		}
+
+		/**
+		 * Register the duplicate post type ability.
+		 *
+		 * @since 6.6.0
+		 */
+		private function register_duplicate_post_type_ability() {
+			wp_register_ability(
+				'scf/duplicate-post-type',
+				array(
+					'label'               => __( 'Duplicate Post Type', 'secure-custom-fields' ),
+					'description'         => __( 'Creates a copy of an existing SCF post type with optional modifications.', 'secure-custom-fields' ),
+					'category'            => 'scf-post-types',
+					'execute_callback'    => array( $this, 'duplicate_post_type_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array(
+							'public' => true,
+						),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => false,
+						),
+					),
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'identifier'  => $this->get_scf_identifier_schema(),
+							'new_post_id' => array(
+								'type'        => 'integer',
+								'description' => __( 'Optional new post ID for the duplicated post type.', 'secure-custom-fields' ),
+							),
+						),
+						'required'   => array( 'identifier' ),
+					),
+					'output_schema'       => $this->get_post_type_with_internal_fields_schema(),
+				)
+			);
+		}
+
+		/**
+		 * Register the export post type ability.
+		 *
+		 * @since 6.6.0
+		 */
+		private function register_export_post_type_ability() {
+			wp_register_ability(
+				'scf/export-post-type',
+				array(
+					'label'               => __( 'Export Post Type', 'secure-custom-fields' ),
+					'description'         => __( 'Exports an SCF post type configuration as JSON for backup or transfer.', 'secure-custom-fields' ),
+					'category'            => 'scf-post-types',
+					'execute_callback'    => array( $this, 'export_post_type_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array(
+							'public' => true,
+						),
+						'annotations'  => array(
+							'readonly'    => true,
+							'destructive' => false,
+							'idempotent'  => true,
+						),
+					),
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'identifier' => $this->get_scf_identifier_schema(),
+						),
+						'required'   => array( 'identifier' ),
+					),
+					'output_schema'       => $this->get_post_type_schema(),
+				)
+			);
+		}
+
+		/**
+		 * Register the import post type ability.
+		 *
+		 * @since 6.6.0
+		 */
+		private function register_import_post_type_ability() {
+			wp_register_ability(
+				'scf/import-post-type',
+				array(
+					'label'               => __( 'Import Post Type', 'secure-custom-fields' ),
+					'description'         => __( 'Imports an SCF post type from JSON configuration data.', 'secure-custom-fields' ),
+					'category'            => 'scf-post-types',
+					'execute_callback'    => array( $this, 'import_post_type_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array(
+							'public' => true,
+						),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => false,
+						),
+					),
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => $this->get_post_type_with_internal_fields_schema(),
+					'output_schema'       => $this->get_post_type_with_internal_fields_schema(),
+				)
+			);
+		}
+
+		/**
+		 * Callback for the list post types ability.
+		 *
+		 * @since 6.6.0
+		 *
+		 * @param array $input The input parameters.
+		 * @return array The response data.
+		 */
+		public function list_post_types_callback( $input ) {
+			$filter = isset( $input['filter'] ) ? $input['filter'] : array();
+
+			$post_types = acf_get_acf_post_types( $filter );
+			return is_array( $post_types ) ? $post_types : array();
+		}
+
+		/**
+		 * Callback for the get post type ability.
+		 *
+		 * @since 6.6.0
+		 *
+		 * @param array $input The input parameters.
+		 * @return array The response data.
+		 */
+		public function get_post_type_callback( $input ) {
+			$post_type = acf_get_post_type( $input['identifier'] );
+
+			if ( ! $post_type ) {
+				return new WP_Error( 'post_type_not_found', __( 'Post type not found.', 'secure-custom-fields' ) );
+			}
+
+			return $post_type;
+		}
+
+		/**
+		 * Callback for the create post type ability.
+		 *
+		 * @since 6.6.0
+		 *
+		 * @param array $input The input parameters.
+		 * @return array The response data.
+		 */
+		public function create_post_type_callback( $input ) {
+			// Check if post type already exists.
+			if ( acf_get_post_type( $input['key'] ) ) {
+				return new WP_Error( 'post_type_exists', __( 'A post type with this key already exists.', 'secure-custom-fields' ) );
+			}
+
+			$post_type = acf_update_post_type( $input );
+
+			if ( ! $post_type ) {
+				return new WP_Error( 'create_post_type_failed', __( 'Failed to create post type.', 'secure-custom-fields' ) );
+			}
+
+			return $post_type;
+		}
+
+		/**
+		 * Callback for the update post type ability.
+		 *
+		 * @since 6.6.0
+		 *
+		 * @param array $input The input parameters.
+		 * @return array|WP_Error The post type data on success, WP_Error on failure.
+		 */
+		public function update_post_type_callback( $input ) {
+			$existing_post_type = acf_get_post_type( $input['ID'] );
+			if ( ! $existing_post_type ) {
+				return new WP_Error( 'post_type_not_found', __( 'Post type not found.', 'secure-custom-fields' ) );
+			}
+
+			// Merge input with existing post type data to preserve unmodified fields.
+			$input = array_merge( $existing_post_type, $input );
+
+			$post_type = acf_update_post_type( $input );
+
+			if ( ! $post_type ) {
+				return new WP_Error( 'update_post_type_failed', __( 'Failed to update post type.', 'secure-custom-fields' ) );
+			}
+
+			return $post_type;
+		}
+
+		/**
+		 * Callback for the delete post type ability.
+		 *
+		 * @since 6.6.0
+		 *
+		 * @param array $input The input parameters.
+		 * @return bool|WP_Error True on success, WP_Error on failure.
+		 */
+		public function delete_post_type_callback( $input ) {
+			$result = acf_delete_post_type( $input['identifier'] );
+
+			if ( ! $result ) {
+				return new WP_Error( 'delete_post_type_failed', __( 'Failed to delete post type.', 'secure-custom-fields' ) );
+			}
+
+			return true;
+		}
+
+		/**
+		 * Callback for the duplicate post type ability.
+		 *
+		 * @since 6.6.0
+		 *
+		 * @param array $input The input parameters.
+		 * @return array|WP_Error The duplicated post type data on success, WP_Error on failure.
+		 */
+		public function duplicate_post_type_callback( $input ) {
+			$new_post_id          = isset( $input['new_post_id'] ) ? $input['new_post_id'] : 0;
+			$duplicated_post_type = acf_duplicate_post_type( $input['identifier'], $new_post_id );
+
+			if ( ! $duplicated_post_type ) {
+				return new WP_Error( 'duplicate_post_type_failed', __( 'Failed to duplicate post type.', 'secure-custom-fields' ) );
+			}
+
+			return $duplicated_post_type;
+		}
+
+		/**
+		 * Callback for the export post type ability.
+		 *
+		 * @since 6.6.0
+		 *
+		 * @param array $input The input parameters.
+		 * @return array|WP_Error The export data on success, WP_Error on failure.
+		 */
+		public function export_post_type_callback( $input ) {
+			$post_type = acf_get_post_type( $input['identifier'] );
+			if ( ! $post_type ) {
+				return new WP_Error( 'post_type_not_found', __( 'Post type not found.', 'secure-custom-fields' ) );
+			}
+
+			$export_data = acf_prepare_internal_post_type_for_export( $post_type, 'acf-post-type' );
+
+			if ( ! $export_data ) {
+				return new WP_Error( 'export_post_type_failed', __( 'Failed to prepare post type for export.', 'secure-custom-fields' ) );
+			}
+
+			return $export_data;
+		}
+
+		/**
+		 * Callback for the import post type ability.
+		 *
+		 * @since 6.6.0
+		 *
+		 * @param array|object $input The input parameters.
+		 * @return array|WP_Error The imported post type data on success, WP_Error on failure.
+		 */
+		public function import_post_type_callback( $input ) {
+			// Import the post type (handles both create and update based on presence of ID).
+			$imported_post_type = acf_import_internal_post_type( $input, 'acf-post-type' );
+
+			if ( ! $imported_post_type ) {
+				return new WP_Error( 'import_post_type_failed', __( 'Failed to import post type.', 'secure-custom-fields' ) );
+			}
+
+			return $imported_post_type;
+		}
 	}
 
-	/**
-	 * Callback for the list post types ability.
-	 *
-	 * @since 6.6.0
-	 *
-	 * @param array $input The input parameters.
-	 * @return array The response data.
-	 */
-	public function list_post_types_callback( $input ) {
-		$filter = isset( $input['filter'] ) ? $input['filter'] : array();
+	// Initialize abilities instance.
+	acf_new_instance( 'SCF_Post_Type_Abilities' );
 
-		$post_types = acf_get_acf_post_types( $filter );
-		return is_array( $post_types ) ? $post_types : array();
-	}
 
-	/**
-	 * Callback for the get post type ability.
-	 *
-	 * @since 6.6.0
-	 *
-	 * @param array $input The input parameters.
-	 * @return array The response data.
-	 */
-	public function get_post_type_callback( $input ) {
-		$post_type = acf_get_post_type( $input['identifier'] );
-
-		if ( ! $post_type ) {
-			return new WP_Error( 'post_type_not_found', __( 'Post type not found.', 'secure-custom-fields' ) );
-		}
-
-		return $post_type;
-	}
-
-	/**
-	 * Callback for the create post type ability.
-	 *
-	 * @since 6.6.0
-	 *
-	 * @param array $input The input parameters.
-	 * @return array The response data.
-	 */
-	public function create_post_type_callback( $input ) {
-		// Check if post type already exists.
-		if ( acf_get_post_type( $input['key'] ) ) {
-			return new WP_Error( 'post_type_exists', __( 'A post type with this key already exists.', 'secure-custom-fields' ) );
-		}
-
-		$post_type = acf_update_post_type( $input );
-
-		if ( ! $post_type ) {
-			return new WP_Error( 'create_post_type_failed', __( 'Failed to create post type.', 'secure-custom-fields' ) );
-		}
-
-		return $post_type;
-	}
-
-	/**
-	 * Callback for the update post type ability.
-	 *
-	 * @since 6.6.0
-	 *
-	 * @param array $input The input parameters.
-	 * @return array|WP_Error The post type data on success, WP_Error on failure.
-	 */
-	public function update_post_type_callback( $input ) {
-		$existing_post_type = acf_get_post_type( $input['ID'] );
-		if ( ! $existing_post_type ) {
-			return new WP_Error( 'post_type_not_found', __( 'Post type not found.', 'secure-custom-fields' ) );
-		}
-
-		// Merge input with existing post type data to preserve unmodified fields.
-		$input = array_merge( $existing_post_type, $input );
-
-		$post_type = acf_update_post_type( $input );
-
-		if ( ! $post_type ) {
-			return new WP_Error( 'update_post_type_failed', __( 'Failed to update post type.', 'secure-custom-fields' ) );
-		}
-
-		return $post_type;
-	}
-
-	/**
-	 * Callback for the delete post type ability.
-	 *
-	 * @since 6.6.0
-	 *
-	 * @param array $input The input parameters.
-	 * @return bool|WP_Error True on success, WP_Error on failure.
-	 */
-	public function delete_post_type_callback( $input ) {
-		$result = acf_delete_post_type( $input['identifier'] );
-
-		if ( ! $result ) {
-			return new WP_Error( 'delete_post_type_failed', __( 'Failed to delete post type.', 'secure-custom-fields' ) );
-		}
-
-		return true;
-	}
-
-	/**
-	 * Callback for the duplicate post type ability.
-	 *
-	 * @since 6.6.0
-	 *
-	 * @param array $input The input parameters.
-	 * @return array|WP_Error The duplicated post type data on success, WP_Error on failure.
-	 */
-	public function duplicate_post_type_callback( $input ) {
-		$new_post_id          = isset( $input['new_post_id'] ) ? $input['new_post_id'] : 0;
-		$duplicated_post_type = acf_duplicate_post_type( $input['identifier'], $new_post_id );
-
-		if ( ! $duplicated_post_type ) {
-			return new WP_Error( 'duplicate_post_type_failed', __( 'Failed to duplicate post type.', 'secure-custom-fields' ) );
-		}
-
-		return $duplicated_post_type;
-	}
-
-	/**
-	 * Callback for the export post type ability.
-	 *
-	 * @since 6.6.0
-	 *
-	 * @param array $input The input parameters.
-	 * @return array|WP_Error The export data on success, WP_Error on failure.
-	 */
-	public function export_post_type_callback( $input ) {
-		$post_type = acf_get_post_type( $input['identifier'] );
-		if ( ! $post_type ) {
-			return new WP_Error( 'post_type_not_found', __( 'Post type not found.', 'secure-custom-fields' ) );
-		}
-
-		$export_data = acf_prepare_internal_post_type_for_export( $post_type, 'acf-post-type' );
-
-		if ( ! $export_data ) {
-			return new WP_Error( 'export_post_type_failed', __( 'Failed to prepare post type for export.', 'secure-custom-fields' ) );
-		}
-
-		return $export_data;
-	}
-
-	/**
-	 * Callback for the import post type ability.
-	 *
-	 * @since 6.6.0
-	 *
-	 * @param array|object $input The input parameters.
-	 * @return array|WP_Error The imported post type data on success, WP_Error on failure.
-	 */
-	public function import_post_type_callback( $input ) {
-		// Import the post type (handles both create and update based on presence of ID).
-		$imported_post_type = acf_import_internal_post_type( $input, 'acf-post-type' );
-
-		if ( ! $imported_post_type ) {
-			return new WP_Error( 'import_post_type_failed', __( 'Failed to import post type.', 'secure-custom-fields' ) );
-		}
-
-		return $imported_post_type;
-	}
-}
-
-acf_new_instance( 'SCF_Post_Type_Abilities' );
+endif; // class_exists check

--- a/includes/class-scf-json-schema-validator.php
+++ b/includes/class-scf-json-schema-validator.php
@@ -21,6 +21,12 @@ if ( ! class_exists( 'SCF_JSON_Schema_Validator' ) ) :
 	 */
 	class SCF_JSON_Schema_Validator {
 
+		/**
+		 * Required schema files for post type abilities
+		 *
+		 * @var array
+		 */
+		public const REQUIRED_SCHEMAS = array( 'post-type', 'internal-fields', 'scf-identifier' );
 
 		/**
 		 * The last validation errors.
@@ -38,9 +44,17 @@ if ( ! class_exists( 'SCF_JSON_Schema_Validator' ) ) :
 
 		/**
 		 * Constructor.
+		 *
+		 * Validates that all required schemas are available on initialization.
+		 * If schemas are missing, registers an admin notice and prevents usage.
 		 */
 		public function __construct() {
 			$this->schema_path = acf_get_path( 'schemas/' );
+
+			// Validate schemas exist on initialization (skip during static analysis)
+			if ( defined( 'ABSPATH' ) && ! $this->validate_required_schemas() ) {
+				add_action( 'admin_notices', array( $this, 'show_schema_error' ) );
+			}
 		}
 
 
@@ -128,6 +142,11 @@ if ( ! class_exists( 'SCF_JSON_Schema_Validator' ) ) :
 			}
 			WP_Filesystem();
 			global $wp_filesystem;
+
+			if ( null === $wp_filesystem ) {
+				return null;
+			}
+
 			$schema_content = $wp_filesystem->get_contents( $schema_file );
 			if ( false === $schema_content ) {
 				return null;
@@ -140,6 +159,37 @@ if ( ! class_exists( 'SCF_JSON_Schema_Validator' ) ) :
 			}
 		}
 
+
+		/**
+		 * Validates that all required schemas are available.
+		 *
+		 * @since 6.6.0
+		 * @return bool True if all required schemas load successfully, false otherwise.
+		 */
+		public function validate_required_schemas() {
+			foreach ( self::REQUIRED_SCHEMAS as $schema_name ) {
+				if ( ! $this->load_schema( $schema_name ) ) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		/**
+		 * Display admin notice when required schemas are not available.
+		 *
+		 * @since 6.6.0
+		 */
+		public function show_schema_error() {
+			?>
+		<div class="notice notice-error is-dismissible">
+			<p>
+				<strong><?php esc_html_e( 'Secure Custom Fields Error:', 'secure-custom-fields' ); ?></strong>
+				<?php esc_html_e( 'Required schema files are missing. Schema validation will not be available. Please ensure all schema files are present in the plugin directory.', 'secure-custom-fields' ); ?>
+			</p>
+		</div>
+			<?php
+		}
 		/**
 		 * Gets the validation errors from the last validation attempt.
 		 *
@@ -245,5 +295,8 @@ if ( ! class_exists( 'SCF_JSON_Schema_Validator' ) ) :
 			return $this->validate_json( $json_content, $schema_name );
 		}
 	}
+
+	// Initialize validator instance.
+	acf_new_instance( 'SCF_JSON_Schema_Validator' );
 
 endif; // class_exists check

--- a/tests/php/includes/test-scf-json-schema-validator.php
+++ b/tests/php/includes/test-scf-json-schema-validator.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Tests for SCF_JSON_Schema_Validator class
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Test SCF JSON Schema Validator
+ */
+class Test_SCF_JSON_Schema_Validator extends BaseTestCase {
+
+	/**
+	 * Instance of SCF_JSON_Schema_Validator for testing
+	 *
+	 * @var SCF_JSON_Schema_Validator
+	 */
+	private $validator;
+
+	/**
+	 * Setup test fixtures
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->validator = new SCF_JSON_Schema_Validator();
+	}
+
+	/**
+	 * Teardown after tests
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->validator = null;
+	}
+
+	/**
+	 * Test that load_schema returns object when schema exists
+	 */
+	public function test_load_schema_returns_object_for_existing_schema() {
+		$schema = $this->validator->load_schema( 'post-type' );
+
+		$this->assertIsObject( $schema, 'load_schema should return an object for existing schema' );
+	}
+
+	/**
+	 * Test that load_schema returns null when schema does not exist
+	 */
+	public function test_load_schema_returns_null_for_missing_schema() {
+		$schema = $this->validator->load_schema( 'nonexistent-schema' );
+
+		$this->assertNull( $schema, 'load_schema should return null for missing schema' );
+	}
+
+	/**
+	 * Test that all required schemas can be loaded
+	 */
+	public function test_all_required_schemas_can_be_loaded() {
+		$required_schemas = SCF_JSON_Schema_Validator::REQUIRED_SCHEMAS;
+
+		foreach ( $required_schemas as $schema_name ) {
+			$schema = $this->validator->load_schema( $schema_name );
+			$this->assertIsObject(
+				$schema,
+				"Schema '{$schema_name}' should be loadable"
+			);
+		}
+	}
+
+	/**
+	 * Test that load_schema loads correct structure
+	 */
+	public function test_load_schema_loads_correct_structure() {
+		$schema = $this->validator->load_schema( 'post-type' );
+
+		$this->assertObjectHasProperty( 'definitions', $schema, 'Schema should have definitions' );
+		$this->assertObjectHasProperty( 'postType', $schema->definitions, 'Definitions should have postType' );
+	}
+
+	/**
+	 * Test that validate_required_schemas returns true when all schemas exist
+	 */
+	public function test_validate_required_schemas_returns_true_when_all_exist() {
+		$result = $this->validator->validate_required_schemas();
+
+		$this->assertTrue( $result, 'validate_required_schemas should return true when all required schemas exist' );
+	}
+
+	/**
+	 * Test validate_data with valid data
+	 */
+	public function test_validate_data_accepts_valid_data() {
+		// Valid post type data structure
+		$valid_data = array(
+			'key'   => 'test_post_type',
+			'label' => 'Test Post Type',
+		);
+
+		$result = $this->validator->validate_data( $valid_data, 'post-type' );
+
+		// Result should be boolean (valid or invalid)
+		$this->assertIsBool( $result );
+	}
+
+	/**
+	 * Test that validation errors are captured
+	 */
+	public function test_validation_errors_are_captured() {
+		// Invalid data - missing required fields
+		$invalid_data = array(
+			'extra_field' => 'value',
+		);
+
+		$result = $this->validator->validate_data( $invalid_data, 'post-type' );
+
+		// Should be invalid
+		$this->assertFalse( $result, 'Invalid data should fail validation' );
+
+		// Should have captured errors
+		$this->assertTrue(
+			$this->validator->has_validation_errors(),
+			'Validator should have captured validation errors'
+		);
+	}
+
+	/**
+	 * Test get_validation_errors returns array
+	 */
+	public function test_get_validation_errors_returns_array() {
+		$errors = $this->validator->get_validation_errors();
+
+		$this->assertIsArray( $errors, 'get_validation_errors should return an array' );
+	}
+
+	/**
+	 * Test validate_json with valid JSON string
+	 */
+	public function test_validate_json_with_valid_json_string() {
+		$valid_json = wp_json_encode(
+			array(
+				'key'   => 'test_post_type',
+				'label' => 'Test Post Type',
+			)
+		);
+
+		$result = $this->validator->validate_json( $valid_json, 'post-type' );
+
+		$this->assertIsBool( $result );
+	}
+
+	/**
+	 * Test validate_json with invalid JSON string
+	 */
+	public function test_validate_json_with_invalid_json_string() {
+		$invalid_json = '{invalid json}';
+
+		$result = $this->validator->validate_json( $invalid_json, 'post-type' );
+
+		$this->assertFalse( $result, 'Invalid JSON should fail validation' );
+		$this->assertTrue(
+			$this->validator->has_validation_errors(),
+			'Should capture JSON parsing error'
+		);
+	}
+
+	/**
+	 * Test get_validation_errors_string returns formatted string
+	 */
+	public function test_get_validation_errors_string_returns_formatted_message() {
+		// Create an error scenario
+		$invalid_data = array();
+		$this->validator->validate_data( $invalid_data, 'post-type' );
+
+		if ( $this->validator->has_validation_errors() ) {
+			$error_string = $this->validator->get_validation_errors_string();
+			$this->assertIsString( $error_string, 'Should return a string' );
+		}
+	}
+
+	/**
+	 * Test that validator catches missing schema files gracefully
+	 */
+	public function test_validator_handles_missing_schema_gracefully() {
+		// Try to load a schema that doesn't exist
+		$schema = $this->validator->load_schema( 'definitely-does-not-exist' );
+
+		// Should return null instead of throwing error
+		$this->assertNull( $schema, 'Should return null for missing schema without throwing' );
+	}
+
+	/**
+	 * Test validate method auto-detects file paths
+	 */
+	public function test_validate_method_detects_file_path() {
+		// Create a temporary JSON file
+		$temp_file  = tempnam( sys_get_temp_dir(), 'scf_test_' );
+		$valid_data = array(
+			'key'   => 'test_post_type',
+			'label' => 'Test Post Type',
+		);
+		// Use WP_Filesystem for file operations.
+		global $wp_filesystem;
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		WP_Filesystem();
+		$wp_filesystem->put_contents( $temp_file, wp_json_encode( $valid_data ) );
+
+		$result = $this->validator->validate( $temp_file, 'post-type' );
+
+		$this->assertIsBool( $result );
+
+		// Cleanup
+		wp_delete_file( $temp_file );
+	}
+
+	/**
+	 * Test validate method detects JSON strings
+	 */
+	public function test_validate_method_detects_json_string() {
+		$json_string = wp_json_encode(
+			array(
+				'key'   => 'test_post_type',
+				'label' => 'Test Post Type',
+			)
+		);
+
+		$result = $this->validator->validate( $json_string, 'post-type' );
+
+		$this->assertIsBool( $result );
+	}
+
+	/**
+	 * Test validate method detects parsed data
+	 */
+	public function test_validate_method_detects_parsed_data() {
+		$data = array(
+			'key'   => 'test_post_type',
+			'label' => 'Test Post Type',
+		);
+
+		$result = $this->validator->validate( $data, 'post-type' );
+
+		$this->assertIsBool( $result );
+	}
+}

--- a/tests/php/includes/test-scf-json-schema-validator.php
+++ b/tests/php/includes/test-scf-json-schema-validator.php
@@ -242,4 +242,268 @@ class Test_SCF_JSON_Schema_Validator extends BaseTestCase {
 
 		$this->assertIsBool( $result );
 	}
+
+	/**
+	 * Test validate_file with missing file
+	 */
+	public function test_validate_file_with_missing_file() {
+		$result = $this->validator->validate_file( '/nonexistent/path/file.json', 'post-type' );
+
+		$this->assertFalse( $result, 'Should return false for missing file' );
+		$this->assertTrue(
+			$this->validator->has_validation_errors(),
+			'Should capture error about missing file'
+		);
+
+		$errors = $this->validator->get_validation_errors();
+		$this->assertNotEmpty( $errors, 'Should have at least one error' );
+	}
+
+	/**
+	 * Test validate_file with valid JSON file
+	 */
+	public function test_validate_file_with_valid_json_file() {
+		$temp_file  = tempnam( sys_get_temp_dir(), 'scf_test_' );
+		$valid_data = array(
+			'key'   => 'test_post_type',
+			'label' => 'Test Post Type',
+		);
+
+		global $wp_filesystem;
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		WP_Filesystem();
+		$wp_filesystem->put_contents( $temp_file, wp_json_encode( $valid_data ) );
+
+		$result = $this->validator->validate_file( $temp_file, 'post-type' );
+
+		$this->assertIsBool( $result );
+
+		// Cleanup
+		wp_delete_file( $temp_file );
+	}
+
+	/**
+	 * Test validate_file with invalid JSON in file
+	 */
+	public function test_validate_file_with_invalid_json_in_file() {
+		$temp_file = tempnam( sys_get_temp_dir(), 'scf_test_' );
+
+		global $wp_filesystem;
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		WP_Filesystem();
+		$wp_filesystem->put_contents( $temp_file, '{invalid json content}' );
+
+		$result = $this->validator->validate_file( $temp_file, 'post-type' );
+
+		$this->assertFalse( $result, 'Should return false for file with invalid JSON' );
+		$this->assertTrue(
+			$this->validator->has_validation_errors(),
+			'Should capture JSON parsing error'
+		);
+
+		// Cleanup
+		wp_delete_file( $temp_file );
+	}
+
+	/**
+	 * Test get_validation_errors_string with custom separator
+	 */
+	public function test_get_validation_errors_string_with_custom_separator() {
+		// Create an error scenario
+		$invalid_data = array();
+		$this->validator->validate_data( $invalid_data, 'post-type' );
+
+		if ( $this->validator->has_validation_errors() ) {
+			$error_string = $this->validator->get_validation_errors_string( ' | ' );
+			$this->assertIsString( $error_string, 'Should return a string' );
+			$this->assertStringContainsString( '|', $error_string, 'Should use custom separator' );
+		}
+	}
+
+	/**
+	 * Test has_validation_errors returns false when no errors
+	 */
+	public function test_has_validation_errors_returns_false_when_no_errors() {
+		// Create a new validator instance to ensure clean state
+		$validator = new SCF_JSON_Schema_Validator();
+
+		// Test that a fresh validator has no errors
+		$this->assertFalse(
+			$validator->has_validation_errors(),
+			'Should return false on fresh validator with no validation attempts'
+		);
+	}
+
+	/**
+	 * Test validate_data clears previous errors
+	 */
+	public function test_validate_data_clears_previous_errors() {
+		// First validation with invalid data
+		$invalid_data = array();
+		$this->validator->validate_data( $invalid_data, 'post-type' );
+		$first_error_count = count( $this->validator->get_validation_errors() );
+		$this->assertTrue(
+			$this->validator->has_validation_errors(),
+			'First validation should have errors'
+		);
+
+		// Second validation with different invalid data (empty again)
+		$second_invalid_data = array();
+		$this->validator->validate_data( $second_invalid_data, 'post-type' );
+		$second_error_count = count( $this->validator->get_validation_errors() );
+
+		// Errors should be cleared (not accumulate)
+		$this->assertTrue(
+			$this->validator->has_validation_errors(),
+			'Should still have validation errors'
+		);
+		// The key point: errors from first validation should be cleared, not accumulated
+		// If clearing works, the error count should be similar or different, but not double
+		$this->assertLessThanOrEqual(
+			$first_error_count * 1.5,
+			$second_error_count,
+			'Errors should be cleared, not accumulated'
+		);
+	}
+
+	/**
+	 * Test validate_json clears previous errors
+	 */
+	public function test_validate_json_clears_previous_errors() {
+		// First validation with invalid JSON
+		$invalid_json = '{bad json}';
+		$this->validator->validate_json( $invalid_json, 'post-type' );
+		$first_error_count = count( $this->validator->get_validation_errors() );
+		$this->assertTrue(
+			$this->validator->has_validation_errors(),
+			'First validation should have errors'
+		);
+
+		// Second validation with different invalid JSON (to ensure errors are cleared, not accumulated)
+		$another_invalid_json = '{also bad}';
+		$this->validator->validate_json( $another_invalid_json, 'post-type' );
+		$second_error_count = count( $this->validator->get_validation_errors() );
+
+		// Errors should be cleared (not accumulate)
+		$this->assertTrue(
+			$this->validator->has_validation_errors(),
+			'Should have validation errors'
+		);
+		// The key point: errors should be cleared between validations, not accumulated
+		$this->assertLessThanOrEqual(
+			$first_error_count * 1.5,
+			$second_error_count,
+			'Errors should be cleared between validations, not accumulated'
+		);
+	}
+
+	/**
+	 * Test validation error structure
+	 */
+	public function test_validation_error_structure() {
+		// Create an error
+		$invalid_data = array();
+		$this->validator->validate_data( $invalid_data, 'post-type' );
+
+		if ( $this->validator->has_validation_errors() ) {
+			$errors = $this->validator->get_validation_errors();
+			$error  = reset( $errors );
+
+			$this->assertIsArray( $error, 'Error should be an array' );
+			$this->assertArrayHasKey( 'field', $error, 'Error should have field key' );
+			$this->assertArrayHasKey( 'message', $error, 'Error should have message key' );
+		}
+	}
+
+	/**
+	 * Test validate with non-existent file falls back to JSON string parsing
+	 */
+	public function test_validate_non_existent_file_falls_back_to_json_parsing() {
+		$json_string = wp_json_encode(
+			array(
+				'key'   => 'test_post_type',
+				'label' => 'Test Post Type',
+			)
+		);
+
+		// Pass a JSON string that looks like it could be a path but isn't
+		$result = $this->validator->validate( $json_string, 'post-type' );
+
+		// Should treat it as JSON string and validate successfully
+		$this->assertIsBool( $result, 'Should return bool even for non-file strings' );
+	}
+
+	/**
+	 * Test load_schema returns consistent results across multiple calls
+	 */
+	public function test_load_schema_returns_consistent_results() {
+		$schema1 = $this->validator->load_schema( 'post-type' );
+		$schema2 = $this->validator->load_schema( 'post-type' );
+
+		$this->assertEquals(
+			wp_json_encode( $schema1 ),
+			wp_json_encode( $schema2 ),
+			'Multiple calls to load_schema should return equivalent objects'
+		);
+	}
+
+	/**
+	 * Test validate_data with nested array structures
+	 */
+	public function test_validate_data_with_nested_array_structures() {
+		$nested_data = array(
+			'key'    => 'test_post_type',
+			'label'  => 'Test Post Type',
+			'fields' => array(
+				array(
+					'key'   => 'field_1',
+					'label' => 'Field 1',
+				),
+			),
+		);
+
+		$result = $this->validator->validate_data( $nested_data, 'post-type' );
+
+		$this->assertIsBool( $result, 'Should handle nested structures' );
+	}
+
+	/**
+	 * Test validate_data converts arrays to objects properly
+	 */
+	public function test_validate_data_converts_arrays_to_objects() {
+		// This tests the internal array-to-object conversion
+		$array_data = array(
+			'key'   => 'test_post_type',
+			'label' => 'Test Post Type',
+		);
+
+		// Validate should internally convert array to object
+		$result = $this->validator->validate_data( $array_data, 'post-type' );
+
+		$this->assertIsBool( $result, 'Should successfully convert and validate array data' );
+	}
+
+	/**
+	 * Test REQUIRED_SCHEMAS constant
+	 */
+	public function test_required_schemas_constant_has_all_required_schemas() {
+		$required = SCF_JSON_Schema_Validator::REQUIRED_SCHEMAS;
+
+		$this->assertIsArray( $required, 'REQUIRED_SCHEMAS should be an array' );
+		$this->assertNotEmpty( $required, 'REQUIRED_SCHEMAS should not be empty' );
+		$this->assertContains( 'post-type', $required, 'Should include post-type' );
+		$this->assertContains( 'internal-fields', $required, 'Should include internal-fields' );
+		$this->assertContains( 'scf-identifier', $required, 'Should include scf-identifier' );
+	}
+
+	/**
+	 * Test constructor initializes schema_path correctly
+	 */
+	public function test_constructor_initializes_schema_path() {
+		// The validator is already initialized in setUp
+		// We just verify it can load schemas (which means path is correct)
+		$schema = $this->validator->load_schema( 'post-type' );
+
+		$this->assertIsObject( $schema, 'Schema path should be correctly initialized' );
+	}
 }


### PR DESCRIPTION
## What
Adds validation check to `SCF_Post_Type_Abilities` that ensures all required schema files exist before registering WordPress Abilities API hooks.

## Why
Without this, missing schemas cause abilitiies registration to crash at runtime. Now, if schemas are missing, abilities simply don't register and will display an admin notice

## How
- Added schema validation in `__construct()` that checks `validate_required_schemas()` before registering hooks
- Changed from `require_once` + `new` to `acf_get_instance()` for validator initialization
- Early return if validation fails (abilities won't register)

## Testing Instructions
1. Run `composer test:php` - all 58 tests pass
2. Verify abilities register normally when all schema files present
3. Verify abilities don't register if schema files missing