### PR TITLE
e2e tests: refactor meta box panel expansion to use Playwright methods

### DIFF
--- a/tests/e2e/field-type-repeater.spec.ts
+++ b/tests/e2e/field-type-repeater.spec.ts
@@ -112,13 +112,11 @@ test.describe( 'Field Type > Repeater', () => {
         // Wait for meta boxes to load and expand the panel if collapsed.
         // @see https://github.com/WordPress/gutenberg/issues/72185
         await page.waitForSelector( '.acf-postbox', { state: 'attached' } );
-        await page.evaluate( () => {
-            document.querySelectorAll( 'button' ).forEach( ( btn ) => {
-                if ( btn.textContent?.includes( 'Meta Boxes' ) && btn.getAttribute( 'aria-expanded' ) === 'false' ) {
-                    btn.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
-                }
-            } );
-        } );
+        const metaBoxPanel = page.getByRole( 'button', { name: 'Meta Boxes' } );
+        if ( ( await metaBoxPanel.getAttribute( 'aria-expanded' ) ) === 'false' ) {
+            await metaBoxPanel.focus();
+            await metaBoxPanel.press( 'Enter' );
+        }
 
         // Add a repeater row - using the correct selector matching the actual DOM element
         const addRowButton = page.locator(

--- a/tests/e2e/field-type-text.spec.ts
+++ b/tests/e2e/field-type-text.spec.ts
@@ -83,13 +83,11 @@ test.describe( 'Field Type > Text', () => {
 		// Wait for meta boxes to load and expand the panel if collapsed.
 		// @see https://github.com/WordPress/gutenberg/issues/72185
 		await page.waitForSelector( '.acf-postbox', { state: 'attached' } );
-		await page.evaluate( () => {
-			document.querySelectorAll( 'button' ).forEach( ( btn ) => {
-				if ( btn.textContent?.includes( 'Meta Boxes' ) && btn.getAttribute( 'aria-expanded' ) === 'false' ) {
-					btn.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
-				}
-			} );
-		} );
+		const metaBoxPanel = page.getByRole( 'button', { name: 'Meta Boxes' } );
+		if ( ( await metaBoxPanel.getAttribute( 'aria-expanded' ) ) === 'false' ) {
+			await metaBoxPanel.focus();
+			await metaBoxPanel.press( 'Enter' );
+		}
 
 		// Fill in the movie title field using data-name attribute
 		const movieTitleField = page.locator(


### PR DESCRIPTION
Follow up to https://github.com/WordPress/secure-custom-fields/pull/257#discussion_r2569471649

Refactors meta box panel expansion in e2e tests to use standard Playwright methods instead of page.evaluate()