### PR TITLE
Skip Block Bindings e2e tests on WordPress < 6.5 (second try)

### DIFF
--- a/tests/e2e/block-bindings-site-editor.spec.ts
+++ b/tests/e2e/block-bindings-site-editor.spec.ts
@@ -2,7 +2,7 @@
  * E2E tests for block bindings in the site editor
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const { test, expect } = require( './fixtures' );
+const { test, expect, wpVersionAtLeast } = require( './fixtures' );
 
 const PLUGIN_SLUG = 'secure-custom-fields';
 const TEST_PLUGIN_SLUG = 'scf-test-setup-post-types';
@@ -10,30 +10,9 @@ const FIELD_GROUP_LABEL = 'Product Details';
 const TEXT_FIELD_LABEL = 'Product Name';
 
 test.describe( 'Block Bindings in Site Editor', () => {
-	test.beforeAll( async ( { page, requestUtils }: any ) => {
+	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activatePlugin( PLUGIN_SLUG );
 		await requestUtils.activatePlugin( TEST_PLUGIN_SLUG );
-
-		// Block Bindings API was introduced in WordPress 6.5
-		// Skip this test suite for older WordPress versions
-		await page.goto( '/wp-admin/' );
-		const isBlockBindingsSupported = await page.evaluate( () => {
-			const body = document.body;
-			// Check for WP versions < 6.5 using branch classes
-			const unsupportedVersions = [
-				'branch-6-2',
-				'branch-6-3',
-				'branch-6-4',
-			];
-			return ! unsupportedVersions.some( ( v ) =>
-				body.classList.contains( v )
-			);
-		} );
-
-		test.skip(
-			! isBlockBindingsSupported,
-			'Block Bindings API not available in WordPress versions < 6.5'
-		);
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
@@ -46,6 +25,13 @@ test.describe( 'Block Bindings in Site Editor', () => {
 		page,
 		admin,
 	} ) => {
+		// Block Bindings API was introduced in WordPress 6.5
+		await page.goto( '/wp-admin/' );
+		test.skip(
+			! ( await wpVersionAtLeast( page, 6, 5 ) ),
+			'Block Bindings API requires WordPress 6.5+'
+		);
+
 		// Navigate to Field Groups and create new.
 		await admin.visitAdminPage( 'edit.php', 'post_type=acf-field-group' );
 		const addNewButton = page.locator( 'a.acf-btn:has-text("Add New")' );

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -99,4 +99,42 @@ const test = wpTest.extend( {
 	},
 } );
 
-module.exports = { test, expect };
+/**
+ * Check if WordPress version is at least the specified version.
+ * Must be called after navigating to an admin page.
+ *
+ * @param {import('@playwright/test').Page} page    Playwright page object.
+ * @param {number}                           major  Major version number.
+ * @param {number}                           minor  Minor version number.
+ * @return {Promise<boolean>} True if WP version >= specified version.
+ */
+async function wpVersionAtLeast( page, major, minor ) {
+	return page.evaluate(
+		( [ maj, min ] ) => {
+			const branchClass = [ ...document.body.classList ].find( ( c ) =>
+				c.startsWith( 'branch-' )
+			);
+			if ( ! branchClass ) return true;
+			const match = branchClass.match( /branch-(\d+)-(\d+)/ );
+			if ( ! match ) return true;
+			const [ , wpMajor, wpMinor ] = match.map( Number );
+			return wpMajor > maj || ( wpMajor === maj && wpMinor >= min );
+		},
+		[ major, minor ]
+	);
+}
+
+/**
+ * Check if WordPress version is below the specified version.
+ * Must be called after navigating to an admin page.
+ *
+ * @param {import('@playwright/test').Page} page    Playwright page object.
+ * @param {number}                           major  Major version number.
+ * @param {number}                           minor  Minor version number.
+ * @return {Promise<boolean>} True if WP version < specified version.
+ */
+async function wpVersionBelow( page, major, minor ) {
+	return ! ( await wpVersionAtLeast( page, major, minor ) );
+}
+
+module.exports = { test, expect, wpVersionAtLeast, wpVersionBelow };


### PR DESCRIPTION
Follow-up to #279, as tests passed in the PR but are failing in trunk