### PR TITLE
Abilities support: Add Taxonomy abilities

### DIFF
--- a/includes/abilities/abilities-integration.php
+++ b/includes/abilities/abilities-integration.php
@@ -39,6 +39,7 @@ if ( ! class_exists( 'SCF_Abilities_Integration' ) ) {
 			}
 
 			acf_include( 'includes/abilities/class-scf-post-type-abilities.php' );
+			acf_include( 'includes/abilities/class-scf-taxonomy-abilities.php' );
 		}
 
 		/**

--- a/includes/abilities/abilities-integration.php
+++ b/includes/abilities/abilities-integration.php
@@ -16,6 +16,7 @@ if ( ! class_exists( 'SCF_Abilities_Integration' ) ) {
 	 * Handles integration with WordPress Abilities API.
 	 *
 	 * @since 6.6.0
+	 * @codeCoverageIgnore Glue code tested implicitly via E2E tests.
 	 */
 	class SCF_Abilities_Integration {
 

--- a/includes/abilities/class-scf-taxonomy-abilities.php
+++ b/includes/abilities/class-scf-taxonomy-abilities.php
@@ -1,0 +1,646 @@
+<?php
+/**
+ * SCF Taxonomy Abilities
+ *
+ * Handles WordPress Abilities API registration for SCF taxonomy management.
+ *
+ * @package wordpress/secure-custom-fields
+ * @since 6.7.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'SCF_Taxonomy_Abilities' ) ) :
+
+	/**
+	 * SCF Taxonomy Abilities class.
+	 *
+	 * Registers and handles all taxonomy management abilities for the
+	 * WordPress Abilities API integration. Provides programmatic access
+	 * to SCF taxonomy operations.
+	 *
+	 * @since 6.7.0
+	 */
+	class SCF_Taxonomy_Abilities {
+
+		/**
+		 * Taxonomy schema to reuse across ability registrations.
+		 *
+		 * @var array|null
+		 */
+		private $taxonomy_schema = null;
+
+		/**
+		 * SCF identifier schema to reuse across ability registrations.
+		 *
+		 * @var array|null
+		 */
+		private $scf_identifier_schema = null;
+
+		/**
+		 * Constructor.
+		 *
+		 * @since 6.7.0
+		 */
+		public function __construct() {
+			$validator = acf_get_instance( 'SCF_JSON_Schema_Validator' );
+
+			// Only register abilities if schemas are available.
+			if ( ! $validator->validate_required_schemas() ) {
+				return;
+			}
+
+			add_action( 'wp_abilities_api_categories_init', array( $this, 'register_categories' ) );
+			add_action( 'wp_abilities_api_init', array( $this, 'register_abilities' ) );
+		}
+
+		/**
+		 * Get the SCF taxonomy schema, loading it once and caching for reuse.
+		 *
+		 * @since 6.7.0
+		 * @return array The taxonomy schema definition.
+		 */
+		private function get_taxonomy_schema() {
+			if ( null === $this->taxonomy_schema ) {
+				$validator = new SCF_JSON_Schema_Validator();
+				$schema    = $validator->load_schema( 'taxonomy' );
+
+				$this->taxonomy_schema = json_decode( wp_json_encode( $schema->definitions->taxonomy ), true );
+			}
+
+			return $this->taxonomy_schema;
+		}
+
+		/**
+		 * Get the SCF identifier schema, loading it once and caching for reuse.
+		 *
+		 * @since 6.7.0
+		 *
+		 * @return array The SCF identifier schema definition.
+		 */
+		private function get_scf_identifier_schema() {
+			if ( null === $this->scf_identifier_schema ) {
+				$validator = new SCF_JSON_Schema_Validator();
+
+				$this->scf_identifier_schema = json_decode( wp_json_encode( $validator->load_schema( 'scf-identifier' ) ), true );
+			}
+
+			return $this->scf_identifier_schema;
+		}
+
+		/**
+		 * Get the internal fields schema (ID, _valid, local).
+		 *
+		 * @since 6.7.0
+		 * @return array The internal fields schema.
+		 */
+		private function get_internal_fields_schema() {
+			$validator = new SCF_JSON_Schema_Validator();
+			$schema    = $validator->load_schema( 'internal-fields' );
+
+			return json_decode( wp_json_encode( $schema->definitions->internalFields ), true );
+		}
+
+		/**
+		 * Get the taxonomy schema extended with internal fields for GET/LIST/CREATE/UPDATE/IMPORT/DUPLICATE operations.
+		 *
+		 * @since 6.7.0
+		 *
+		 * @return array The extended taxonomy schema with internal fields.
+		 */
+		private function get_taxonomy_with_internal_fields_schema() {
+			$schema               = $this->get_taxonomy_schema();
+			$internal_fields      = $this->get_internal_fields_schema();
+			$schema['properties'] = array_merge( $schema['properties'], $internal_fields['properties'] );
+
+			return $schema;
+		}
+
+		/**
+		 * Register SCF ability categories.
+		 *
+		 * @since 6.7.0
+		 */
+		public function register_categories() {
+			wp_register_ability_category(
+				'scf-taxonomies',
+				array(
+					'label'       => __( 'SCF Taxonomies', 'secure-custom-fields' ),
+					'description' => __( 'Abilities for managing Secure Custom Fields taxonomies.', 'secure-custom-fields' ),
+				)
+			);
+		}
+
+		/**
+		 * Register all taxonomy abilities.
+		 *
+		 * @since 6.7.0
+		 */
+		public function register_abilities() {
+			$this->register_list_taxonomies_ability();
+			$this->register_get_taxonomy_ability();
+			$this->register_create_taxonomy_ability();
+			$this->register_update_taxonomy_ability();
+			$this->register_delete_taxonomy_ability();
+			$this->register_duplicate_taxonomy_ability();
+			$this->register_export_taxonomy_ability();
+			$this->register_import_taxonomy_ability();
+		}
+
+		/**
+		 * Register the list taxonomies ability.
+		 *
+		 * @since 6.7.0
+		 */
+		private function register_list_taxonomies_ability() {
+			wp_register_ability(
+				'scf/list-taxonomies',
+				array(
+					'label'               => __( 'List Taxonomies', 'secure-custom-fields' ),
+					'description'         => __( 'Retrieves a list of all SCF taxonomies with optional filtering.', 'secure-custom-fields' ),
+					'category'            => 'scf-taxonomies',
+					'execute_callback'    => array( $this, 'list_taxonomies_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array(
+							'public' => true,
+						),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => true,
+						),
+					),
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'filter' => array(
+								'type'        => 'object',
+								'description' => __( 'Optional filters to apply to the taxonomy list.', 'secure-custom-fields' ),
+								'properties'  => array(
+									'active' => array(
+										'type'        => 'boolean',
+										'description' => __( 'Filter by active status.', 'secure-custom-fields' ),
+									),
+								),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'  => 'array',
+						'items' => $this->get_taxonomy_with_internal_fields_schema(),
+					),
+				)
+			);
+		}
+
+		/**
+		 * Register the get taxonomy ability.
+		 *
+		 * @since 6.7.0
+		 */
+		private function register_get_taxonomy_ability() {
+			wp_register_ability(
+				'scf/get-taxonomy',
+				array(
+					'label'               => __( 'Get Taxonomy', 'secure-custom-fields' ),
+					'description'         => __( 'Retrieves a specific SCF taxonomy configuration by ID or key.', 'secure-custom-fields' ),
+					'category'            => 'scf-taxonomies',
+					'execute_callback'    => array( $this, 'get_taxonomy_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array(
+							'public' => true,
+						),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => true,
+						),
+					),
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'identifier' => $this->get_scf_identifier_schema(),
+						),
+						'required'   => array( 'identifier' ),
+					),
+					'output_schema'       => $this->get_taxonomy_with_internal_fields_schema(),
+				)
+			);
+		}
+
+		/**
+		 * Register the create taxonomy ability.
+		 *
+		 * @since 6.7.0
+		 */
+		private function register_create_taxonomy_ability() {
+			$input_schema = $this->get_taxonomy_schema();
+
+			wp_register_ability(
+				'scf/create-taxonomy',
+				array(
+					'label'               => __( 'Create Taxonomy', 'secure-custom-fields' ),
+					'description'         => __( 'Creates a new custom taxonomy in SCF with the provided configuration.', 'secure-custom-fields' ),
+					'category'            => 'scf-taxonomies',
+					'execute_callback'    => array( $this, 'create_taxonomy_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array(
+							'public' => true,
+						),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => false,
+						),
+					),
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => $input_schema,
+					'output_schema'       => $this->get_taxonomy_with_internal_fields_schema(),
+				)
+			);
+		}
+
+		/**
+		 * Register the update taxonomy ability.
+		 *
+		 * @since 6.7.0
+		 */
+		private function register_update_taxonomy_ability() {
+
+			// For updates, only ID is required, everything else is optional.
+			$input_schema             = $this->get_taxonomy_with_internal_fields_schema();
+			$input_schema['required'] = array( 'ID' );
+
+			wp_register_ability(
+				'scf/update-taxonomy',
+				array(
+					'label'               => __( 'Update Taxonomy', 'secure-custom-fields' ),
+					'description'         => __( 'Updates an existing SCF taxonomy with new configuration.', 'secure-custom-fields' ),
+					'category'            => 'scf-taxonomies',
+					'execute_callback'    => array( $this, 'update_taxonomy_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array(
+							'public' => true,
+						),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => true,
+						),
+					),
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => $input_schema,
+					'output_schema'       => $this->get_taxonomy_with_internal_fields_schema(),
+				)
+			);
+		}
+
+		/**
+		 * Register the delete taxonomy ability.
+		 *
+		 * @since 6.7.0
+		 */
+		private function register_delete_taxonomy_ability() {
+			wp_register_ability(
+				'scf/delete-taxonomy',
+				array(
+					'label'               => __( 'Delete Taxonomy', 'secure-custom-fields' ),
+					'description'         => __( 'Permanently deletes an SCF taxonomy. This action cannot be undone.', 'secure-custom-fields' ),
+					'category'            => 'scf-taxonomies',
+					'execute_callback'    => array( $this, 'delete_taxonomy_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array(
+							'public' => true,
+						),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => true,
+							'idempotent'  => true,
+						),
+					),
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'identifier' => $this->get_scf_identifier_schema(),
+						),
+						'required'   => array( 'identifier' ),
+					),
+					'output_schema'       => array(
+						'type'        => 'boolean',
+						'description' => __( 'True if taxonomy was successfully deleted.', 'secure-custom-fields' ),
+					),
+				)
+			);
+		}
+
+		/**
+		 * Register the duplicate taxonomy ability.
+		 *
+		 * @since 6.7.0
+		 */
+		private function register_duplicate_taxonomy_ability() {
+			wp_register_ability(
+				'scf/duplicate-taxonomy',
+				array(
+					'label'               => __( 'Duplicate Taxonomy', 'secure-custom-fields' ),
+					'description'         => __( 'Creates a copy of an existing SCF taxonomy. The duplicate receives a new unique key but retains the same taxonomy slug, so it will not register until the slug is changed.', 'secure-custom-fields' ),
+					'category'            => 'scf-taxonomies',
+					'execute_callback'    => array( $this, 'duplicate_taxonomy_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array(
+							'public' => true,
+						),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => false,
+						),
+					),
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'identifier'  => $this->get_scf_identifier_schema(),
+							'new_post_id' => array(
+								'type'        => 'integer',
+								'description' => __( 'Optional new post ID for the duplicated taxonomy.', 'secure-custom-fields' ),
+							),
+						),
+						'required'   => array( 'identifier' ),
+					),
+					'output_schema'       => $this->get_taxonomy_with_internal_fields_schema(),
+				)
+			);
+		}
+
+		/**
+		 * Register the export taxonomy ability.
+		 *
+		 * @since 6.7.0
+		 */
+		private function register_export_taxonomy_ability() {
+			wp_register_ability(
+				'scf/export-taxonomy',
+				array(
+					'label'               => __( 'Export Taxonomy', 'secure-custom-fields' ),
+					'description'         => __( 'Exports an SCF taxonomy configuration as JSON for backup or transfer.', 'secure-custom-fields' ),
+					'category'            => 'scf-taxonomies',
+					'execute_callback'    => array( $this, 'export_taxonomy_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array(
+							'public' => true,
+						),
+						'annotations'  => array(
+							'readonly'    => true,
+							'destructive' => false,
+							'idempotent'  => true,
+						),
+					),
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'identifier' => $this->get_scf_identifier_schema(),
+						),
+						'required'   => array( 'identifier' ),
+					),
+					'output_schema'       => $this->get_taxonomy_schema(),
+				)
+			);
+		}
+
+		/**
+		 * Register the import taxonomy ability.
+		 *
+		 * @since 6.7.0
+		 */
+		private function register_import_taxonomy_ability() {
+			wp_register_ability(
+				'scf/import-taxonomy',
+				array(
+					'label'               => __( 'Import Taxonomy', 'secure-custom-fields' ),
+					'description'         => __( 'Imports an SCF taxonomy from JSON configuration data.', 'secure-custom-fields' ),
+					'category'            => 'scf-taxonomies',
+					'execute_callback'    => array( $this, 'import_taxonomy_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array(
+							'public' => true,
+						),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => false,
+						),
+					),
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => $this->get_taxonomy_with_internal_fields_schema(),
+					'output_schema'       => $this->get_taxonomy_with_internal_fields_schema(),
+				)
+			);
+		}
+
+		/**
+		 * Callback for the list taxonomies ability.
+		 *
+		 * @since 6.7.0
+		 *
+		 * @param array $input The input parameters.
+		 * @return array The response data.
+		 */
+		public function list_taxonomies_callback( $input ) {
+			$filter = isset( $input['filter'] ) ? $input['filter'] : array();
+
+			$taxonomies = acf_get_acf_taxonomies( $filter );
+			return is_array( $taxonomies ) ? $taxonomies : array();
+		}
+
+		/**
+		 * Callback for the get taxonomy ability.
+		 *
+		 * @since 6.7.0
+		 *
+		 * @param array $input The input parameters.
+		 * @return array|WP_Error The taxonomy data on success, WP_Error on failure.
+		 */
+		public function get_taxonomy_callback( $input ) {
+			$taxonomy = acf_get_taxonomy( $input['identifier'] );
+
+			if ( ! $taxonomy ) {
+				return $this->taxonomy_not_found_error();
+			}
+
+			return $taxonomy;
+		}
+
+		/**
+		 * Callback for the create taxonomy ability.
+		 *
+		 * @since 6.7.0
+		 *
+		 * @param array $input The input parameters.
+		 * @return array|WP_Error The taxonomy data on success, WP_Error on failure.
+		 */
+		public function create_taxonomy_callback( $input ) {
+			// Check if taxonomy already exists.
+			if ( acf_get_taxonomy( $input['key'] ) ) {
+				return new WP_Error( 'taxonomy_exists', __( 'A taxonomy with this key already exists.', 'secure-custom-fields' ) );
+			}
+
+			$taxonomy = acf_update_taxonomy( $input );
+
+			if ( ! $taxonomy ) {
+				return new WP_Error( 'create_taxonomy_failed', __( 'Failed to create taxonomy.', 'secure-custom-fields' ) );
+			}
+
+			return $taxonomy;
+		}
+
+		/**
+		 * Callback for the update taxonomy ability.
+		 *
+		 * @since 6.7.0
+		 *
+		 * @param array $input The input parameters.
+		 * @return array|WP_Error The taxonomy data on success, WP_Error on failure.
+		 */
+		public function update_taxonomy_callback( $input ) {
+			$existing_taxonomy = acf_get_taxonomy( $input['ID'] );
+			if ( ! $existing_taxonomy ) {
+				return $this->taxonomy_not_found_error();
+			}
+
+			// Merge input with existing taxonomy data to preserve unmodified fields.
+			$input = array_merge( $existing_taxonomy, $input );
+
+			$taxonomy = acf_update_taxonomy( $input );
+
+			if ( ! $taxonomy ) {
+				return new WP_Error( 'update_taxonomy_failed', __( 'Failed to update taxonomy.', 'secure-custom-fields' ) );
+			}
+
+			return $taxonomy;
+		}
+
+		/**
+		 * Callback for the delete taxonomy ability.
+		 *
+		 * @since 6.7.0
+		 *
+		 * @param array $input The input parameters.
+		 * @return bool|WP_Error True on success, WP_Error on failure.
+		 */
+		public function delete_taxonomy_callback( $input ) {
+			$taxonomy = acf_get_taxonomy( $input['identifier'] );
+			if ( ! $taxonomy ) {
+				return $this->taxonomy_not_found_error();
+			}
+
+			$result = acf_delete_taxonomy( $input['identifier'] );
+
+			if ( ! $result ) {
+				return new WP_Error( 'delete_taxonomy_failed', __( 'Failed to delete taxonomy.', 'secure-custom-fields' ) );
+			}
+
+			return true;
+		}
+
+		/**
+		 * Callback for the duplicate taxonomy ability.
+		 *
+		 * @since 6.7.0
+		 *
+		 * @param array $input The input parameters.
+		 * @return array|WP_Error The duplicated taxonomy data on success, WP_Error on failure.
+		 */
+		public function duplicate_taxonomy_callback( $input ) {
+			$taxonomy = acf_get_taxonomy( $input['identifier'] );
+			if ( ! $taxonomy ) {
+				return $this->taxonomy_not_found_error();
+			}
+
+			$new_post_id         = isset( $input['new_post_id'] ) ? $input['new_post_id'] : 0;
+			$duplicated_taxonomy = acf_duplicate_taxonomy( $input['identifier'], $new_post_id );
+
+			if ( ! $duplicated_taxonomy ) {
+				return new WP_Error( 'duplicate_taxonomy_failed', __( 'Failed to duplicate taxonomy.', 'secure-custom-fields' ) );
+			}
+
+			return $duplicated_taxonomy;
+		}
+
+		/**
+		 * Callback for the export taxonomy ability.
+		 *
+		 * @since 6.7.0
+		 *
+		 * @param array $input The input parameters.
+		 * @return array|WP_Error The export data on success, WP_Error on failure.
+		 */
+		public function export_taxonomy_callback( $input ) {
+			$taxonomy = acf_get_taxonomy( $input['identifier'] );
+			if ( ! $taxonomy ) {
+				return $this->taxonomy_not_found_error();
+			}
+
+			$export_data = acf_prepare_internal_post_type_for_export( $taxonomy, 'acf-taxonomy' );
+
+			if ( ! $export_data ) {
+				return new WP_Error( 'export_taxonomy_failed', __( 'Failed to prepare taxonomy for export.', 'secure-custom-fields' ) );
+			}
+
+			return $export_data;
+		}
+
+		/**
+		 * Callback for the import taxonomy ability.
+		 *
+		 * @since 6.7.0
+		 *
+		 * @param array|object $input The input parameters.
+		 * @return array|WP_Error The imported taxonomy data on success, WP_Error on failure.
+		 */
+		public function import_taxonomy_callback( $input ) {
+			// Import the taxonomy (handles both create and update based on presence of ID).
+			$imported_taxonomy = acf_import_internal_post_type( $input, 'acf-taxonomy' );
+
+			if ( ! $imported_taxonomy ) {
+				return new WP_Error( 'import_taxonomy_failed', __( 'Failed to import taxonomy.', 'secure-custom-fields' ) );
+			}
+
+			return $imported_taxonomy;
+		}
+
+		/**
+		 * Returns a WP_Error for taxonomy not found.
+		 *
+		 * @since 6.7.0
+		 * @return WP_Error The error object with 404 status.
+		 */
+		private function taxonomy_not_found_error() {
+			return new WP_Error(
+				'taxonomy_not_found',
+				__( 'Taxonomy not found.', 'secure-custom-fields' ),
+				array( 'status' => 404 )
+			);
+		}
+	}
+
+	// Initialize abilities instance.
+	acf_new_instance( 'SCF_Taxonomy_Abilities' );
+
+
+endif; // class_exists check.

