### PR TITLE
e2e tests: fix tests compatibility for WP 6.2

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,11 +30,12 @@ jobs:
                 node: ['22', '24']
                 wp: ['6.2', 'latest', 'trunk']
                 exclude:
-                    # TEMPORARY, DO NOT MERGE: testing WP 6.2 compatibility fix
+                    # On PRs: only test Node 22 + WP trunk for fast feedback
+                    # On trunk: full matrix with minimum and latest WP versions
                     - event: 'pull_request'
                       node: '24'
                     - event: 'pull_request'
-                      wp: 'latest'
+                      wp: '6.2'
                     - event: 'pull_request'
                       wp: 'trunk'
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,12 +30,11 @@ jobs:
                 node: ['22', '24']
                 wp: ['6.2', 'latest', 'trunk']
                 exclude:
-                    # On PRs: only test Node 22 + WP trunk for fast feedback
-                    # On trunk: full matrix with minimum and latest WP versions
+                    # TEMPORARY, DO NOT MERGE: testing WP 6.2 compatibility fix
                     - event: 'pull_request'
                       node: '24'
                     - event: 'pull_request'
-                      wp: '6.2'
+                      wp: 'latest'
                     - event: 'pull_request'
                       wp: 'trunk'
 

--- a/tests/e2e/block-testimonial.spec.ts
+++ b/tests/e2e/block-testimonial.spec.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const { test, expect } = require( './fixtures' );
 
 const PLUGIN_SLUG = 'secure-custom-fields';
 const TEST_PLUGIN_SLUG = 'scf-test-plugin-testimonial-block';

--- a/tests/e2e/field-type-text-term.spec.ts
+++ b/tests/e2e/field-type-text-term.spec.ts
@@ -104,12 +104,11 @@ test.describe( 'Field Type > Text', () => {
         
         // Visit the category archive page
         await page.goto( '/?cat=1' );
-        
+
         // Verify the custom field value appears on the frontend
-        await page.waitForSelector( '#scf-test-term-title' );
         await expect(
-            page.locator( '#scf-test-term-title' )
-        ).toContainText( 'Term title: Custom Term Value' );
+            page.getByText( 'Term title: Custom Term Value' )
+        ).toBeVisible();
     } );
 } );
 

--- a/tests/e2e/field-type-text-user.spec.ts
+++ b/tests/e2e/field-type-text-user.spec.ts
@@ -109,12 +109,11 @@ test.describe( 'Field Type > Text', () => {
 		} );
         // Visit the author archive page
 		await page.goto( '/?author=1' );
-		
+
 		// Verify the custom field value appears on the frontend
-		await page.waitForSelector( '#scf-test-user-title' );
 		await expect(
-			page.locator( '#scf-test-user-title' )
-		).toContainText( 'User title: Test User Title' );
+			page.getByText( 'User title: Test User Title' )
+		).toBeVisible();
 
     } );
 } );

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -33,7 +33,7 @@ async function saveCoverage( coverage ) {
 	);
 }
 
-// Extend WordPress test with Istanbul coverage collection
+// Extend WordPress test with Istanbul coverage collection and WP version compatibility
 const test = wpTest.extend( {
 	page: async ( { page }, use ) => {
 		await use( page );
@@ -45,6 +45,40 @@ const test = wpTest.extend( {
 				await saveCoverage( coverage );
 			}
 		}
+	},
+
+	/**
+	 * Override editor fixture to provide version-compatible openPreviewPage.
+	 * WP 6.3+ has "View" button, WP 6.2 has "Preview" button.
+	 */
+	editor: async ( { editor, page, context }, use ) => {
+		await use( {
+			...editor,
+			openPreviewPage: async () => {
+				const isWP63OrLater = await page.evaluate(
+					() => ! document.body.classList.contains( 'branch-6-2' )
+				);
+
+				if ( isWP63OrLater ) {
+					return editor.openPreviewPage();
+				}
+
+				// WP 6.2: fallback to checking for the "Preview" button
+				const editorTopBar = page.locator(
+					'role=region[name="Editor top bar"i]'
+				);
+				await editorTopBar
+					.locator( 'role=button[name="Preview"i]' )
+					.click();
+
+				const [ previewPage ] = await Promise.all( [
+					context.waitForEvent( 'page' ),
+					page.click( 'role=menuitem[name="Preview in new tab"i]' ),
+				] );
+
+				return previewPage;
+			},
+		} );
 	},
 } );
 

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -47,38 +47,55 @@ const test = wpTest.extend( {
 		}
 	},
 
-	/**
-	 * Override editor fixture to provide version-compatible openPreviewPage.
-	 * WP 6.3+ has "View" button, WP 6.2 has "Preview" button.
-	 */
+	// Override editor fixture to provide version-compatible methods.
+	// WP 6.3+ has "View" button and iframe canvas, WP 6.2 has "Preview" button and no iframe.
 	editor: async ( { editor, page, context }, use ) => {
-		await use( {
-			...editor,
-			openPreviewPage: async () => {
-				const isWP63OrLater = await page.evaluate(
-					() => ! document.body.classList.contains( 'branch-6-2' )
-				);
+		// Create extended editor object with version-compatible overrides
+		const extendedEditor = Object.create( editor, {
+			// WP 6.2 doesn't have iframe canvas. Return a Promise so
+			// `await editor.canvas` works correctly for both versions.
+			canvas: {
+				get() {
+					return ( async () => {
+						const isWP62 = await page.evaluate(
+							() => document.body.classList.contains( 'branch-6-2' )
+						);
+						if ( isWP62 ) {
+							return page;
+						}
+						return page.frameLocator( 'iframe[name="editor-canvas"]' );
+					} )();
+				},
+			},
+			// WP 6.2 has "Preview" button, WP 6.3+ has "View" button.
+			openPreviewPage: {
+				value: async () => {
+					const isWP62 = await page.evaluate(
+						() => document.body.classList.contains( 'branch-6-2' )
+					);
 
-				if ( isWP63OrLater ) {
-					return editor.openPreviewPage();
-				}
+					if ( ! isWP62 ) {
+						return editor.openPreviewPage();
+					}
 
-				// WP 6.2: fallback to checking for the "Preview" button
-				const editorTopBar = page.locator(
-					'role=region[name="Editor top bar"i]'
-				);
-				await editorTopBar
-					.locator( 'role=button[name="Preview"i]' )
-					.click();
+					const editorTopBar = page.locator(
+						'role=region[name="Editor top bar"i]'
+					);
+					await editorTopBar
+						.locator( 'role=button[name="Preview"i]' )
+						.click();
 
-				const [ previewPage ] = await Promise.all( [
-					context.waitForEvent( 'page' ),
-					page.click( 'role=menuitem[name="Preview in new tab"i]' ),
-				] );
+					const [ previewPage ] = await Promise.all( [
+						context.waitForEvent( 'page' ),
+						page.click( 'role=menuitem[name="Preview in new tab"i]' ),
+					] );
 
-				return previewPage;
+					return previewPage;
+				},
 			},
 		} );
+
+		await use( extendedEditor );
 	},
 } );
 


### PR DESCRIPTION
## What
Fixes the e2e suite so that it also works with WordPress 6.2

## Why
SCF requires a minimum WordPress version of 6.2, but the wp test utils we are using don't support older versions 

## How
- Creating an extended `editor` object that provides compatible ways to get:
  - The preview page (the button text changed in WP 6.3)
  - The canvas (there was no iframe in 6.2)
- Switching term/user tests from ID selectors to text locators