### PR TITLE
JSON Schemas: Refactor PHPUnit tests to extract base class

### DIFF
--- a/tests/php/schemas/BaseSchemaTestCase.php
+++ b/tests/php/schemas/BaseSchemaTestCase.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Abstract base class for SCF JSON Schema validation tests.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__, 3 ) . '/includes/class-scf-json-schema-validator.php';
+
+/**
+ * Abstract Class BaseSchemaTestCase
+ *
+ * Provides common functionality for testing SCF JSON schemas.
+ * Extend this class and implement the abstract methods to test a specific schema.
+ */
+abstract class BaseSchemaTestCase extends TestCase {
+
+	/**
+	 * The schema validator instance.
+	 *
+	 * @var SCF_JSON_Schema_Validator
+	 */
+	protected $validator;
+
+	/**
+	 * Path to test fixtures.
+	 *
+	 * @var string
+	 */
+	protected $fixtures_path;
+
+	/**
+	 * Get the schema type to test (e.g., 'post-type', 'taxonomy').
+	 *
+	 * @return string
+	 */
+	abstract protected function get_schema_type(): string;
+
+	/**
+	 * Get the path to the fixtures directory for this schema.
+	 *
+	 * @return string
+	 */
+	abstract protected function get_fixtures_path(): string;
+
+	/**
+	 * Get the definition name in the schema (e.g., 'postType', 'taxonomy').
+	 *
+	 * @return string
+	 */
+	abstract protected function get_definition_name(): string;
+
+	/**
+	 * Get the required fields for this schema.
+	 *
+	 * @return array
+	 */
+	abstract protected function get_required_fields(): array;
+
+	/**
+	 * Data provider for valid entities.
+	 *
+	 * @return array
+	 */
+	abstract public function validEntitiesProvider(): array;
+
+	/**
+	 * Data provider for invalid entities.
+	 *
+	 * @return array
+	 */
+	abstract public function invalidEntitiesProvider(): array;
+
+	/**
+	 * Set up test environment.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->validator     = new SCF_JSON_Schema_Validator();
+		$this->fixtures_path = $this->get_fixtures_path();
+	}
+
+	/**
+	 * Test that the schema loads correctly.
+	 */
+	public function test_schema_loads() {
+		$schema_type     = $this->get_schema_type();
+		$definition_name = $this->get_definition_name();
+		$required_fields = $this->get_required_fields();
+
+		$schema = $this->validator->load_schema( $schema_type );
+
+		$this->assertNotNull( $schema, ucfirst( $schema_type ) . ' schema should load successfully' );
+		$this->assertObjectHasProperty( 'oneOf', $schema, 'Schema should use oneOf for flexibility' );
+		$this->assertObjectHasProperty( 'definitions', $schema, 'Schema should have definitions' );
+		$this->assertObjectHasProperty( $definition_name, $schema->definitions, "Schema should define {$definition_name}" );
+
+		// Check that the definition has the correct required fields.
+		$definition = $schema->definitions->$definition_name;
+		foreach ( $required_fields as $field ) {
+			$this->assertContains( $field, $definition->required, "{$field} should be required" );
+		}
+	}
+
+	/**
+	 * Test validation of valid entities using data provider.
+	 *
+	 * @dataProvider validEntitiesProvider
+	 * @param mixed  $data        The entity data to validate.
+	 * @param string $description Test description.
+	 */
+	public function test_valid_entities_from_data_provider( $data, $description ) {
+		$result = $this->validator->validate( $data, $this->get_schema_type() );
+		$this->assertTrue( $result, $description );
+		$this->assertFalse( $this->validator->has_validation_errors(), 'Should have no validation errors' );
+	}
+
+	/**
+	 * Test validation of invalid entities using data provider.
+	 *
+	 * @dataProvider invalidEntitiesProvider
+	 * @param mixed  $data        The entity data to validate.
+	 * @param string $description Test description.
+	 */
+	public function test_invalid_entities_from_data_provider( $data, $description ) {
+		$result = $this->validator->validate( $data, $this->get_schema_type() );
+		$this->assertFalse( $result, $description );
+		$this->assertTrue( $this->validator->has_validation_errors(), 'Should have validation errors' );
+	}
+
+	/**
+	 * Test validation with valid fixture files (JSON file import scenarios).
+	 */
+	public function test_valid_entities_from_fixture_files() {
+		$valid_files = glob( $this->fixtures_path . 'valid/*.json' );
+		$this->assertNotEmpty( $valid_files, 'Should have valid fixture files' );
+
+		foreach ( $valid_files as $file_path ) {
+			$filename = basename( $file_path );
+			$result   = $this->validator->validate( $file_path, $this->get_schema_type() );
+
+			if ( ! $result ) {
+				$errors = $this->validator->get_validation_errors_string();
+				$this->fail( "Valid fixture {$filename} should pass validation. Errors: {$errors}" );
+			}
+
+			$this->assertTrue( $result, "Valid fixture {$filename} should pass validation" );
+		}
+	}
+
+	/**
+	 * Test validation with invalid fixture files (JSON file import scenarios).
+	 */
+	public function test_invalid_entities_from_fixture_files() {
+		$invalid_files = glob( $this->fixtures_path . 'invalid/*.json' );
+		$this->assertNotEmpty( $invalid_files, 'Should have invalid fixture files' );
+
+		foreach ( $invalid_files as $file_path ) {
+			$filename = basename( $file_path );
+			$result   = $this->validator->validate( $file_path, $this->get_schema_type() );
+			$this->assertFalse( $result, "Invalid fixture {$filename} should fail validation" );
+		}
+	}
+}