--- a/tests/e2e/abilities-taxonomies.spec.ts
+++ b/tests/e2e/abilities-taxonomies.spec.ts
@@ -1,0 +1,482 @@
+/**
+ * E2E tests for SCF Taxonomy Abilities
+ *
+ * Tests the WordPress Abilities API endpoints for SCF taxonomy management.
+ *
+ * HTTP Method Reference (per PR #152 in WordPress/abilities-api):
+ * - Read-only abilities (readonly: true) → GET with query params
+ * - Regular abilities (readonly: false, destructive: false) → POST with body
+ * - Destructive abilities (destructive: true) → DELETE with query params
+ */
+const { test, expect } = require( './fixtures' );
+
+test.describe( 'Taxonomy Abilities', () => {
+	const PLUGIN_SLUG = 'secure-custom-fields';
+	const ABILITIES_BASE = '/wp-abilities/v1/abilities';
+
+	// Reusable test taxonomy - each test creates/cleans its own instance
+	const TEST_TAXONOMY = {
+		key: 'taxonomy_e2e_test',
+		title: 'E2E Test Taxonomy',
+		taxonomy: 'e2e_test_tax',
+	};
+
+	// Helper functions
+
+	/**
+	 * Check if Abilities API exists (for older WordPress versions).
+	 *
+	 * @param {Object} requestUtils - Playwright request utilities.
+	 */
+	async function abilitiesApiExists( requestUtils ) {
+		try {
+			await requestUtils.rest( {
+				method: 'GET',
+				path: '/wp-abilities/v1',
+			} );
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	/**
+	 * Assert that a REST request throws a "not found" error with 404 status.
+	 *
+	 * @param {Promise} requestPromise - The REST request promise to check.
+	 */
+	async function expectNotFound( requestPromise ) {
+		try {
+			await requestPromise;
+			throw new Error( 'Expected not found error but request succeeded' );
+		} catch ( error ) {
+			expect( error.code ).toBe( 'taxonomy_not_found' );
+			expect( error.data?.status ).toBe( 404 );
+		}
+	}
+
+	/**
+	 * Assert that a REST request throws an "invalid input" error with 400 status.
+	 *
+	 * @param {Promise} requestPromise - The REST request promise to check.
+	 */
+	async function expectInvalidInput( requestPromise ) {
+		try {
+			await requestPromise;
+			throw new Error(
+				'Expected invalid input error but request succeeded'
+			);
+		} catch ( error ) {
+			expect( error.code ).toBe( 'ability_invalid_input' );
+			expect( error.data?.status ).toBe( 400 );
+		}
+	}
+
+	// Taxonomy API helpers
+
+	async function listTaxonomies( requestUtils, filter = {} ) {
+		return await requestUtils.rest( {
+			method: 'POST',
+			path: `${ ABILITIES_BASE }/scf/list-taxonomies/run`,
+			data: { input: { filter } },
+		} );
+	}
+
+	async function getTaxonomy( requestUtils, identifier ) {
+		return await requestUtils.rest( {
+			method: 'POST',
+			path: `${ ABILITIES_BASE }/scf/get-taxonomy/run`,
+			data: { input: { identifier } },
+		} );
+	}
+
+	async function createTaxonomy(
+		requestUtils,
+		taxonomyData = TEST_TAXONOMY
+	) {
+		return await requestUtils.rest( {
+			method: 'POST',
+			path: `${ ABILITIES_BASE }/scf/create-taxonomy/run`,
+			data: { input: taxonomyData },
+		} );
+	}
+
+	async function updateTaxonomy( requestUtils, input ) {
+		return await requestUtils.rest( {
+			method: 'POST',
+			path: `${ ABILITIES_BASE }/scf/update-taxonomy/run`,
+			data: { input },
+		} );
+	}
+
+	async function deleteTaxonomy( requestUtils, identifier ) {
+		return await requestUtils.rest( {
+			method: 'DELETE',
+			path: `${ ABILITIES_BASE }/scf/delete-taxonomy/run`,
+			params: { 'input[identifier]': identifier },
+		} );
+	}
+
+	async function duplicateTaxonomy( requestUtils, identifier ) {
+		return await requestUtils.rest( {
+			method: 'POST',
+			path: `${ ABILITIES_BASE }/scf/duplicate-taxonomy/run`,
+			data: { input: { identifier } },
+		} );
+	}
+
+	async function exportTaxonomy( requestUtils, identifier ) {
+		return await requestUtils.rest( {
+			method: 'GET',
+			path: `${ ABILITIES_BASE }/scf/export-taxonomy/run`,
+			params: { 'input[identifier]': identifier },
+		} );
+	}
+
+	async function importTaxonomy( requestUtils, taxonomyData ) {
+		return await requestUtils.rest( {
+			method: 'POST',
+			path: `${ ABILITIES_BASE }/scf/import-taxonomy/run`,
+			data: { input: taxonomyData },
+		} );
+	}
+
+	/**
+	 * Clean up a taxonomy (ignore errors if it doesn't exist).
+	 *
+	 * @param {Object} requestUtils - Playwright request utilities.
+	 * @param {string} identifier   - The taxonomy identifier (key or ID).
+	 */
+	async function cleanupTaxonomy( requestUtils, identifier ) {
+		try {
+			await deleteTaxonomy( requestUtils, identifier );
+		} catch {
+			// Ignore errors - taxonomy may not exist
+		}
+	}
+
+	// Test setup
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin( PLUGIN_SLUG );
+
+		// Skip all tests if Abilities API is not available (older WordPress versions)
+		const hasAbilitiesApi = await abilitiesApiExists( requestUtils );
+		test.skip(
+			! hasAbilitiesApi,
+			'Abilities API not available in this WordPress version'
+		);
+	} );
+
+	// List taxonomies - POST with body
+
+	test.describe( 'scf/list-taxonomies', () => {
+		test.beforeEach( async ( { requestUtils } ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+			await createTaxonomy( requestUtils );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+		} );
+
+		test( 'should list all SCF taxonomies', async ( { requestUtils } ) => {
+			const result = await listTaxonomies( requestUtils );
+
+			expect( Array.isArray( result ) ).toBe( true );
+			expect(
+				result.some( ( tax ) => tax.key === TEST_TAXONOMY.key )
+			).toBe( true );
+		} );
+
+		test( 'should support filter parameter', async ( { requestUtils } ) => {
+			const result = await listTaxonomies( requestUtils, {
+				active: true,
+			} );
+
+			expect( Array.isArray( result ) ).toBe( true );
+		} );
+	} );
+
+	// Get taxonomy - POST with body
+
+	test.describe( 'scf/get-taxonomy', () => {
+		test.beforeEach( async ( { requestUtils } ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+			await createTaxonomy( requestUtils );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+		} );
+
+		test( 'should get a taxonomy by identifier', async ( {
+			requestUtils,
+		} ) => {
+			const result = await getTaxonomy( requestUtils, TEST_TAXONOMY.key );
+
+			expect( result ).toHaveProperty(
+				'taxonomy',
+				TEST_TAXONOMY.taxonomy
+			);
+			expect( result ).toHaveProperty( 'title', TEST_TAXONOMY.title );
+		} );
+
+		test( 'should return error for non-existent taxonomy', async ( {
+			requestUtils,
+		} ) => {
+			await expectNotFound(
+				getTaxonomy( requestUtils, 'nonexistent_taxonomy_abc' )
+			);
+		} );
+	} );
+
+	// Export taxonomy - GET with query params (readonly)
+
+	test.describe( 'scf/export-taxonomy', () => {
+		test.beforeEach( async ( { requestUtils } ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+			await createTaxonomy( requestUtils );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+		} );
+
+		test( 'should export a taxonomy as JSON', async ( {
+			requestUtils,
+		} ) => {
+			const result = await exportTaxonomy(
+				requestUtils,
+				TEST_TAXONOMY.key
+			);
+
+			expect( result ).toHaveProperty( 'key', TEST_TAXONOMY.key );
+			expect( result ).toHaveProperty(
+				'taxonomy',
+				TEST_TAXONOMY.taxonomy
+			);
+			expect( result ).toHaveProperty( 'title', TEST_TAXONOMY.title );
+		} );
+
+		test( 'should return error for non-existent taxonomy', async ( {
+			requestUtils,
+		} ) => {
+			await expectNotFound(
+				exportTaxonomy( requestUtils, 'nonexistent_export' )
+			);
+		} );
+	} );
+
+	// Create taxonomy - POST with body
+
+	test.describe( 'scf/create-taxonomy', () => {
+		test.beforeEach( async ( { requestUtils } ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+		} );
+
+		test( 'should create a new taxonomy', async ( { requestUtils } ) => {
+			const result = await createTaxonomy( requestUtils );
+
+			expect( result ).toHaveProperty(
+				'taxonomy',
+				TEST_TAXONOMY.taxonomy
+			);
+			expect( result ).toHaveProperty( 'title', TEST_TAXONOMY.title );
+			expect( result ).toHaveProperty( 'key', TEST_TAXONOMY.key );
+		} );
+
+		test( 'should return error when required fields are missing', async ( {
+			requestUtils,
+		} ) => {
+			await expectInvalidInput(
+				createTaxonomy( requestUtils, {
+					title: 'Missing Key and Taxonomy',
+				} )
+			);
+		} );
+	} );
+
+	// Update taxonomy - POST with body
+
+	test.describe( 'scf/update-taxonomy', () => {
+		let testTaxonomyId;
+
+		test.beforeEach( async ( { requestUtils } ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+			const result = await createTaxonomy( requestUtils );
+			testTaxonomyId = result.ID;
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+		} );
+
+		test( 'should update an existing taxonomy', async ( {
+			requestUtils,
+		} ) => {
+			const result = await updateTaxonomy( requestUtils, {
+				ID: testTaxonomyId,
+				title: 'Updated Title',
+			} );
+
+			expect( result ).toHaveProperty( 'title', 'Updated Title' );
+		} );
+
+		test( 'should return error for non-existent taxonomy ID', async ( {
+			requestUtils,
+		} ) => {
+			await expectNotFound(
+				updateTaxonomy( requestUtils, {
+					ID: 999999,
+					title: 'Should Fail',
+				} )
+			);
+		} );
+
+		test( 'should return error when ID is missing', async ( {
+			requestUtils,
+		} ) => {
+			await expectInvalidInput(
+				updateTaxonomy( requestUtils, { title: 'Missing ID' } )
+			);
+		} );
+	} );
+
+	// Delete taxonomy - DELETE with query params (destructive)
+
+	test.describe( 'scf/delete-taxonomy', () => {
+		test.beforeEach( async ( { requestUtils } ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+			await createTaxonomy( requestUtils );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+		} );
+
+		test( 'should delete an existing taxonomy', async ( {
+			requestUtils,
+		} ) => {
+			const result = await deleteTaxonomy(
+				requestUtils,
+				TEST_TAXONOMY.key
+			);
+			expect( result ).toBe( true );
+
+			// Verify it's actually deleted
+			await expectNotFound(
+				getTaxonomy( requestUtils, TEST_TAXONOMY.key )
+			);
+		} );
+
+		test( 'should return error for non-existent taxonomy', async ( {
+			requestUtils,
+		} ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+
+			await expectNotFound(
+				deleteTaxonomy( requestUtils, 'nonexistent_taxonomy_xyz' )
+			);
+		} );
+
+		test( 'should return error when identifier is missing', async ( {
+			requestUtils,
+		} ) => {
+			await expectInvalidInput(
+				requestUtils.rest( {
+					method: 'DELETE',
+					path: `${ ABILITIES_BASE }/scf/delete-taxonomy/run`,
+					params: { input: '' },
+				} )
+			);
+		} );
+	} );
+
+	// Duplicate taxonomy - POST with body
+	//
+	// Note: The duplicate receives a new unique key but retains the same
+	// taxonomy slug. The duplicate won't register until slug is changed.
+
+	test.describe( 'scf/duplicate-taxonomy', () => {
+		let duplicatedKey;
+
+		test.beforeEach( async ( { requestUtils } ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+			await createTaxonomy( requestUtils );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+			if ( duplicatedKey ) {
+				await cleanupTaxonomy( requestUtils, duplicatedKey );
+				duplicatedKey = null;
+			}
+		} );
+
+		test( 'should duplicate an existing taxonomy', async ( {
+			requestUtils,
+		} ) => {
+			const result = await duplicateTaxonomy(
+				requestUtils,
+				TEST_TAXONOMY.key
+			);
+			duplicatedKey = result.key;
+
+			expect( result ).toHaveProperty( 'key' );
+			expect( result ).toHaveProperty( 'taxonomy' );
+			expect( result.key ).not.toBe( TEST_TAXONOMY.key );
+			expect( result.taxonomy ).toBe( TEST_TAXONOMY.taxonomy );
+			expect( result.title ).toContain( '(copy)' );
+		} );
+
+		test( 'should return error for non-existent taxonomy', async ( {
+			requestUtils,
+		} ) => {
+			await expectNotFound(
+				duplicateTaxonomy(
+					requestUtils,
+					'nonexistent_duplicate_source'
+				)
+			);
+		} );
+	} );
+
+	// Import taxonomy - POST with body
+
+	test.describe( 'scf/import-taxonomy', () => {
+		test.beforeEach( async ( { requestUtils } ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await cleanupTaxonomy( requestUtils, TEST_TAXONOMY.key );
+		} );
+
+		test( 'should import a taxonomy from JSON', async ( {
+			requestUtils,
+		} ) => {
+			const result = await importTaxonomy( requestUtils, TEST_TAXONOMY );
+
+			expect( result ).toHaveProperty(
+				'taxonomy',
+				TEST_TAXONOMY.taxonomy
+			);
+			expect( result ).toHaveProperty( 'title', TEST_TAXONOMY.title );
+		} );
+
+		test( 'should return error when required fields are missing', async ( {
+			requestUtils,
+		} ) => {
+			await expectInvalidInput(
+				importTaxonomy( requestUtils, {
+					title: 'Missing Required Fields',
+				} )
+			);
+		} );
+	} );
+} );

