### PR TITLE
Continuous Integration: Add WP version matrix to test PRs against WordPress trunk

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ permissions: {}
 
 jobs:
     test:
-        name: Node.js ${{ matrix.node }}
+        name: Node ${{ matrix.node }} / WP ${{ matrix.wp }}
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -28,10 +28,17 @@ jobs:
             matrix:
                 event: ['${{ github.event_name }}']
                 node: ['22', '24']
+                wp: ['latest', 'trunk']
                 exclude:
-                    # On PRs: only test Node 22
+                    # On PRs: only test Node 22 + WP trunk
+                    # TODO: Revert to WP latest on PRs once WP 6.9 is released with the Abilities API
                     - event: 'pull_request'
                       node: '24'
+                    - event: 'pull_request'
+                      wp: 'latest'
+
+        env:
+            WP_ENV_CORE: ${{ matrix.wp == 'trunk' && 'WordPress/WordPress' || null }}
 
         steps:
             - uses: actions/checkout@v4

--- a/tests/e2e/field-type-repeater.spec.ts
+++ b/tests/e2e/field-type-repeater.spec.ts
@@ -109,6 +109,17 @@ test.describe( 'Field Type > Repeater', () => {
         // Navigate to edit post page
         await admin.editPost( post.id );
 
+        // Wait for meta boxes to load and expand the panel if collapsed.
+        // @see https://github.com/WordPress/gutenberg/issues/72185
+        await page.waitForSelector( '.acf-postbox', { state: 'attached' } );
+        await page.evaluate( () => {
+            document.querySelectorAll( 'button' ).forEach( ( btn ) => {
+                if ( btn.textContent?.includes( 'Meta Boxes' ) && btn.getAttribute( 'aria-expanded' ) === 'false' ) {
+                    btn.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+                }
+            } );
+        } );
+
         // Add a repeater row - using the correct selector matching the actual DOM element
         const addRowButton = page.locator(
             'a.acf-button.acf-repeater-add-row[data-event="add-row"]'

--- a/tests/e2e/field-type-text.spec.ts
+++ b/tests/e2e/field-type-text.spec.ts
@@ -80,6 +80,17 @@ test.describe( 'Field Type > Text', () => {
 		// Navigate to edit post page
 		await admin.editPost( post.id );
 
+		// Wait for meta boxes to load and expand the panel if collapsed.
+		// @see https://github.com/WordPress/gutenberg/issues/72185
+		await page.waitForSelector( '.acf-postbox', { state: 'attached' } );
+		await page.evaluate( () => {
+			document.querySelectorAll( 'button' ).forEach( ( btn ) => {
+				if ( btn.textContent?.includes( 'Meta Boxes' ) && btn.getAttribute( 'aria-expanded' ) === 'false' ) {
+					btn.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+				}
+			} );
+		} );
+
 		// Fill in the movie title field using data-name attribute
 		const movieTitleField = page.locator(
 			'.acf-field[data-name="movie_title"] input[type="text"]'


### PR DESCRIPTION
## What
Add WP version matrix to CI to test PRs against trunk, and fix failing tests against trunk.

## Why
- In general, testing against trunk helps catch compatibility issues early, but in particular, to test the Abilities only available in the unreleased 6.9 version
- E2e tests fail on WP trunk because the Meta Boxes panel is now collapsed by default

## How
- Add WP version matrix (`latest` + `trunk`) to e2e workflow
- On PRs, only test WP trunk until WP 6.9 releases with the Abilities API, when we can revert back to latest
- Fix existing tests by expanding the Meta Boxes panel if collapsed before interacting with SCF fields (workaround for [WordPress/gutenberg#72185](https://github.com/WordPress/gutenberg/issues/72185))

## Testing Instructions
1. Run e2e tests locally with WP trunk: `WP_ENV_CORE=WordPress/WordPress npm run test:e2e`
2. Tests should pass without "element is not visible" errors