### PR TITLE
Codecov: Remove `coverage.changes` section from codecov settings

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -25,12 +25,6 @@ coverage:
                 threshold: 5%
                 if_ci_failed: ignore
 
-        changes:
-            default:
-                target: 70%
-                threshold: 5%
-                if_ci_failed: ignore
-
 ignore:
     - '*.min.css'
     - '*.min.js'


### PR DESCRIPTION
## What
Removes the `changes` section from codecov settings

## Why
Codecov's YAML validator was complaining about the target options for this setting. This patch removes the setting entirely, as it's only for anomalies outside the patch in question.

## Testing
When the Codecov comment appears in this PR, the link for this PR's report within Codecov shouldn't show the same error as with the rest of PRs:
<img width="980" height="96" alt="image" src="https://github.com/user-attachments/assets/41dec49a-3b91-4a90-aa98-f3d63aef4996" />