--- a/tests/php/includes/abilities/abilities-api-mocks.php
+++ b/tests/php/includes/abilities/abilities-api-mocks.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Mock functions for WordPress Abilities API
+ *
+ * These mock functions capture ability registrations for testing
+ * when the WordPress Abilities API is not available (e.g., in WorDBless).
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+global $mock_registered_abilities, $mock_registered_ability_categories;
+$mock_registered_abilities          = array();
+$mock_registered_ability_categories = array();
+
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	/**
+	 * Mock wp_register_ability for testing.
+	 *
+	 * @param string $name Ability name.
+	 * @param array  $args Ability arguments.
+	 * @return bool Always returns true.
+	 */
+	function wp_register_ability( $name, $args ) {
+		global $mock_registered_abilities;
+		$mock_registered_abilities[ $name ] = $args;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_register_ability_category' ) ) {
+	/**
+	 * Mock wp_register_ability_category for testing.
+	 *
+	 * @param string $name Category name.
+	 * @param array  $args Category arguments.
+	 * @return bool Always returns true.
+	 */
+	function wp_register_ability_category( $name, $args ) {
+		global $mock_registered_ability_categories;
+		$mock_registered_ability_categories[ $name ] = $args;
+		return true;
+	}
+}

--- a/tests/php/includes/abilities/test-scf-taxonomy-abilities.php
+++ b/tests/php/includes/abilities/test-scf-taxonomy-abilities.php
@@ -11,7 +11,10 @@
 
 use WorDBless\BaseTestCase;
 
