### PR TITLE
Abilities support: Add abilities for Options Pages

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -36,3 +36,5 @@ ignore:
     - 'node_modules'
     - 'tests'
     - 'vendor'
+    # Individual file exclusions
+    - 'includes/abilities/class-scf-ui-options-page-abilities.php' # Thin wrapper - logic tested via base class

--- a/includes/abilities/class-scf-abilities-integration.php
+++ b/includes/abilities/class-scf-abilities-integration.php
@@ -42,6 +42,7 @@ if ( ! class_exists( 'SCF_Abilities_Integration' ) ) {
 			acf_include( 'includes/abilities/class-scf-internal-post-type-abilities.php' );
 			acf_include( 'includes/abilities/class-scf-post-type-abilities.php' );
 			acf_include( 'includes/abilities/class-scf-taxonomy-abilities.php' );
+			acf_include( 'includes/abilities/class-scf-ui-options-page-abilities.php' );
 		}
 
 		/**

--- a/includes/abilities/class-scf-ui-options-page-abilities.php
+++ b/includes/abilities/class-scf-ui-options-page-abilities.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * SCF UI Options Page Abilities
+ *
+ * Handles WordPress Abilities API registration for SCF UI options page management.
+ *
+ * @package wordpress/secure-custom-fields
+ * @since 6.8.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'SCF_UI_Options_Page_Abilities' ) ) :
+
+	/**
+	 * SCF UI Options Page Abilities class.
+	 *
+	 * Registers and handles all UI options page management abilities for the
+	 * WordPress Abilities API integration. Provides programmatic access
+	 * to SCF UI options page operations.
+	 *
+	 * @since 6.8.0
+	 */
+	class SCF_UI_Options_Page_Abilities extends SCF_Internal_Post_Type_Abilities {
+
+		/**
+		 * The internal post type identifier.
+		 *
+		 * @var string
+		 */
+		protected $internal_post_type = 'acf-ui-options-page';
+	}
+
+	// Initialize abilities instance.
+	acf_new_instance( 'SCF_UI_Options_Page_Abilities' );
+
+endif; // class_exists check.

--- a/includes/abilities/class-scf-ui-options-page-abilities.php
+++ b/includes/abilities/class-scf-ui-options-page-abilities.php
@@ -6,6 +6,7 @@
  *
  * @package wordpress/secure-custom-fields
  * @since 6.8.0
+ * @codeCoverageIgnore Base class is tested.
  */
 
 // Exit if accessed directly.

--- a/includes/class-scf-json-schema-validator.php
+++ b/includes/class-scf-json-schema-validator.php
@@ -26,7 +26,7 @@ if ( ! class_exists( 'SCF_JSON_Schema_Validator' ) ) :
 		 *
 		 * @var array
 		 */
-		public const REQUIRED_SCHEMAS = array( 'post-type', 'taxonomy', 'internal-fields', 'scf-identifier' );
+		public const REQUIRED_SCHEMAS = array( 'post-type', 'taxonomy', 'ui-options-page', 'internal-fields', 'scf-identifier' );
 
 		/**
 		 * The last validation errors.

--- a/tests/e2e/abilities-internal-post-types.spec.ts
+++ b/tests/e2e/abilities-internal-post-types.spec.ts
@@ -1,8 +1,8 @@
 /**
- * E2E tests for SCF Internal Post Type Abilities (Post Types and Taxonomies)
+ * E2E tests for SCF Internal Post Type Abilities (Post Types, Taxonomies, and UI Options Pages)
  *
- * Tests the WordPress Abilities API endpoints for SCF post type and taxonomy management.
- * Both entity types share the same base class, so tests are parameterized.
+ * Tests the WordPress Abilities API endpoints for SCF internal post type management.
+ * All entity types share the same base class, so tests are parameterized.
  *
  * HTTP Method Reference:
  * - Read-only abilities (readonly: true) → GET with bracket notation: { 'input[key]': value }
@@ -41,6 +41,17 @@ const ENTITY_TYPES = [
 			key: 'taxonomy_e2e_test',
 			title: 'E2E Test Taxonomy',
 			taxonomy: 'e2e_test_tax',
+		},
+	},
+	{
+		name: 'UI Options Page',
+		slug: 'ui-options-page',
+		slugPlural: 'ui-options-pages',
+		identifierKey: 'menu_slug',
+		testEntity: {
+			key: 'ui_options_page_e2e_test',
+			title: 'E2E Test Options Page',
+			menu_slug: 'e2e-test-options',
 		},
 	},
 ];

--- a/tests/php/includes/abilities/test-scf-internal-post-type-abilities.php
+++ b/tests/php/includes/abilities/test-scf-internal-post-type-abilities.php
@@ -13,10 +13,10 @@ use WorDBless\BaseTestCase;
 // Load mock Abilities API functions before loading the class.
 require_once __DIR__ . '/abilities-api-mocks.php';
 
-// Load ACF internal post type class to register the taxonomy instance.
+// Load ACF_Taxonomy class required by SCF_Taxonomy_Abilities.
 require_once dirname( __DIR__, 4 ) . '/includes/post-types/class-acf-taxonomy.php';
 
-// Load the abilities classes after ACF classes are loaded.
+// Load abilities classes for testing.
 require_once dirname( __DIR__, 4 ) . '/includes/abilities/class-scf-internal-post-type-abilities.php';
 require_once dirname( __DIR__, 4 ) . '/includes/abilities/class-scf-taxonomy-abilities.php';
 


### PR DESCRIPTION
## What
Part of https://github.com/WordPress/secure-custom-fields/issues/171

Adds WordPress Abilities API support for UI Options Pages, enabling AI assistants and external tools to manage options pages programmatically.

## Why
Enables AI-powered workflows to create, read, update, delete, duplicate, import, and export options pages, maintaining consistency with the existing abilities implementation pattern.

## How
Follows the same pattern as the other abilities
- Added `SCF_UI_Options_Page_Abilities` class extending the base internal post type abilities
- Registered options pages abilities in the abilities integration class
- Added E2E tests covering all CRUD operations for options pages
- Excluded abilities class from codecov, as it is only settings and the real execution happens in the base class

## Testing Instructions
1. Activate the plugin and ensure WordPress 6.9 with Abilities API support
2. Install the [MCP Adapter plugin](https://github.com/WordPress/mcp-adapter)
3. Create an application password
4. Use your favorite agent to connect to your site using the application password
5. List abilities, create an options page, duplicate it, update it, etc. through MCP