### PR TITLE
JSON Schemas: fix too-early validation of schemas in FTP hosts

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -24,6 +24,8 @@
 		<!-- Refactoring of this scale is not in scope yet.-->
 		<exclude name="WordPress.Files.FileName" />
 		<!-- Exclude the entire filename rule -->
+		<exclude name="WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents" />
+		<!-- file_get_contents is safe for reading local plugin files bundled with the plugin. -->
 	</rule>
 
 	<rule ref="WordPress.Security.EscapeOutput">

--- a/includes/class-scf-json-schema-validator.php
+++ b/includes/class-scf-json-schema-validator.php
@@ -133,21 +133,12 @@ if ( ! class_exists( 'SCF_JSON_Schema_Validator' ) ) :
 		public function load_schema( $schema_name ) {
 			$schema_file = $this->schema_path . $schema_name . '.schema.json';
 
-			if ( ! file_exists( $schema_file ) ) {
+			if ( ! file_exists( $schema_file ) || ! is_readable( $schema_file ) ) {
 				return null;
 			}
 
-			if ( ! function_exists( 'WP_Filesystem' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/file.php';
-			}
-			WP_Filesystem();
-			global $wp_filesystem;
-
-			if ( null === $wp_filesystem ) {
-				return null;
-			}
-
-			$schema_content = $wp_filesystem->get_contents( $schema_file );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local plugin file, safe to read directly.
+			$schema_content = file_get_contents( $schema_file );
 			if ( false === $schema_content ) {
 				return null;
 			}
@@ -275,17 +266,13 @@ if ( ! class_exists( 'SCF_JSON_Schema_Validator' ) ) :
 		public function validate_file( $file_path, $schema_name ) {
 			$this->clear_validation_errors();
 
-			if ( ! file_exists( $file_path ) ) {
+			if ( ! file_exists( $file_path ) || ! is_readable( $file_path ) ) {
 				$this->add_validation_error( 'file', 'File does not exist: ' . $file_path );
 				return false;
 			}
 
-			if ( ! function_exists( 'WP_Filesystem' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/file.php';
-			}
-			WP_Filesystem();
-			global $wp_filesystem;
-			$json_content = $wp_filesystem->get_contents( $file_path );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local plugin file, safe to read directly.
+			$json_content = file_get_contents( $file_path );
 
 			if ( false === $json_content ) {
 				$this->add_validation_error( 'file', 'Could not read file: ' . $file_path );

--- a/includes/class-scf-json-schema-validator.php
+++ b/includes/class-scf-json-schema-validator.php
@@ -137,7 +137,6 @@ if ( ! class_exists( 'SCF_JSON_Schema_Validator' ) ) :
 				return null;
 			}
 
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local plugin file, safe to read directly.
 			$schema_content = file_get_contents( $schema_file );
 			if ( false === $schema_content ) {
 				return null;
@@ -271,7 +270,6 @@ if ( ! class_exists( 'SCF_JSON_Schema_Validator' ) ) :
 				return false;
 			}
 
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local plugin file, safe to read directly.
 			$json_content = file_get_contents( $file_path );
 
 			if ( false === $json_content ) {

--- a/includes/class-scf-json-schema-validator.php
+++ b/includes/class-scf-json-schema-validator.php
@@ -44,17 +44,9 @@ if ( ! class_exists( 'SCF_JSON_Schema_Validator' ) ) :
 
 		/**
 		 * Constructor.
-		 *
-		 * Validates that all required schemas are available on initialization.
-		 * If schemas are missing, registers an admin notice and prevents usage.
 		 */
 		public function __construct() {
 			$this->schema_path = acf_get_path( 'schemas/' );
-
-			// Validate schemas exist on initialization (skip during static analysis)
-			if ( defined( 'ABSPATH' ) && ! $this->validate_required_schemas() ) {
-				add_action( 'admin_notices', array( $this, 'show_schema_error' ) );
-			}
 		}
 
 
@@ -165,21 +157,6 @@ if ( ! class_exists( 'SCF_JSON_Schema_Validator' ) ) :
 			return true;
 		}
 
-		/**
-		 * Display admin notice when required schemas are not available.
-		 *
-		 * @since 6.6.0
-		 */
-		public function show_schema_error() {
-			?>
-		<div class="notice notice-error is-dismissible">
-			<p>
-				<strong><?php esc_html_e( 'Secure Custom Fields Error:', 'secure-custom-fields' ); ?></strong>
-				<?php esc_html_e( 'Required schema files are missing. Schema validation will not be available. Please ensure all schema files are present in the plugin directory.', 'secure-custom-fields' ); ?>
-			</p>
-		</div>
-			<?php
-		}
 		/**
 		 * Gets the validation errors from the last validation attempt.
 		 *


### PR DESCRIPTION
## What
Fix fatal error `Call to undefined function wp_generate_password()` on specific hosts, as reported in the forums: https://wordpress.org/support/topic/fatal-error-on-plugin-update-to-6-6-0/

## Why
Trying to be extra defensive, the JSON Schema validator validated the existence of the schemas during its construction. On hosts where WP uses FTP/SSH filesystem access, the call to`WP_Filesystem()` to load the schemas triggers code that calls `wp_generate_password()` - a pluggable function not yet available during early plugin load:
- The JSON schema validator was calling `WP_Filesystem()` in the constructor, before WordPress was fully initialized
- `WP_Filesystem` is overkill for reading local plugin-bundled JSON files (it was used to satisfy PHPStan requirements).

## How
- Removing the constructor schema validation (schemas will now be fully lazy loaded)
- Replacing `WP_Filesystem` with native `file_get_contents()` for reading local schema files
	- Plus adding PHPCS global exclusion for `file_get_contents`

## Testing Instructions
1. Update the plugin and verify no fatal error on activation
2. Use the abilities API and verify the schema validation still works
3. Run `vendor/bin/phpunit --filter "Test_SCF_JSON_Schema_Validator"`