-// Load the abilities class directly since wp_register_ability doesn't exist in WorDBless.
+// Load mock Abilities API functions before loading the class.
+require_once __DIR__ . '/abilities-api-mocks.php';
+
+// Load the abilities class after mocks are defined.
 require_once dirname( __DIR__, 3 ) . '/../includes/abilities/class-scf-taxonomy-abilities.php';
 
 /**
@@ -45,10 +48,134 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 		$this->abilities = acf_get_instance( 'SCF_Taxonomy_Abilities' );
 	}
 
+	// Registration tests.
+
+	/**
+	 * Test register_categories registers the scf-taxonomies category
+	 */
+	public function test_register_categories_registers_scf_taxonomies() {
+		global $mock_registered_ability_categories;
+		$mock_registered_ability_categories = array();
+
+		$this->abilities->register_categories();
+
+		$this->assertArrayHasKey( 'scf-taxonomies', $mock_registered_ability_categories );
+		$this->assertArrayHasKey( 'label', $mock_registered_ability_categories['scf-taxonomies'] );
+	}
+
+	/**
+	 * Test register_abilities registers all expected abilities
+	 */
+	public function test_register_abilities_registers_all_abilities() {
+		global $mock_registered_abilities;
+		$mock_registered_abilities = array();
+
+		$this->abilities->register_abilities();
+
+		$expected_abilities = array(
+			'scf/list-taxonomies',
+			'scf/get-taxonomy',
+			'scf/create-taxonomy',
+			'scf/update-taxonomy',
+			'scf/delete-taxonomy',
+			'scf/duplicate-taxonomy',
+			'scf/export-taxonomy',
+			'scf/import-taxonomy',
+		);
+
+		foreach ( $expected_abilities as $ability_name ) {
+			$this->assertArrayHasKey( $ability_name, $mock_registered_abilities, "Missing ability: $ability_name" );
+		}
+	}
+
+	/**
+	 * Test registered abilities have correct category
+	 */
+	public function test_registered_abilities_have_correct_category() {
+		global $mock_registered_abilities;
+		$mock_registered_abilities = array();
+
+		$this->abilities->register_abilities();
+
+		foreach ( $mock_registered_abilities as $name => $args ) {
+			$this->assertEquals(
+				'scf-taxonomies',
+				$args['category'],
+				"Ability $name has wrong category"
+			);
+		}
+	}
+
+	/**
+	 * Test registered abilities have execute callbacks
+	 */
+	public function test_registered_abilities_have_execute_callbacks() {
+		global $mock_registered_abilities;
+		$mock_registered_abilities = array();
+
+		$this->abilities->register_abilities();
+
+		foreach ( $mock_registered_abilities as $name => $args ) {
+			$this->assertArrayHasKey( 'execute_callback', $args, "Ability $name missing execute_callback" );
+			$this->assertIsCallable( $args['execute_callback'], "Ability $name execute_callback is not callable" );
+		}
+	}
+
+	/**
+	 * Test registered abilities have input schemas
+	 */
+	public function test_registered_abilities_have_input_schemas() {
+		global $mock_registered_abilities;
+		$mock_registered_abilities = array();
+
+		$this->abilities->register_abilities();
+
+		foreach ( $mock_registered_abilities as $name => $args ) {
+			$this->assertArrayHasKey( 'input_schema', $args, "Ability $name missing input_schema" );
+		}
+	}
+
+	/**
+	 * Test delete ability is marked as destructive
+	 */
+	public function test_delete_ability_is_destructive() {
+		global $mock_registered_abilities;
+		$mock_registered_abilities = array();
+
+		$this->abilities->register_abilities();
+
+		$this->assertArrayHasKey( 'scf/delete-taxonomy', $mock_registered_abilities );
+		$ability     = $mock_registered_abilities['scf/delete-taxonomy'];
+		$meta        = $ability['meta'] ?? array();
+		$annotations = $meta['annotations'] ?? array();
+		$this->assertTrue( $annotations['destructive'] ?? false, 'Delete ability should be marked destructive' );
+	}
+
+	/**
+	 * Test export ability is marked as readonly
+	 */
+	public function test_export_ability_is_readonly() {
+		global $mock_registered_abilities;
+		$mock_registered_abilities = array();
+
+		$this->abilities->register_abilities();
+
+		$this->assertArrayHasKey( 'scf/export-taxonomy', $mock_registered_abilities );
+		$ability     = $mock_registered_abilities['scf/export-taxonomy'];
+		$meta        = $ability['meta'] ?? array();
+		$annotations = $meta['annotations'] ?? array();
+		$this->assertTrue( $annotations['readonly'] ?? false, 'Export ability should be marked readonly' );
+	}
+
+	// Callback tests.
+
 	/**
 	 * Test list_taxonomies_callback returns array
+	 *
+	 * Note: Full CRUD flow tests require WordPress post persistence
+	 * which WorDBless doesn't fully support. These are tested in E2E.
 	 */
