### PR TITLE
Post Type Abilities: Add e2e tests

### DIFF
--- a/tests/e2e/abilities-post-types.spec.ts
+++ b/tests/e2e/abilities-post-types.spec.ts
@@ -21,9 +21,7 @@ test.describe( 'Post Type Abilities', () => {
 		post_type: 'e2e_test',
 	};
 
-	// -------------------------------------------------------------------------
-	// Helper Functions
-	// -------------------------------------------------------------------------
+	// Helper functions
 
 	/**
 	 * Check if Abilities API exists (for older WordPress versions).
@@ -66,9 +64,7 @@ test.describe( 'Post Type Abilities', () => {
 		}
 	}
 
-	// -------------------------------------------------------------------------
-	// Post Type API Helpers
-	// -------------------------------------------------------------------------
+	// Post type API helpers
 
 	async function listPostTypes( requestUtils, filter = {} ) {
 		return await requestUtils.rest( {
@@ -145,9 +141,7 @@ test.describe( 'Post Type Abilities', () => {
 		}
 	}
 
-	// -------------------------------------------------------------------------
-	// Test Setup
-	// -------------------------------------------------------------------------
+	// Test setup
 
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activatePlugin( PLUGIN_SLUG );
@@ -160,9 +154,7 @@ test.describe( 'Post Type Abilities', () => {
 		);
 	} );
 
-	// -------------------------------------------------------------------------
-	// LIST POST TYPES - POST with body
-	// -------------------------------------------------------------------------
+	// List post types - POST with body
 
 	test.describe( 'scf/list-post-types', () => {
 		test.beforeEach( async ( { requestUtils } ) => {
@@ -188,9 +180,7 @@ test.describe( 'Post Type Abilities', () => {
 		} );
 	} );
 
-	// -------------------------------------------------------------------------
-	// GET POST TYPE - POST with body
-	// -------------------------------------------------------------------------
+	// Get post type - POST with body
 
 	test.describe( 'scf/get-post-type', () => {
 		test.beforeEach( async ( { requestUtils } ) => {
@@ -214,9 +204,7 @@ test.describe( 'Post Type Abilities', () => {
 		} );
 	} );
 
-	// -------------------------------------------------------------------------
-	// EXPORT POST TYPE - GET with query params (readonly)
-	// -------------------------------------------------------------------------
+	// Export post type - GET with query params (readonly)
 
 	test.describe( 'scf/export-post-type', () => {
 		test.beforeEach( async ( { requestUtils } ) => {
@@ -241,9 +229,7 @@ test.describe( 'Post Type Abilities', () => {
 		} );
 	} );
 
-	// -------------------------------------------------------------------------
-	// CREATE POST TYPE - POST with body
-	// -------------------------------------------------------------------------
+	// Create post type - POST with body
 
 	test.describe( 'scf/create-post-type', () => {
 		test.beforeEach( async ( { requestUtils } ) => {
@@ -267,9 +253,7 @@ test.describe( 'Post Type Abilities', () => {
 		} );
 	} );
 
-	// -------------------------------------------------------------------------
-	// UPDATE POST TYPE - POST with body
-	// -------------------------------------------------------------------------
+	// Update post type - POST with body
 
 	test.describe( 'scf/update-post-type', () => {
 		let testPostTypeId;
@@ -302,9 +286,7 @@ test.describe( 'Post Type Abilities', () => {
 		} );
 	} );
 
-	// -------------------------------------------------------------------------
-	// DELETE POST TYPE - DELETE with query params (destructive)
-	// -------------------------------------------------------------------------
+	// Delete post type - DELETE with query params (destructive)
 
 	test.describe( 'scf/delete-post-type', () => {
 		test.beforeEach( async ( { requestUtils } ) => {
@@ -341,12 +323,10 @@ test.describe( 'Post Type Abilities', () => {
 		} );
 	} );
 
-	// -------------------------------------------------------------------------
-	// DUPLICATE POST TYPE - POST with body
+	// Duplicate post type - POST with body
 	//
 	// Note: The duplicate receives a new unique key but retains the same
 	// post_type slug. The duplicate won't register until slug is changed.
-	// -------------------------------------------------------------------------
 
 	test.describe( 'scf/duplicate-post-type', () => {
 		let duplicatedKey;
@@ -380,9 +360,7 @@ test.describe( 'Post Type Abilities', () => {
 		} );
 	} );
 
-	// -------------------------------------------------------------------------
-	// IMPORT POST TYPE - POST with body
-	// -------------------------------------------------------------------------
+	// Import post type - POST with body
 
 	test.describe( 'scf/import-post-type', () => {
 		test.beforeEach( async ( { requestUtils } ) => {

--- a/tests/e2e/abilities-post-types.spec.ts
+++ b/tests/e2e/abilities-post-types.spec.ts
@@ -1,0 +1,407 @@
+/**
+ * E2E tests for SCF Post Type Abilities
+ *
+ * Tests the WordPress Abilities API endpoints for SCF post type management.
+ *
+ * HTTP Method Reference (per PR #152 in WordPress/abilities-api):
+ * - Read-only abilities (readonly: true) → GET with query params
+ * - Regular abilities (readonly: false, destructive: false) → POST with body
+ * - Destructive abilities (destructive: true) → DELETE with query params
+ */
+const { test, expect } = require( './fixtures' );
+
+test.describe( 'Post Type Abilities', () => {
+	const PLUGIN_SLUG = 'secure-custom-fields';
+	const ABILITIES_BASE = '/wp-abilities/v1/abilities';
+
+	// Reusable test post type - each test creates/cleans its own instance
+	const TEST_POST_TYPE = {
+		key: 'post_type_e2e_test',
+		title: 'E2E Test Type',
+		post_type: 'e2e_test',
+	};
+
+	// -------------------------------------------------------------------------
+	// Helper Functions
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Check if Abilities API exists (for older WordPress versions).
+	 */
+	async function abilitiesApiExists( requestUtils ) {
+		try {
+			await requestUtils.rest( {
+				method: 'GET',
+				path: '/wp-abilities/v1',
+			} );
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	/**
+	 * Assert that a REST request throws a "not found" error with 404 status.
+	 */
+	async function expectNotFound( requestPromise ) {
+		try {
+			await requestPromise;
+			throw new Error( 'Expected not found error but request succeeded' );
+		} catch ( error ) {
+			expect( error.code ).toBe( 'post_type_not_found' );
+			expect( error.data?.status ).toBe( 404 );
+		}
+	}
+
+	/**
+	 * Assert that a REST request throws an "invalid input" error with 400 status.
+	 */
+	async function expectInvalidInput( requestPromise ) {
+		try {
+			await requestPromise;
+			throw new Error( 'Expected invalid input error but request succeeded' );
+		} catch ( error ) {
+			expect( error.code ).toBe( 'ability_invalid_input' );
+			expect( error.data?.status ).toBe( 400 );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Post Type API Helpers
+	// -------------------------------------------------------------------------
+
+	async function listPostTypes( requestUtils, filter = {} ) {
+		return await requestUtils.rest( {
+			method: 'POST',
+			path: `${ ABILITIES_BASE }/scf/list-post-types/run`,
+			data: { input: { filter } },
+		} );
+	}
+
+	async function getPostType( requestUtils, identifier ) {
+		return await requestUtils.rest( {
+			method: 'POST',
+			path: `${ ABILITIES_BASE }/scf/get-post-type/run`,
+			data: { input: { identifier } },
+		} );
+	}
+
+	async function createPostType( requestUtils, postTypeData = TEST_POST_TYPE ) {
+		return await requestUtils.rest( {
+			method: 'POST',
+			path: `${ ABILITIES_BASE }/scf/create-post-type/run`,
+			data: { input: postTypeData },
+		} );
+	}
+
+	async function updatePostType( requestUtils, input ) {
+		return await requestUtils.rest( {
+			method: 'POST',
+			path: `${ ABILITIES_BASE }/scf/update-post-type/run`,
+			data: { input },
+		} );
+	}
+
+	async function deletePostType( requestUtils, identifier ) {
+		return await requestUtils.rest( {
+			method: 'DELETE',
+			path: `${ ABILITIES_BASE }/scf/delete-post-type/run`,
+			params: { 'input[identifier]': identifier },
+		} );
+	}
+
+	async function duplicatePostType( requestUtils, identifier ) {
+		return await requestUtils.rest( {
+			method: 'POST',
+			path: `${ ABILITIES_BASE }/scf/duplicate-post-type/run`,
+			data: { input: { identifier } },
+		} );
+	}
+
+	async function exportPostType( requestUtils, identifier ) {
+		return await requestUtils.rest( {
+			method: 'GET',
+			path: `${ ABILITIES_BASE }/scf/export-post-type/run`,
+			params: { 'input[identifier]': identifier },
+		} );
+	}
+
+	async function importPostType( requestUtils, postTypeData ) {
+		return await requestUtils.rest( {
+			method: 'POST',
+			path: `${ ABILITIES_BASE }/scf/import-post-type/run`,
+			data: { input: postTypeData },
+		} );
+	}
+
+	/**
+	 * Clean up a post type (ignore errors if it doesn't exist).
+	 */
+	async function cleanupPostType( requestUtils, identifier ) {
+		try {
+			await deletePostType( requestUtils, identifier );
+		} catch {
+			// Ignore errors - post type may not exist
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Test Setup
+	// -------------------------------------------------------------------------
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin( PLUGIN_SLUG );
+
+		// Skip all tests if Abilities API is not available (older WordPress versions)
+		const hasAbilitiesApi = await abilitiesApiExists( requestUtils );
+		test.skip(
+			! hasAbilitiesApi,
+			'Abilities API not available in this WordPress version'
+		);
+	} );
+
+	// -------------------------------------------------------------------------
+	// LIST POST TYPES - POST with body
+	// -------------------------------------------------------------------------
+
+	test.describe( 'scf/list-post-types', () => {
+		test.beforeEach( async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+			await createPostType( requestUtils );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+		} );
+
+		test( 'should list all SCF post types', async ( { requestUtils } ) => {
+			const result = await listPostTypes( requestUtils );
+
+			expect( Array.isArray( result ) ).toBe( true );
+			expect( result.some( ( pt ) => pt.key === TEST_POST_TYPE.key ) ).toBe( true );
+		} );
+
+		test( 'should support filter parameter', async ( { requestUtils } ) => {
+			const result = await listPostTypes( requestUtils, { active: true } );
+
+			expect( Array.isArray( result ) ).toBe( true );
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// GET POST TYPE - POST with body
+	// -------------------------------------------------------------------------
+
+	test.describe( 'scf/get-post-type', () => {
+		test.beforeEach( async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+			await createPostType( requestUtils );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+		} );
+
+		test( 'should get a post type by identifier', async ( { requestUtils } ) => {
+			const result = await getPostType( requestUtils, TEST_POST_TYPE.key );
+
+			expect( result ).toHaveProperty( 'post_type', TEST_POST_TYPE.post_type );
+			expect( result ).toHaveProperty( 'title', TEST_POST_TYPE.title );
+		} );
+
+		test( 'should return error for non-existent post type', async ( { requestUtils } ) => {
+			await expectNotFound( getPostType( requestUtils, 'nonexistent_type_abc' ) );
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// EXPORT POST TYPE - GET with query params (readonly)
+	// -------------------------------------------------------------------------
+
+	test.describe( 'scf/export-post-type', () => {
+		test.beforeEach( async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+			await createPostType( requestUtils );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+		} );
+
+		test( 'should export a post type as JSON', async ( { requestUtils } ) => {
+			const result = await exportPostType( requestUtils, TEST_POST_TYPE.key );
+
+			expect( result ).toHaveProperty( 'key', TEST_POST_TYPE.key );
+			expect( result ).toHaveProperty( 'post_type', TEST_POST_TYPE.post_type );
+			expect( result ).toHaveProperty( 'title', TEST_POST_TYPE.title );
+		} );
+
+		test( 'should return error for non-existent post type', async ( { requestUtils } ) => {
+			await expectNotFound( exportPostType( requestUtils, 'nonexistent_export' ) );
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// CREATE POST TYPE - POST with body
+	// -------------------------------------------------------------------------
+
+	test.describe( 'scf/create-post-type', () => {
+		test.beforeEach( async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+		} );
+
+		test( 'should create a new post type', async ( { requestUtils } ) => {
+			const result = await createPostType( requestUtils );
+
+			expect( result ).toHaveProperty( 'post_type', TEST_POST_TYPE.post_type );
+			expect( result ).toHaveProperty( 'title', TEST_POST_TYPE.title );
+			expect( result ).toHaveProperty( 'key', TEST_POST_TYPE.key );
+		} );
+
+		test( 'should return error when required fields are missing', async ( { requestUtils } ) => {
+			await expectInvalidInput( createPostType( requestUtils, { title: 'Missing Key and Post Type' } ) );
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// UPDATE POST TYPE - POST with body
+	// -------------------------------------------------------------------------
+
+	test.describe( 'scf/update-post-type', () => {
+		let testPostTypeId;
+
+		test.beforeEach( async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+			const result = await createPostType( requestUtils );
+			testPostTypeId = result.ID;
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+		} );
+
+		test( 'should update an existing post type', async ( { requestUtils } ) => {
+			const result = await updatePostType( requestUtils, {
+				ID: testPostTypeId,
+				title: 'Updated Title',
+			} );
+
+			expect( result ).toHaveProperty( 'title', 'Updated Title' );
+		} );
+
+		test( 'should return error for non-existent post type ID', async ( { requestUtils } ) => {
+			await expectNotFound( updatePostType( requestUtils, { ID: 999999, title: 'Should Fail' } ) );
+		} );
+
+		test( 'should return error when ID is missing', async ( { requestUtils } ) => {
+			await expectInvalidInput( updatePostType( requestUtils, { title: 'Missing ID' } ) );
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// DELETE POST TYPE - DELETE with query params (destructive)
+	// -------------------------------------------------------------------------
+
+	test.describe( 'scf/delete-post-type', () => {
+		test.beforeEach( async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+			await createPostType( requestUtils );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+		} );
+
+		test( 'should delete an existing post type', async ( { requestUtils } ) => {
+			const result = await deletePostType( requestUtils, TEST_POST_TYPE.key );
+			expect( result ).toBe( true );
+
+			// Verify it's actually deleted
+			await expectNotFound( getPostType( requestUtils, TEST_POST_TYPE.key ) );
+		} );
+
+		test( 'should return error for non-existent post type', async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+
+			await expectNotFound( deletePostType( requestUtils, 'nonexistent_type_xyz' ) );
+		} );
+
+		test( 'should return error when identifier is missing', async ( { requestUtils } ) => {
+			await expectInvalidInput(
+				requestUtils.rest( {
+					method: 'DELETE',
+					path: `${ ABILITIES_BASE }/scf/delete-post-type/run`,
+					params: { input: '' },
+				} )
+			);
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// DUPLICATE POST TYPE - POST with body
+	//
+	// Note: The duplicate receives a new unique key but retains the same
+	// post_type slug. The duplicate won't register until slug is changed.
+	// -------------------------------------------------------------------------
+
+	test.describe( 'scf/duplicate-post-type', () => {
+		let duplicatedKey;
+
+		test.beforeEach( async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+			await createPostType( requestUtils );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+			if ( duplicatedKey ) {
+				await cleanupPostType( requestUtils, duplicatedKey );
+				duplicatedKey = null;
+			}
+		} );
+
+		test( 'should duplicate an existing post type', async ( { requestUtils } ) => {
+			const result = await duplicatePostType( requestUtils, TEST_POST_TYPE.key );
+			duplicatedKey = result.key;
+
+			expect( result ).toHaveProperty( 'key' );
+			expect( result ).toHaveProperty( 'post_type' );
+			expect( result.key ).not.toBe( TEST_POST_TYPE.key );
+			expect( result.post_type ).toBe( TEST_POST_TYPE.post_type );
+			expect( result.title ).toContain( '(copy)' );
+		} );
+
+		test( 'should return error for non-existent post type', async ( { requestUtils } ) => {
+			await expectNotFound( duplicatePostType( requestUtils, 'nonexistent_duplicate_source' ) );
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// IMPORT POST TYPE - POST with body
+	// -------------------------------------------------------------------------
+
+	test.describe( 'scf/import-post-type', () => {
+		test.beforeEach( async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await cleanupPostType( requestUtils, TEST_POST_TYPE.key );
+		} );
+
+		test( 'should import a post type from JSON', async ( { requestUtils } ) => {
+			const result = await importPostType( requestUtils, TEST_POST_TYPE );
+
+			expect( result ).toHaveProperty( 'post_type', TEST_POST_TYPE.post_type );
+			expect( result ).toHaveProperty( 'title', TEST_POST_TYPE.title );
+		} );
+
+		test( 'should return error when required fields are missing', async ( { requestUtils } ) => {
+			await expectInvalidInput( importPostType( requestUtils, { title: 'Missing Required Fields' } ) );
+		} );
+	} );
+} );

--- a/tests/php/includes/abilities/test-scf-post-type-abilities.php
+++ b/tests/php/includes/abilities/test-scf-post-type-abilities.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Tests for SCF_Post_Type_Abilities class
+ *
+ * Note: Full integration tests including create/get/update/delete flows are covered
+ * by e2e tests in tests/e2e/abilities-post-types.spec.ts. These PHPUnit tests focus
+ * on callback structure and error handling that can be tested in WorDBless.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+// Load the abilities class directly since wp_register_ability doesn't exist in WorDBless.
+require_once dirname( __DIR__, 3 ) . '/../includes/abilities/class-scf-post-type-abilities.php';
+
+/**
+ * Test SCF Post Type Abilities callbacks
+ */
+class Test_SCF_Post_Type_Abilities extends BaseTestCase {
+
+	/**
+	 * Instance of SCF_Post_Type_Abilities for testing
+	 *
+	 * @var SCF_Post_Type_Abilities
+	 */
+	private $abilities;
+
+	/**
+	 * Test post type data
+	 *
+	 * @var array
+	 */
+	private $test_post_type = array(
+		'key'       => 'post_type_phpunit_test',
+		'title'     => 'PHPUnit Test Type',
+		'post_type' => 'phpunit_test',
+	);
+
+	/**
+	 * Setup test fixtures
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->abilities = acf_get_instance( 'SCF_Post_Type_Abilities' );
+	}
+
+	/**
+	 * Test list_post_types_callback returns array
+	 */
+	public function test_list_post_types_returns_array() {
+		$result = $this->abilities->list_post_types_callback( array() );
+
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Test list_post_types_callback with filter parameter
+	 */
+	public function test_list_post_types_with_filter() {
+		$result = $this->abilities->list_post_types_callback(
+			array( 'filter' => array( 'active' => true ) )
+		);
+
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Test create_post_type_callback returns array with key
+	 */
+	public function test_create_post_type_returns_array_with_key() {
+		$result = $this->abilities->create_post_type_callback( $this->test_post_type );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'key', $result );
+		$this->assertEquals( $this->test_post_type['key'], $result['key'] );
+	}
+
+	/**
+	 * Test create_post_type_callback returns array with title
+	 */
+	public function test_create_post_type_returns_array_with_title() {
+		$result = $this->abilities->create_post_type_callback( $this->test_post_type );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'title', $result );
+		$this->assertEquals( $this->test_post_type['title'], $result['title'] );
+	}
+
+	/**
+	 * Test get_post_type_callback returns WP_Error for non-existent ID
+	 */
+	public function test_get_post_type_not_found_returns_error() {
+		$result = $this->abilities->get_post_type_callback(
+			array( 'identifier' => 999999 )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'post_type_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test get_post_type_callback returns 404 status for non-existent key
+	 */
+	public function test_get_post_type_not_found_returns_404_status() {
+		$result = $this->abilities->get_post_type_callback(
+			array( 'identifier' => 'nonexistent_post_type' )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$error_data = $result->get_error_data();
+		$this->assertEquals( 404, $error_data['status'] );
+	}
+
+	/**
+	 * Test update_post_type_callback returns WP_Error for non-existent ID
+	 */
+	public function test_update_post_type_not_found_returns_error() {
+		$result = $this->abilities->update_post_type_callback(
+			array(
+				'ID'    => 999999,
+				'title' => 'Should Fail',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'post_type_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test delete_post_type_callback returns WP_Error for non-existent ID
+	 */
+	public function test_delete_post_type_not_found_returns_error() {
+		$result = $this->abilities->delete_post_type_callback(
+			array( 'identifier' => 999999 )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'post_type_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test delete_post_type_callback returns 404 status for non-existent key
+	 */
+	public function test_delete_post_type_not_found_returns_404_status() {
+		$result = $this->abilities->delete_post_type_callback(
+			array( 'identifier' => 'nonexistent_delete_target' )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$error_data = $result->get_error_data();
+		$this->assertEquals( 404, $error_data['status'] );
+	}
+
+	/**
+	 * Test duplicate_post_type_callback returns WP_Error for non-existent ID
+	 */
+	public function test_duplicate_post_type_not_found_returns_error() {
+		$result = $this->abilities->duplicate_post_type_callback(
+			array( 'identifier' => 999999 )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'post_type_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test export_post_type_callback returns WP_Error for non-existent ID
+	 */
+	public function test_export_post_type_not_found_returns_error() {
+		$result = $this->abilities->export_post_type_callback(
+			array( 'identifier' => 999999 )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'post_type_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test import_post_type_callback returns array
+	 */
+	public function test_import_post_type_returns_array() {
+		$result = $this->abilities->import_post_type_callback( $this->test_post_type );
+
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Test import_post_type_callback returns correct post_type
+	 */
+	public function test_import_post_type_returns_correct_post_type() {
+		$result = $this->abilities->import_post_type_callback( $this->test_post_type );
+
+		$this->assertIsArray( $result );
+		$this->assertEquals( $this->test_post_type['post_type'], $result['post_type'] );
+	}
+
+	/**
+	 * Test import_post_type_callback returns correct title
+	 */
+	public function test_import_post_type_returns_correct_title() {
+		$result = $this->abilities->import_post_type_callback( $this->test_post_type );
+
+		$this->assertIsArray( $result );
+		$this->assertEquals( $this->test_post_type['title'], $result['title'] );
+	}
+}


### PR DESCRIPTION
## What
Add comprehensive e2e tests for SCF Post Type Abilities.

## Why
Ensures the Post Type abilities work correctly through the WordPress Abilities API

## How

- Added new test file `tests/e2e/abilities-post-types.spec.ts`
- Tests all 8 post type abilities
- Tests call REST API endpoints directly (no UI interaction or MCP)
- Each test includes success cases and error handling (404 not found, 400 invalid input)
- Tests skip automatically on WordPress versions without the Abilities API

## Testing Instructions

1. Run `npm run test:e2e tests/e2e/abilities-post-types.spec.ts`
2. All tests should pass on WordPress 6.9+ or with the Abilities API plugin installed
3. Tests should skip gracefully on older WordPress versions or without the plugin