### PR TITLE
Fix block validation on WordPress 6.2

### DIFF
--- a/assets/src/js/_acf-validation.js
+++ b/assets/src/js/_acf-validation.js
@@ -1162,9 +1162,11 @@
 											'editor-post-publish-panel'
 										)[ 0 ];
 									if ( publishPanel ) {
+										// See https://github.com/WordPress/secure-custom-fields/pull/272
+										// `togglePublishSidebar` was only introduced in WP 6.6, it should be optional
 										wp.data
 											.dispatch( 'core/editor' )
-											.togglePublishSidebar();
+											.togglePublishSidebar?.();
 									}
 
 									// Add block to errors array


### PR DESCRIPTION
## What

Fixes block validation failing on WordPress 6.2, allowing posts to publish despite validation errors in blocks.

## Why

While working on #271 to make e2e tests compatible with WP 6.2, one test failed for a valid reason related to production code: `togglePublishSidebar()` was added in WordPress 6.3 and doesn't exist in 6.2. The error broke the promise chain before it could return `hasError = true`. This caused the validation to silently fail, allowing posts with invalid blocks to be published.

## How

Checking if `togglePublishSidebar` exists before calling it:
- The function is only used for closing the publish panel; validation logic is unaffected
- When the method doesn't exist, we skip the panel close, but validation still works correctly

## Testing Instructions

1. Set up an instance of WordPress 6.2
2. Create a post with a testimonial block, or any SCF block with required fields
3. Clear a required field and try to publish
4. Verify the post is NOT published, and an error notice appears