-	public function test_list_taxonomies_returns_array() {
+	public function test_list_taxonomies_callback_returns_array() {
 		$result = $this->abilities->list_taxonomies_callback( array() );
 
 		$this->assertIsArray( $result );
@@ -57,7 +184,7 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 	/**
 	 * Test list_taxonomies_callback with filter parameter
 	 */
-	public function test_list_taxonomies_with_filter() {
+	public function test_list_taxonomies_callback_with_filter() {
 		$result = $this->abilities->list_taxonomies_callback(
 			array( 'filter' => array( 'active' => true ) )
 		);
@@ -66,31 +193,9 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 	}
 
 	/**
-	 * Test create_taxonomy_callback returns array with key
-	 */
-	public function test_create_taxonomy_returns_array_with_key() {
-		$result = $this->abilities->create_taxonomy_callback( $this->test_taxonomy );
-
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'key', $result );
-		$this->assertEquals( $this->test_taxonomy['key'], $result['key'] );
-	}
-
-	/**
-	 * Test create_taxonomy_callback returns array with title
-	 */
-	public function test_create_taxonomy_returns_array_with_title() {
-		$result = $this->abilities->create_taxonomy_callback( $this->test_taxonomy );
-
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'title', $result );
-		$this->assertEquals( $this->test_taxonomy['title'], $result['title'] );
-	}
-
-	/**
 	 * Test get_taxonomy_callback returns WP_Error for non-existent ID
 	 */
-	public function test_get_taxonomy_not_found_returns_error() {
+	public function test_get_taxonomy_callback_not_found_returns_error() {
 		$result = $this->abilities->get_taxonomy_callback(
 			array( 'identifier' => 999999 )
 		);
@@ -102,7 +207,7 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 	/**
 	 * Test get_taxonomy_callback returns 404 status for non-existent key
 	 */
-	public function test_get_taxonomy_not_found_returns_404_status() {
+	public function test_get_taxonomy_callback_not_found_returns_404_status() {
 		$result = $this->abilities->get_taxonomy_callback(
 			array( 'identifier' => 'nonexistent_taxonomy' )
 		);
@@ -113,9 +218,31 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 	}
 
 	/**
+	 * Test create_taxonomy_callback returns array with key
+	 */
+	public function test_create_taxonomy_callback_returns_array_with_key() {
+		$result = $this->abilities->create_taxonomy_callback( $this->test_taxonomy );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'key', $result );
+		$this->assertEquals( $this->test_taxonomy['key'], $result['key'] );
+	}
+
+	/**
+	 * Test create_taxonomy_callback returns array with title
+	 */
+	public function test_create_taxonomy_callback_returns_array_with_title() {
+		$result = $this->abilities->create_taxonomy_callback( $this->test_taxonomy );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'title', $result );
+		$this->assertEquals( $this->test_taxonomy['title'], $result['title'] );
+	}
+
+	/**
 	 * Test update_taxonomy_callback returns WP_Error for non-existent ID
 	 */
-	public function test_update_taxonomy_not_found_returns_error() {
+	public function test_update_taxonomy_callback_not_found_returns_error() {
 		$result = $this->abilities->update_taxonomy_callback(
 			array(
 				'ID'    => 999999,
@@ -130,7 +257,7 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 	/**
 	 * Test delete_taxonomy_callback returns WP_Error for non-existent ID
 	 */
-	public function test_delete_taxonomy_not_found_returns_error() {
+	public function test_delete_taxonomy_callback_not_found_returns_error() {
 		$result = $this->abilities->delete_taxonomy_callback(
 			array( 'identifier' => 999999 )
 		);
@@ -142,7 +269,7 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 	/**
 	 * Test delete_taxonomy_callback returns 404 status for non-existent key
 	 */
-	public function test_delete_taxonomy_not_found_returns_404_status() {
+	public function test_delete_taxonomy_callback_not_found_returns_404_status() {
 		$result = $this->abilities->delete_taxonomy_callback(
 			array( 'identifier' => 'nonexistent_delete_target' )
 		);
@@ -155,7 +282,7 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 	/**
 	 * Test duplicate_taxonomy_callback returns WP_Error for non-existent ID
 	 */
-	public function test_duplicate_taxonomy_not_found_returns_error() {
+	public function test_duplicate_taxonomy_callback_not_found_returns_error() {
 		$result = $this->abilities->duplicate_taxonomy_callback(
 			array( 'identifier' => 999999 )
 		);
@@ -167,7 +294,7 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 	/**
 	 * Test export_taxonomy_callback returns WP_Error for non-existent ID
 	 */
-	public function test_export_taxonomy_not_found_returns_error() {
+	public function test_export_taxonomy_callback_not_found_returns_error() {
 		$result = $this->abilities->export_taxonomy_callback(
 			array( 'identifier' => 999999 )
 		);
@@ -179,7 +306,7 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 	/**
 	 * Test import_taxonomy_callback returns array
 	 */
-	public function test_import_taxonomy_returns_array() {
+	public function test_import_taxonomy_callback_returns_array() {
 		$result = $this->abilities->import_taxonomy_callback( $this->test_taxonomy );
 
 		$this->assertIsArray( $result );
@@ -188,7 +315,7 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 	/**
 	 * Test import_taxonomy_callback returns correct taxonomy
 	 */
-	public function test_import_taxonomy_returns_correct_taxonomy() {
+	public function test_import_taxonomy_callback_returns_correct_taxonomy() {
 		$result = $this->abilities->import_taxonomy_callback( $this->test_taxonomy );
 
 		$this->assertIsArray( $result );
@@ -198,10 +325,83 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 	/**
 	 * Test import_taxonomy_callback returns correct title
 	 */
-	public function test_import_taxonomy_returns_correct_title() {
+	public function test_import_taxonomy_callback_returns_correct_title() {
 		$result = $this->abilities->import_taxonomy_callback( $this->test_taxonomy );
 
 		$this->assertIsArray( $result );
 		$this->assertEquals( $this->test_taxonomy['title'], $result['title'] );
+	}
+
+	// Schema tests.
+
+	/**
+	 * Test get_taxonomy_schema returns valid schema
+	 */
+	public function test_get_taxonomy_schema_returns_array() {
+		$reflection = new ReflectionClass( $this->abilities );
+		$method     = $reflection->getMethod( 'get_taxonomy_schema' );
+
+		$schema = $method->invoke( $this->abilities );
+
+		$this->assertIsArray( $schema );
+		$this->assertArrayHasKey( 'type', $schema );
+		$this->assertEquals( 'object', $schema['type'] );
+	}
+
+	/**
+	 * Test get_taxonomy_schema has required fields
+	 */
+	public function test_get_taxonomy_schema_has_required_fields() {
+		$reflection = new ReflectionClass( $this->abilities );
+		$method     = $reflection->getMethod( 'get_taxonomy_schema' );
+
+		$schema = $method->invoke( $this->abilities );
+
+		$this->assertArrayHasKey( 'required', $schema );
+		$this->assertContains( 'key', $schema['required'] );
+		$this->assertContains( 'title', $schema['required'] );
+		$this->assertContains( 'taxonomy', $schema['required'] );
+	}
+
+	/**
+	 * Test get_scf_identifier_schema returns valid schema
+	 */
+	public function test_get_scf_identifier_schema_returns_array() {
+		$reflection = new ReflectionClass( $this->abilities );
+		$method     = $reflection->getMethod( 'get_scf_identifier_schema' );
+
+		$schema = $method->invoke( $this->abilities );
+
+		$this->assertIsArray( $schema );
+		// Should have description and allow integer or string.
+		$this->assertArrayHasKey( 'description', $schema );
+	}
+
+	// Helper method tests.
+
+	/**
+	 * Test taxonomy_not_found_error returns correct error code
+	 */
+	public function test_taxonomy_not_found_error_returns_correct_code() {
+		$reflection = new ReflectionClass( $this->abilities );
+		$method     = $reflection->getMethod( 'taxonomy_not_found_error' );
+
+		$error = $method->invoke( $this->abilities );
+
+		$this->assertInstanceOf( WP_Error::class, $error );
+		$this->assertEquals( 'taxonomy_not_found', $error->get_error_code() );
+	}
+
+	/**
+	 * Test taxonomy_not_found_error returns 404 status
+	 */
+	public function test_taxonomy_not_found_error_returns_404() {
+		$reflection = new ReflectionClass( $this->abilities );
+		$method     = $reflection->getMethod( 'taxonomy_not_found_error' );
+
+		$error      = $method->invoke( $this->abilities );
+		$error_data = $error->get_error_data();
+
+		$this->assertEquals( 404, $error_data['status'] );
 	}
 }

--- a/tests/php/includes/abilities/test-scf-taxonomy-abilities.php
+++ b/tests/php/includes/abilities/test-scf-taxonomy-abilities.php
@@ -48,6 +48,60 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 		$this->abilities = acf_get_instance( 'SCF_Taxonomy_Abilities' );
 	}
 
+	// Constructor tests.
+
+	/**
+	 * Test constructor registers WordPress action hooks
+	 */
+	public function test_constructor_registers_action_hooks() {
+		// The constructor should have registered these action hooks.
+		$this->assertNotFalse(
+			has_action( 'wp_abilities_api_categories_init', array( $this->abilities, 'register_categories' ) ),
+			'Should register wp_abilities_api_categories_init action'
+		);
+		$this->assertNotFalse(
+			has_action( 'wp_abilities_api_init', array( $this->abilities, 'register_abilities' ) ),
+			'Should register wp_abilities_api_init action'
+		);
+	}
+
+	/**
+	 * Test constructor does not register hooks when schema validation fails
+	 */
+	public function test_constructor_skips_hooks_when_schemas_invalid() {
+		global $acf_instances;
+
+		// Store original validator.
+		$original_validator = $acf_instances['SCF_JSON_Schema_Validator'] ?? null;
+
+		// Create mock validator that returns false.
+		$mock_validator                             = new class() {
+			/**
+			 * Mock validation that always fails.
+			 *
+			 * @return bool Always returns false.
+			 */
+			public function validate_required_schemas() {
+				return false;
+			}
+		};
+		$acf_instances['SCF_JSON_Schema_Validator'] = $mock_validator;
+
+		// Create a fresh instance (bypassing acf_get_instance cache for this class).
+		$test_instance = new SCF_Taxonomy_Abilities();
+
+		// Verify NO hooks were registered for this instance.
+		$this->assertFalse(
+			has_action( 'wp_abilities_api_categories_init', array( $test_instance, 'register_categories' ) ),
+			'Should NOT register hooks when schema validation fails'
+		);
+
+		// Restore original validator.
+		if ( $original_validator ) {
+			$acf_instances['SCF_JSON_Schema_Validator'] = $original_validator;
+		}
+	}
+
 	// Registration tests.
 
 	/**

--- a/tests/php/includes/abilities/test-scf-taxonomy-abilities.php
+++ b/tests/php/includes/abilities/test-scf-taxonomy-abilities.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Tests for SCF_Taxonomy_Abilities class
+ *
+ * Note: Full integration tests including create/get/update/delete flows are covered
+ * by e2e tests in tests/e2e/abilities-taxonomies.spec.ts. These PHPUnit tests focus
+ * on callback structure and error handling that can be tested in WorDBless.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+// Load the abilities class directly since wp_register_ability doesn't exist in WorDBless.
+require_once dirname( __DIR__, 3 ) . '/../includes/abilities/class-scf-taxonomy-abilities.php';
+
+/**
+ * Test SCF Taxonomy Abilities callbacks
+ */
+class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
+
+	/**
+	 * Instance of SCF_Taxonomy_Abilities for testing
+	 *
+	 * @var SCF_Taxonomy_Abilities
+	 */
+	private $abilities;
+
+	/**
+	 * Test taxonomy data
+	 *
+	 * @var array
+	 */
+	private $test_taxonomy = array(
+		'key'      => 'taxonomy_phpunit_test',
+		'title'    => 'PHPUnit Test Taxonomy',
+		'taxonomy' => 'phpunit_test',
+	);
+
+	/**
+	 * Setup test fixtures
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->abilities = acf_get_instance( 'SCF_Taxonomy_Abilities' );
+	}
+
+	/**
+	 * Test list_taxonomies_callback returns array
+	 */
+	public function test_list_taxonomies_returns_array() {
+		$result = $this->abilities->list_taxonomies_callback( array() );
+
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Test list_taxonomies_callback with filter parameter
+	 */
+	public function test_list_taxonomies_with_filter() {
+		$result = $this->abilities->list_taxonomies_callback(
+			array( 'filter' => array( 'active' => true ) )
+		);
+
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Test create_taxonomy_callback returns array with key
+	 */
+	public function test_create_taxonomy_returns_array_with_key() {
+		$result = $this->abilities->create_taxonomy_callback( $this->test_taxonomy );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'key', $result );
+		$this->assertEquals( $this->test_taxonomy['key'], $result['key'] );
+	}
+
+	/**
+	 * Test create_taxonomy_callback returns array with title
+	 */
+	public function test_create_taxonomy_returns_array_with_title() {
+		$result = $this->abilities->create_taxonomy_callback( $this->test_taxonomy );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'title', $result );
+		$this->assertEquals( $this->test_taxonomy['title'], $result['title'] );
+	}
+
+	/**
+	 * Test get_taxonomy_callback returns WP_Error for non-existent ID
+	 */
+	public function test_get_taxonomy_not_found_returns_error() {
+		$result = $this->abilities->get_taxonomy_callback(
+			array( 'identifier' => 999999 )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'taxonomy_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test get_taxonomy_callback returns 404 status for non-existent key
+	 */
+	public function test_get_taxonomy_not_found_returns_404_status() {
+		$result = $this->abilities->get_taxonomy_callback(
+			array( 'identifier' => 'nonexistent_taxonomy' )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$error_data = $result->get_error_data();
+		$this->assertEquals( 404, $error_data['status'] );
+	}
+
+	/**
+	 * Test update_taxonomy_callback returns WP_Error for non-existent ID
+	 */
+	public function test_update_taxonomy_not_found_returns_error() {
+		$result = $this->abilities->update_taxonomy_callback(
+			array(
+				'ID'    => 999999,
+				'title' => 'Should Fail',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'taxonomy_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test delete_taxonomy_callback returns WP_Error for non-existent ID
+	 */
+	public function test_delete_taxonomy_not_found_returns_error() {
+		$result = $this->abilities->delete_taxonomy_callback(
+			array( 'identifier' => 999999 )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'taxonomy_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test delete_taxonomy_callback returns 404 status for non-existent key
+	 */
+	public function test_delete_taxonomy_not_found_returns_404_status() {
+		$result = $this->abilities->delete_taxonomy_callback(
+			array( 'identifier' => 'nonexistent_delete_target' )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$error_data = $result->get_error_data();
+		$this->assertEquals( 404, $error_data['status'] );
+	}
+
+	/**
+	 * Test duplicate_taxonomy_callback returns WP_Error for non-existent ID
+	 */
+	public function test_duplicate_taxonomy_not_found_returns_error() {
+		$result = $this->abilities->duplicate_taxonomy_callback(
+			array( 'identifier' => 999999 )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'taxonomy_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test export_taxonomy_callback returns WP_Error for non-existent ID
+	 */
+	public function test_export_taxonomy_not_found_returns_error() {
+		$result = $this->abilities->export_taxonomy_callback(
+			array( 'identifier' => 999999 )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'taxonomy_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test import_taxonomy_callback returns array
+	 */
+	public function test_import_taxonomy_returns_array() {
+		$result = $this->abilities->import_taxonomy_callback( $this->test_taxonomy );
+
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Test import_taxonomy_callback returns correct taxonomy
+	 */
+	public function test_import_taxonomy_returns_correct_taxonomy() {
+		$result = $this->abilities->import_taxonomy_callback( $this->test_taxonomy );
+
+		$this->assertIsArray( $result );
+		$this->assertEquals( $this->test_taxonomy['taxonomy'], $result['taxonomy'] );
+	}
+
+	/**
+	 * Test import_taxonomy_callback returns correct title
+	 */
+	public function test_import_taxonomy_returns_correct_title() {
+		$result = $this->abilities->import_taxonomy_callback( $this->test_taxonomy );
+
+		$this->assertIsArray( $result );
+		$this->assertEquals( $this->test_taxonomy['title'], $result['title'] );
+	}
+}

--- a/tests/php/includes/abilities/test-scf-taxonomy-abilities.php
+++ b/tests/php/includes/abilities/test-scf-taxonomy-abilities.php
@@ -340,6 +340,7 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 	public function test_get_taxonomy_schema_returns_array() {
 		$reflection = new ReflectionClass( $this->abilities );
 		$method     = $reflection->getMethod( 'get_taxonomy_schema' );
+		$method->setAccessible( true );
 
 		$schema = $method->invoke( $this->abilities );
 
@@ -354,6 +355,7 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 	public function test_get_taxonomy_schema_has_required_fields() {
 		$reflection = new ReflectionClass( $this->abilities );
 		$method     = $reflection->getMethod( 'get_taxonomy_schema' );
+		$method->setAccessible( true );
 
 		$schema = $method->invoke( $this->abilities );
 
@@ -369,6 +371,7 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 	public function test_get_scf_identifier_schema_returns_array() {
 		$reflection = new ReflectionClass( $this->abilities );
 		$method     = $reflection->getMethod( 'get_scf_identifier_schema' );
+		$method->setAccessible( true );
 
 		$schema = $method->invoke( $this->abilities );
 
@@ -385,6 +388,7 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 	public function test_taxonomy_not_found_error_returns_correct_code() {
 		$reflection = new ReflectionClass( $this->abilities );
 		$method     = $reflection->getMethod( 'taxonomy_not_found_error' );
+		$method->setAccessible( true );
 
 		$error = $method->invoke( $this->abilities );
 
@@ -398,6 +402,7 @@ class Test_SCF_Taxonomy_Abilities extends BaseTestCase {
 	public function test_taxonomy_not_found_error_returns_404() {
 		$reflection = new ReflectionClass( $this->abilities );
 		$method     = $reflection->getMethod( 'taxonomy_not_found_error' );
+		$method->setAccessible( true );
 
 		$error      = $method->invoke( $this->abilities );
 		$error_data = $error->get_error_data();


### PR DESCRIPTION
## What
Part of #171

Add WordPress Abilities API support for SCF taxonomy management, enabling AI assistants and MCP clients to create, read, update, delete, duplicate, import, and export taxonomies.

## Why
Taxonomies need the same MCP/Abilities integration that post types already have; AI assistants should be able to manage custom taxonomies through the Abilities API

## How
- Adds `SCF_Taxonomy_Abilities` class with 8 abilities: list, get, create, update, delete, duplicate, export, import
- Registers abilities under `scf-taxonomies` category, reusing the JSON Schema introduced in #261 
- Follows existing post-type abilities patterns for consistency

## Testing Instructions
1. Ensure WordPress has the Abilities API available (6.9+ or through the Abilities API plugin)
2. Connect your preferred LLM to your WP installation through the MCP Adapter
3. Ask the LLM to list the SCF abilities.
4. Ask it to list, create, update, delete, etc. taxonomies. It should use the available abilities