### PR TITLE
JSON Schemas: fix `menu_icon` property in Options Pages schema

### DIFF
--- a/schemas/ui-options-page.schema.json
+++ b/schemas/ui-options-page.schema.json
@@ -90,28 +90,29 @@
 				"menu_icon": {
 					"oneOf": [
 						{
-							"type": "string",
-							"description": "Icon as string: Dashicon name (e.g. 'dashicons-admin-generic') or full URL to image file"
-						},
-						{
 							"type": "object",
 							"properties": {
 								"type": {
 									"type": "string",
 									"enum": [ "dashicons", "url", "media_library" ],
-									"description": "Icon source type: 'dashicons' for WordPress dashicons, 'url' for custom image URL, 'media_library' for media library attachment"
+									"description": "Icon source type: 'dashicons' for WordPress dashicons, 'url' for custom image URL, 'media_library' for media library attachment ID"
 								},
 								"value": {
 									"type": [ "string", "integer" ],
-									"description": "The icon value: dashicon class name, image URL, or media library attachment ID"
+									"description": "The icon value: dashicon class name (e.g. 'dashicons-admin-generic'), image URL, or media library attachment ID"
 								}
 							},
 							"required": [ "type", "value" ],
 							"additionalProperties": false,
-							"description": "[SCF] SCF icon object format: {\"type\": \"dashicons\", \"value\": \"dashicons-admin-generic\"}"
+							"description": "[SCF] Object with type and value properties specifying the icon source and identifier."
+						},
+						{
+							"type": "array",
+							"maxItems": 0,
+							"description": "Empty array representing unset/default state (no icon configured)."
 						}
 					],
-					"description": "The menu icon. Can be a string (URL or dashicon name) or SCF object format with type and value properties."
+					"description": "The menu icon displayed in the admin menu. Accepts object format with type/value properties, or empty array when no icon is configured."
 				},
 				"position": {
 					"type": [ "integer", "string", "null" ],

--- a/tests/php/schemas/UIOptionsPageSchemaTest.php
+++ b/tests/php/schemas/UIOptionsPageSchemaTest.php
@@ -120,15 +120,6 @@ class UIOptionsPageSchemaTest extends BaseSchemaTestCase {
 				),
 				'Parent page with menu_icon object should be valid',
 			),
-			'menu_icon as string'               => array(
-				array(
-					'key'       => 'ui_options_page_settings',
-					'title'     => 'Settings',
-					'menu_slug' => 'settings',
-					'menu_icon' => 'dashicons-admin-generic',
-				),
-				'Options page with menu_icon as string should be valid',
-			),
 			'menu_icon with url type'           => array(
 				array(
 					'key'       => 'ui_options_page_settings',
@@ -152,6 +143,15 @@ class UIOptionsPageSchemaTest extends BaseSchemaTestCase {
 					),
 				),
 				'Options page with menu_icon media_library type should be valid',
+			),
+			'menu_icon as empty array'          => array(
+				array(
+					'key'       => 'ui_options_page_settings',
+					'title'     => 'Settings',
+					'menu_slug' => 'settings',
+					'menu_icon' => array(),
+				),
+				'Options page with empty menu_icon array (default state when no icon configured) should be valid',
 			),
 			'child page with parent_slug'       => array(
 				array(


### PR DESCRIPTION
## What
Fixes a bug in the `menu_icon` property that came up while adding Options Pages abilities in #273, as it had the wrong type.