### PR TITLE
e2e: Fix broken tests in trunk against WP versions under 6.9

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,7 +35,7 @@ jobs:
                     - event: 'pull_request'
                       node: '24'
                     - event: 'pull_request'
-                      wp: 'latest'
+                      wp: 'trunk'
 
         env:
             WP_ENV_CORE: ${{ matrix.wp == 'trunk' && 'WordPress/WordPress' || null }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,7 +35,7 @@ jobs:
                     - event: 'pull_request'
                       node: '24'
                     - event: 'pull_request'
-                      wp: 'trunk'
+                      wp: 'latest'
 
         env:
             WP_ENV_CORE: ${{ matrix.wp == 'trunk' && 'WordPress/WordPress' || null }}

--- a/tests/e2e/field-type-repeater.spec.ts
+++ b/tests/e2e/field-type-repeater.spec.ts
@@ -113,7 +113,10 @@ test.describe( 'Field Type > Repeater', () => {
         // @see https://github.com/WordPress/gutenberg/issues/72185
         await page.waitForSelector( '.acf-postbox', { state: 'attached' } );
         const metaBoxPanel = page.getByRole( 'button', { name: 'Meta Boxes' } );
-        if ( ( await metaBoxPanel.getAttribute( 'aria-expanded' ) ) === 'false' ) {
+        if (
+            ( await metaBoxPanel.count() ) > 0 &&
+            ( await metaBoxPanel.getAttribute( 'aria-expanded' ) ) === 'false'
+        ) {
             await metaBoxPanel.focus();
             await metaBoxPanel.press( 'Enter' );
         }

--- a/tests/e2e/field-type-text.spec.ts
+++ b/tests/e2e/field-type-text.spec.ts
@@ -84,7 +84,10 @@ test.describe( 'Field Type > Text', () => {
 		// @see https://github.com/WordPress/gutenberg/issues/72185
 		await page.waitForSelector( '.acf-postbox', { state: 'attached' } );
 		const metaBoxPanel = page.getByRole( 'button', { name: 'Meta Boxes' } );
-		if ( ( await metaBoxPanel.getAttribute( 'aria-expanded' ) ) === 'false' ) {
+		if (
+			( await metaBoxPanel.count() ) > 0 &&
+			( await metaBoxPanel.getAttribute( 'aria-expanded' ) ) === 'false'
+		) {
 			await metaBoxPanel.focus();
 			await metaBoxPanel.press( 'Enter' );
 		}


### PR DESCRIPTION
## What
Fixes e2e tests that are broken in trunk after #259 

## Why
The refactor introduced in #259 was incompatible with WP 6.8, but I didn't catch the test regression as the PR was running the tests against trunk, not 6.8.

## How
Only trying to open the metabox panel if the button to open it exists, which will support both cases where the metaboxes panel is open and collapsed.