### PR TITLE
Skip Block Bindings e2e tests on WordPress < 6.5

### DIFF
--- a/tests/e2e/block-bindings-site-editor.spec.ts
+++ b/tests/e2e/block-bindings-site-editor.spec.ts
@@ -8,7 +8,6 @@ const PLUGIN_SLUG = 'secure-custom-fields';
 const TEST_PLUGIN_SLUG = 'scf-test-setup-post-types';
 const FIELD_GROUP_LABEL = 'Product Details';
 const TEXT_FIELD_LABEL = 'Product Name';
-const IMAGE_FIELD_LABEL = 'Product Image';
 
 test.describe( 'Block Bindings in Site Editor', () => {
 	test.beforeAll( async ( { page, requestUtils }: any ) => {
@@ -70,11 +69,15 @@ test.describe( 'Block Bindings in Site Editor', () => {
 		await fieldType.selectOption( 'text' );
 
 		// Select Group Settings > Enable REST API
-		const groupSettingsTab = page.getByRole( 'link', { name: 'Group Settings' } );
+		const groupSettingsTab = page.getByRole( 'link', {
+			name: 'Group Settings',
+		} );
 		await groupSettingsTab.click();
 
 		// Enable Show in REST API
-		const showInRestCheckbox = page.locator( '#acf_field_group-show_in_rest' );
+		const showInRestCheckbox = page.locator(
+			'#acf_field_group-show_in_rest'
+		);
 		await showInRestCheckbox.check( { force: true } );
 
 		// Submit form.
@@ -89,49 +92,72 @@ test.describe( 'Block Bindings in Site Editor', () => {
 		await expect( successNotice ).toContainText( 'Field group published' );
 
 		// Navigate to site editor
-		await admin.visitAdminPage( 'site-editor.php?p=%2Fwp_template%2Ftwentytwentyfive%2F%2Fsingle&canvas=edit' );
+		await admin.visitAdminPage(
+			'site-editor.php?p=%2Fwp_template%2Ftwentytwentyfive%2F%2Fsingle&canvas=edit'
+		);
 
 		// Wait for the site editor to load - wait for the iframe or editor container
-		await page.waitForSelector('iframe[name="editor-canvas"]', { timeout: 10000 });
-		await page.waitForTimeout(2000); // Give the editor a moment to fully load
+		await page.waitForSelector( 'iframe[name="editor-canvas"]', {
+			timeout: 10000,
+		} );
+		await page.waitForTimeout( 2000 ); // Give the editor a moment to fully load
 
 		// Close the welcome guide modal if it appears by pressing Escape
 		await page.keyboard.press( 'Escape' );
 		await page.waitForTimeout( 500 );
 
 		// Get the iframe and work within it
-		const frameLocator = page.frameLocator('iframe[name="editor-canvas"]');
-		
+		const frameLocator = page.frameLocator(
+			'iframe[name="editor-canvas"]'
+		);
+
 		// Click on the content block within the iframe
-		const contentBlock = frameLocator.locator('[data-type="core/post-content"]').first();
+		const contentBlock = frameLocator
+			.locator( '[data-type="core/post-content"]' )
+			.first();
 		await contentBlock.click();
 
 		// Press Enter to add a new paragraph block
-		await page.keyboard.press('Enter');
+		await page.keyboard.press( 'Enter' );
 
 		// Wait for the newly created empty paragraph block
-		await frameLocator.locator('[data-type="core/paragraph"][data-empty="true"]').waitFor({ timeout: 5000 });
+		await frameLocator
+			.locator( '[data-type="core/paragraph"][data-empty="true"]' )
+			.waitFor( { timeout: 5000 } );
 
 		// Click on the empty paragraph block to select it
-		const emptyParagraph = frameLocator.locator('[data-type="core/paragraph"][data-empty="true"]');
+		const emptyParagraph = frameLocator.locator(
+			'[data-type="core/paragraph"][data-empty="true"]'
+		);
 		await emptyParagraph.click();
 
 		// Wait for the "Connect to a field" panel to appear in the block inspector
-		await page.waitForSelector('input[id^="components-form-token-input-combobox-control-"]', { timeout: 5000 });
+		await page.waitForSelector(
+			'input[id^="components-form-token-input-combobox-control-"]',
+			{ timeout: 5000 }
+		);
 
 		// Click on the combobox input to open suggestions
-		const comboboxInput = page.locator('input[id^="components-form-token-input-combobox-control-"]').first();
+		const comboboxInput = page
+			.locator(
+				'input[id^="components-form-token-input-combobox-control-"]'
+			)
+			.first();
 		await comboboxInput.click();
 
 		// Wait for suggestions to appear
-		await page.waitForSelector('ul[id^="components-form-token-suggestions-combobox-control-"]', { timeout: 5000 });
+		await page.waitForSelector(
+			'ul[id^="components-form-token-suggestions-combobox-control-"]',
+			{ timeout: 5000 }
+		);
 
 		// Select "Product Name" from the dropdown
-		await page.getByRole('option', { name: 'Product Name' }).click();
+		await page.getByRole( 'option', { name: 'Product Name' } ).click();
 
 		// Verify the paragraph block now contains "Product Name"
-		const boundParagraph = frameLocator.locator('[data-type="core/paragraph"]:has-text("Product Name")');
+		const boundParagraph = frameLocator.locator(
+			'[data-type="core/paragraph"]:has-text("Product Name")'
+		);
 		await expect( boundParagraph ).toBeVisible();
-
 	} );
 } );

--- a/tests/e2e/block-bindings-site-editor.spec.ts
+++ b/tests/e2e/block-bindings-site-editor.spec.ts
@@ -11,9 +11,30 @@ const TEXT_FIELD_LABEL = 'Product Name';
 const IMAGE_FIELD_LABEL = 'Product Image';
 
 test.describe( 'Block Bindings in Site Editor', () => {
-	test.beforeAll( async ( { requestUtils }: any ) => {
+	test.beforeAll( async ( { page, requestUtils }: any ) => {
 		await requestUtils.activatePlugin( PLUGIN_SLUG );
 		await requestUtils.activatePlugin( TEST_PLUGIN_SLUG );
+
+		// Block Bindings API was introduced in WordPress 6.5
+		// Skip this test suite for older WordPress versions
+		await page.goto( '/wp-admin/' );
+		const isBlockBindingsSupported = await page.evaluate( () => {
+			const body = document.body;
+			// Check for WP versions < 6.5 using branch classes
+			const unsupportedVersions = [
+				'branch-6-2',
+				'branch-6-3',
+				'branch-6-4',
+			];
+			return ! unsupportedVersions.some( ( v ) =>
+				body.classList.contains( v )
+			);
+		} );
+
+		test.skip(
+			! isBlockBindingsSupported,
+			'Block Bindings API not available in WordPress versions < 6.5'
+		);
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {


### PR DESCRIPTION
## What

Skip the Block Bindings Site Editor e2e test on WordPress versions that don't support the feature.

## Why

Block Bindings API was introduced in WordPress 6.5, and the tests were failing on WP 6.2 CI matrix.

## How
Adding a version detection in `test.beforeAll` using `branch-6-x` body classes, and skipping the test suite if the version is older than 6.5.


## Testing Instructions

1. Run e2e tests against WP 6.2: binding tests should be skipped with the message `Block Bindings API not available in WordPress versions < 6.5`.
2. Run e2e tests against WP 6.5+: test should execute normally.