### PR TITLE
Codecov: skip patch coverage checks in commits

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -24,6 +24,7 @@ coverage:
                 target: 70%
                 threshold: 5%
                 if_ci_failed: ignore
+                only_pulls: true
 
 ignore:
     - '*.min.css'


### PR DESCRIPTION
## What
Sets Codecov to run patch coverage checks in PRs and avoid running them in commits.

## Why?


If a PR has lost patch coverage, the PR checks will show a non-blocking error ❌

However, this is not a blocker, but if the PR is merged, the commit against trunk will show the same error, leaving trunk in a fake "failed state":
<img width="384" height="52" alt="image" src="https://github.com/user-attachments/assets/5e0f2690-efad-4e13-85f9-139fd33beee3" />

Commits against trunk should only check overall coverage and not check the last commit specifically.