--- a/tests/php/schemas/PostTypeSchemaTest.php
+++ b/tests/php/schemas/PostTypeSchemaTest.php
@@ -2,72 +2,64 @@
 /**
  * Tests for the SCF Post Type JSON Schema validation.
  *
- * @package SCF
+ * @package wordpress/secure-custom-fields
  */
 
-/**
- * Tests for the SCF Post Type JSON Schema validation.
- *
- * @package SCF
- */
+use PHPUnit\Framework\TestCase;
 
-require_once dirname( dirname( __DIR__ ) ) . '/includes/class-scf-json-schema-validator.php';
+require_once 'BaseSchemaTestCase.php';
 
 /**
  * Class PostTypeSchemaTest
  *
  * Tests JSON Schema validation for SCF post types.
  */
-class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
+class PostTypeSchemaTest extends BaseSchemaTestCase {
 
 	/**
-	 * The schema validator instance.
+	 * Get the schema type to test.
 	 *
-	 * @var SCF_JSON_Schema_Validator
+	 * @return string
 	 */
-	private $validator;
-
-	/**
-	 * Path to test fixtures.
-	 *
-	 * @var string
-	 */
-	private $fixtures_path;
-
-	/**
-	 * Set up test environment.
-	 */
-	public function setUp(): void {
-		parent::setUp();
-
-		$this->validator     = new SCF_JSON_Schema_Validator();
-		$this->fixtures_path = __DIR__ . '/fixtures/schemas/post-types/';
+	protected function get_schema_type(): string {
+		return 'post-type';
 	}
 
 	/**
-	 * Test that the post-type schema loads correctly.
+	 * Get the path to the fixtures directory.
+	 *
+	 * @return string
 	 */
-	public function test_post_type_schema_loads() {
-		$schema = $this->validator->load_schema( 'post-type' );
+	protected function get_fixtures_path(): string {
+		return dirname( __DIR__ ) . '/fixtures/schemas/post-types/';
+	}
 
-		$this->assertNotNull( $schema, 'Post type schema should load successfully' );
-		$this->assertObjectHasProperty( 'oneOf', $schema, 'Schema should use oneOf for flexibility' );
-		$this->assertObjectHasProperty( 'definitions', $schema, 'Schema should have definitions' );
-		$this->assertObjectHasProperty( 'postType', $schema->definitions, 'Schema should define postType' );
+	/**
+	 * Get the definition name in the schema.
+	 *
+	 * @return string
+	 */
+	protected function get_definition_name(): string {
+		return 'postType';
+	}
 
-		// Check that the postType definition has the correct required fields
-		$post_type_def = $schema->definitions->postType;
-		$this->assertContains( 'key', $post_type_def->required, 'Key should be required' );
-		$this->assertContains( 'title', $post_type_def->required, 'Title should be required' );
-		$this->assertContains( 'post_type', $post_type_def->required, 'Post type should be required' );
+	/**
+	 * Get the required fields for this schema.
+	 *
+	 * @return array
+	 */
+	protected function get_required_fields(): array {
+		return array( 'key', 'title', 'post_type' );
 	}
 
 	/**
 	 * Data provider for valid post types.
+	 *
+	 * @return array
 	 */
-	public function validPostTypesProvider() {
+	public function validEntitiesProvider(): array {
 		return array(
-			'basic valid'                  => array(
+			'basic valid'                    => array(
 				array(
 					'key'       => 'post_type_book',
 					'title'     => 'Book',
@@ -75,7 +67,7 @@ class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
 				),
 				'Basic post type should validate successfully',
 			),
-			'array with two items'         => array(
+			'array with two items'           => array(
 				array(
 					array(
 						'key'       => 'post_type_book',
@@ -90,7 +82,7 @@ class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
 				),
 				'Array of two post types should validate successfully',
 			),
-			'with dashes'                  => array(
+			'with dashes'                    => array(
 				array(
 					'key'       => 'post_type_my_product',
 					'title'     => 'My Product',
@@ -98,7 +90,7 @@ class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
 				),
 				'Post type with dashes should be valid',
 			),
-			'with underscores'             => array(
+			'with underscores'               => array(
 				array(
 					'key'       => 'post_type_my_product',
 					'title'     => 'My Product',
@@ -106,7 +98,7 @@ class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
 				),
 				'Post type with underscores should be valid',
 			),
-			'with numbers'                 => array(
+			'with numbers'                   => array(
 				array(
 					'key'       => 'post_type_product123',
 					'title'     => 'Product',
@@ -114,7 +106,7 @@ class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
 				),
 				'Post type with numbers should be valid',
 			),
-			'custom supports'              => array(
+			'custom supports'                => array(
 				array(
 					'key'       => 'post_type_book',
 					'title'     => 'Book',
@@ -123,7 +115,7 @@ class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
 				),
 				'Post type with custom supports should be valid',
 			),
-			'rewrite false'                => array(
+			'rewrite false'                  => array(
 				array(
 					'key'       => 'post_type_book',
 					'title'     => 'Book',
@@ -132,7 +124,7 @@ class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
 				),
 				'Post type with rewrite as false should validate',
 			),
-			'rewrite object'               => array(
+			'rewrite object'                 => array(
 				array(
 					'key'       => 'post_type_book',
 					'title'     => 'Book',
@@ -146,7 +138,7 @@ class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
 				),
 				'Post type with rewrite object should validate',
 			),
-			'with capabilities'            => array(
+			'with capabilities'              => array(
 				array(
 					'key'          => 'post_type_book',
 					'title'        => 'Book',
@@ -159,7 +151,7 @@ class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
 				),
 				'Post type with valid capabilities should validate',
 			),
-			'taxonomies empty array'       => array(
+			'taxonomies empty array'         => array(
 				array(
 					'key'        => 'post_type_test',
 					'title'      => 'Test',
@@ -168,7 +160,7 @@ class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
 				),
 				'Post type with empty taxonomies array should validate',
 			),
-			'taxonomies empty string'      => array(
+			'taxonomies empty string'        => array(
 				array(
 					'key'        => 'post_type_test',
 					'title'      => 'Test',
@@ -177,7 +169,7 @@ class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
 				),
 				'Post type with empty taxonomies string should validate',
 			),
-			'taxonomies array with values' => array(
+			'taxonomies array with values'   => array(
 				array(
 					'key'        => 'post_type_test',
 					'title'      => 'Test',
@@ -186,7 +178,7 @@ class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
 				),
 				'Post type with taxonomies array should validate',
 			),
-			'menu_position null'           => array(
+			'menu_position null'             => array(
 				array(
 					'key'           => 'post_type_test',
 					'title'         => 'Test',
@@ -195,7 +187,7 @@ class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
 				),
 				'Post type with null menu_position should validate',
 			),
-			'menu_position empty string'   => array(
+			'menu_position empty string'     => array(
 				array(
 					'key'           => 'post_type_test',
 					'title'         => 'Test',
@@ -204,7 +196,7 @@ class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
 				),
 				'Post type with empty string menu_position should validate',
 			),
-			'menu_position integer'        => array(
+			'menu_position integer'          => array(
 				array(
 					'key'           => 'post_type_test',
 					'title'         => 'Test',
@@ -213,13 +205,33 @@ class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
 				),
 				'Post type with integer menu_position should validate',
 			),
+			'advanced_configuration integer' => array(
+				array(
+					'key'                    => 'post_type_book',
+					'title'                  => 'Book',
+					'post_type'              => 'book',
+					'advanced_configuration' => 1,
+				),
+				'Post type with advanced_configuration as integer should be valid',
+			),
+			'advanced_configuration boolean' => array(
+				array(
+					'key'                    => 'post_type_book',
+					'title'                  => 'Book',
+					'post_type'              => 'book',
+					'advanced_configuration' => true,
+				),
+				'Post type with advanced_configuration as boolean should be valid',
+			),
 		);
 	}
 
 	/**
 	 * Data provider for invalid post types.
+	 *
+	 * @return array
 	 */
-	public function invalidPostTypesProvider() {
+	public function invalidEntitiesProvider(): array {
 		return array(
 			'missing key'           => array(
 				array(
@@ -293,65 +305,5 @@ class PostTypeSchemaTest extends \PHPUnit\Framework\TestCase {
 				'Post type with additional properties should fail validation',
 			),
 		);
-	}
-
-	/**
-	 * Test validation of valid post types using data provider.
-	 *
-	 * @dataProvider validPostTypesProvider
-	 * @param mixed  $data        The post type data to validate.
-	 * @param string $description Test description.
-	 */
-	public function test_valid_post_types_from_data_provider( $data, $description ) {
-		$result = $this->validator->validate( $data, 'post-type' );
-		$this->assertTrue( $result, $description );
-		$this->assertFalse( $this->validator->has_validation_errors(), 'Should have no validation errors' );
-	}
-
-	/**
-	 * Test validation of invalid post types using data provider.
-	 *
-	 * @dataProvider invalidPostTypesProvider
-	 * @param mixed  $data        The post type data to validate.
-	 * @param string $description Test description.
-	 */
-	public function test_invalid_post_types_from_data_provider( $data, $description ) {
-		$result = $this->validator->validate( $data, 'post-type' );
-		$this->assertFalse( $result, $description );
-		$this->assertTrue( $this->validator->has_validation_errors(), 'Should have validation errors' );
-	}
-
-	/**
-	 * Test validation with valid fixture files (JSON file import scenarios).
-	 */
-	public function test_valid_post_types_from_fixture_files() {
-		$valid_files = glob( $this->fixtures_path . 'valid/*.json' );
-		$this->assertNotEmpty( $valid_files, 'Should have valid fixture files' );
-
-		foreach ( $valid_files as $file_path ) {
-			$filename = basename( $file_path );
-			$result   = $this->validator->validate( $file_path, 'post-type' );
-
-			if ( ! $result ) {
-				$errors = $this->validator->get_validation_errors_string();
-				$this->fail( "Valid fixture {$filename} should pass validation. Errors: {$errors}" );
-			}
-
-			$this->assertTrue( $result, "Valid fixture {$filename} should pass validation" );
-		}
-	}
-
-	/**
-	 * Test validation with invalid fixture files (JSON file import scenarios).
-	 */
-	public function test_invalid_post_types_from_fixture_files() {
-		$invalid_files = glob( $this->fixtures_path . 'invalid/*.json' );
-		$this->assertNotEmpty( $invalid_files, 'Should have invalid fixture files' );
-
-		foreach ( $invalid_files as $file_path ) {
-			$filename = basename( $file_path );
-			$result   = $this->validator->validate( $file_path, 'post-type' );
-			$this->assertFalse( $result, "Invalid fixture {$filename} should fail validation" );
-		}
 	}
 }

--- a/tests/php/schemas/TaxonomySchemaTest.php
+++ b/tests/php/schemas/TaxonomySchemaTest.php
@@ -2,73 +2,72 @@
 /**
  * Tests for the SCF Taxonomy JSON Schema validation.
  *
- * @package SCF
+ * @package wordpress/secure-custom-fields
  */
 
-/**
- * Tests for the SCF Taxonomy JSON Schema validation.
- *
- * @package SCF
- */
+use PHPUnit\Framework\TestCase;
 
-require_once dirname( dirname( __DIR__ ) ) . '/includes/class-scf-json-schema-validator.php';
+require_once 'BaseSchemaTestCase.php';
 
 /**
  * Class TaxonomySchemaTest
  *
  * Tests JSON Schema validation for SCF taxonomies.
  */
-class TaxonomySchemaTest extends \PHPUnit\Framework\TestCase {
+class TaxonomySchemaTest extends BaseSchemaTestCase {
 
 	/**
-	 * The schema validator instance.
+	 * Get the schema type to test.
 	 *
-	 * @var SCF_JSON_Schema_Validator
+	 * @return string
 	 */
-	private $validator;
-
-	/**
-	 * Path to test fixtures.
-	 *
-	 * @var string
-	 */
-	private $fixtures_path;
-
-	/**
-	 * Set up test environment.
-	 */
-	public function setUp(): void {
-		parent::setUp();
-
-		$this->validator     = new SCF_JSON_Schema_Validator();
-		$this->fixtures_path = __DIR__ . '/fixtures/schemas/taxonomies/';
+	protected function get_schema_type(): string {
+		return 'taxonomy';
 	}
 
 	/**
-	 * Test that the taxonomy schema loads correctly.
+	 * Get the path to the fixtures directory.
+	 *
+	 * @return string
 	 */
-	public function test_taxonomy_schema_loads() {
-		$schema = $this->validator->load_schema( 'taxonomy' );
+	protected function get_fixtures_path(): string {
+		return dirname( __DIR__ ) . '/fixtures/schemas/taxonomies/';
+	}
 
-		$this->assertNotNull( $schema, 'Taxonomy schema should load successfully' );
-		$this->assertObjectHasProperty( 'oneOf', $schema, 'Schema should use oneOf for flexibility' );
-		$this->assertObjectHasProperty( 'definitions', $schema, 'Schema should have definitions' );
-		$this->assertObjectHasProperty( 'taxonomy', $schema->definitions, 'Schema should define taxonomy' );
+	/**
+	 * Get the definition name in the schema.
+	 *
+	 * @return string
+	 */
+	protected function get_definition_name(): string {
+		return 'taxonomy';
+	}
 
-		// Check that the taxonomy definition has the correct required fields.
+	/**
+	 * Get the required fields for this schema.
+	 *
+	 * @return array
+	 */
+	protected function get_required_fields(): array {
+		return array( 'key', 'title', 'taxonomy' );
+	}
+
+	/**
+	 * Test that object_type is NOT required (taxonomy-specific).
+	 */
+	public function test_object_type_is_optional() {
+		$schema       = $this->validator->load_schema( 'taxonomy' );
 		$taxonomy_def = $schema->definitions->taxonomy;
-		$this->assertContains( 'key', $taxonomy_def->required, 'Key should be required' );
-		$this->assertContains( 'title', $taxonomy_def->required, 'Title should be required' );
-		$this->assertContains( 'taxonomy', $taxonomy_def->required, 'Taxonomy should be required' );
 
-		// Verify that object_type is NOT required (it's optional with allow_null=1).
 		$this->assertNotContains( 'object_type', $taxonomy_def->required, 'Object type should NOT be required' );
 	}
 
 	/**
 	 * Data provider for valid taxonomies.
+	 *
+	 * @return array
 	 */
-	public function validTaxonomiesProvider() {
+	public function validEntitiesProvider(): array {
 		return array(
 			'basic valid'                    => array(
 				array(
@@ -296,8 +295,10 @@ class TaxonomySchemaTest extends \PHPUnit\Framework\TestCase {
 
 	/**
 	 * Data provider for invalid taxonomies.
+	 *
+	 * @return array
 	 */
-	public function invalidTaxonomiesProvider() {
+	public function invalidEntitiesProvider(): array {
 		return array(
 			'missing key'               => array(
 				array(
@@ -406,65 +407,5 @@ class TaxonomySchemaTest extends \PHPUnit\Framework\TestCase {
 				'Taxonomy with non-string capability value should fail validation',
 			),
 		);
-	}
-
-	/**
-	 * Test validation of valid taxonomies using data provider.
-	 *
-	 * @dataProvider validTaxonomiesProvider
-	 * @param mixed  $data        The taxonomy data to validate.
-	 * @param string $description Test description.
-	 */
-	public function test_valid_taxonomies_from_data_provider( $data, $description ) {
-		$result = $this->validator->validate( $data, 'taxonomy' );
-		$this->assertTrue( $result, $description );
-		$this->assertFalse( $this->validator->has_validation_errors(), 'Should have no validation errors' );
-	}
-
-	/**
-	 * Test validation of invalid taxonomies using data provider.
-	 *
-	 * @dataProvider invalidTaxonomiesProvider
-	 * @param mixed  $data        The taxonomy data to validate.
-	 * @param string $description Test description.
-	 */
-	public function test_invalid_taxonomies_from_data_provider( $data, $description ) {
-		$result = $this->validator->validate( $data, 'taxonomy' );
-		$this->assertFalse( $result, $description );
-		$this->assertTrue( $this->validator->has_validation_errors(), 'Should have validation errors' );
-	}
-
-	/**
-	 * Test validation with valid fixture files (JSON file import scenarios).
-	 */
-	public function test_valid_taxonomies_from_fixture_files() {
-		$valid_files = glob( $this->fixtures_path . 'valid/*.json' );
-		$this->assertNotEmpty( $valid_files, 'Should have valid fixture files' );
-
-		foreach ( $valid_files as $file_path ) {
-			$filename = basename( $file_path );
-			$result   = $this->validator->validate( $file_path, 'taxonomy' );
-
-			if ( ! $result ) {
-				$errors = $this->validator->get_validation_errors_string();
-				$this->fail( "Valid fixture {$filename} should pass validation. Errors: {$errors}" );
-			}
-
-			$this->assertTrue( $result, "Valid fixture {$filename} should pass validation" );
-		}
-	}
-
-	/**
-	 * Test validation with invalid fixture files (JSON file import scenarios).
-	 */
-	public function test_invalid_taxonomies_from_fixture_files() {
-		$invalid_files = glob( $this->fixtures_path . 'invalid/*.json' );
-		$this->assertNotEmpty( $invalid_files, 'Should have invalid fixture files' );
-
-		foreach ( $invalid_files as $file_path ) {
-			$filename = basename( $file_path );
-			$result   = $this->validator->validate( $file_path, 'taxonomy' );
-			$this->assertFalse( $result, "Invalid fixture {$filename} should fail validation" );
-		}
 	}
 }


### PR DESCRIPTION
## What
Refactors JSON Schema tests to use an abstract base class.

## Why
- `PostTypeSchemaTest` and `TaxonomySchemaTest` had ~80 lines of duplicate test logic
- Adding new schema tests (field groups, options pages) would require copying the same boilerplate

## How
- Created `BaseSchemaTestCase` abstract class with shared test methods
- Moved schema tests to dedicated `tests/php/schemas/` directory
- Each schema test now only defines its specific data providers and configuration

## Testing Instructions
1. Run `vendor/bin/phpunit tests/php/schemas/`