### PR TITLE
Backports: Updates from 6.7.0

### DIFF
--- a/assets/src/js/_acf-field-accordion.js
+++ b/assets/src/js/_acf-field-accordion.js
@@ -94,6 +94,15 @@
 				accordionManager.iconHtml( { open: this.get( 'open' ) } )
 			);
 
+			$label.attr( {
+				tabindex: 0,
+				role: 'button',
+				'aria-expanded': this.get( 'open' ) ? 'true' : 'false',
+			} );
+			$input.attr( {
+				role: 'region',
+			} );
+
 			// classes
 			// - remove 'inside' which is a #poststuff WP class
 			var $parent = $field.parent();
@@ -131,6 +140,7 @@
 
 		events: {
 			'click .acf-accordion-title': 'onClick',
+			'keydown .acf-accordion-title': 'onKeydown',
 			'invalidField .acf-accordion': 'onInvalidField',
 		},
 
@@ -174,6 +184,10 @@
 				this.iconHtml( { open: true } )
 			);
 			$el.addClass( '-open' );
+			$el.find( '.acf-accordion-title:first' ).attr(
+				'aria-expanded',
+				'true'
+			);
 
 			// action
 			acf.doAction( 'show', $el );
@@ -195,6 +209,10 @@
 				this.iconHtml( { open: false } )
 			);
 			$el.removeClass( '-open' );
+			$el.find( '.acf-accordion-title:first' ).attr(
+				'aria-expanded',
+				'false'
+			);
 
 			// action
 			acf.doAction( 'hide', $el );
@@ -207,7 +225,15 @@
 			// open close
 			this.toggle( $el.parent() );
 		},
-
+		onKeydown: function ( e, $el ) {
+			// check for enter or space
+			if ( 13 === e.which ) {
+				// prevent Default
+				e.preventDefault();
+				// open close
+				this.toggle( $el.parent() );
+			}
+		},
 		onInvalidField: function ( e, $el ) {
 			// bail early if already focused
 			if ( this.busy ) {

--- a/assets/src/js/_acf-field-google-map.js
+++ b/assets/src/js/_acf-field-google-map.js
@@ -7,9 +7,9 @@
 		wait: 'load',
 
 		events: {
-			'click a[data-name="clear"]': 'onClickClear',
-			'click a[data-name="locate"]': 'onClickLocate',
-			'click a[data-name="search"]': 'onClickSearch',
+			'click button[data-name="clear"]': 'onClickClear',
+			'click button[data-name="locate"]': 'onClickLocate',
+			'click button[data-name="search"]': 'onClickSearch',
 			'keydown .search': 'onKeydownSearch',
 			'keyup .search': 'onKeyupSearch',
 			'focus .search': 'onFocusSearch',
@@ -513,8 +513,13 @@
 			this.searchAddress( this.$search().val() );
 		},
 
-		onFocusSearch: function ( e, $el ) {
-			this.setState( 'searching' );
+		onFocusSearch: function ( event, searchInput ) {
+			const currentValue = this.val();
+			const currentAddress = currentValue ? currentValue.address : '';
+
+			if ( searchInput.val() !== currentAddress ) {
+				this.setState( 'searching' );
+			}
 		},
 
 		onBlurSearch: function ( e, $el ) {
@@ -529,9 +534,20 @@
 		},
 
 		onKeyupSearch: function ( e, $el ) {
-			// Clear empty value.
-			if ( ! $el.val() ) {
+			const val = this.val();
+			const address = val ? val.address : '';
+
+			if ( $el.val() ) {
+				// If search input has value
+				if ( $el.val() !== address ) {
+					this.setState( 'searching' );
+				} else {
+					this.setState( 'default' );
+				}
+			} else {
+				// If search input is empty
 				this.val( false );
+				this.setState( 'default' );
 			}
 		},
 

--- a/assets/src/js/_acf-tinymce.js
+++ b/assets/src/js/_acf-tinymce.js
@@ -111,7 +111,6 @@
 					if ( ! $textarea.closest( '.attachment-info' ).length ) {
 						$textarea.trigger( 'change' );
 					}
-					$textarea.trigger( 'change' );
 				} );
 
 				ed.on( 'blur', function ( e ) {

--- a/assets/src/js/_acf-tinymce.js
+++ b/assets/src/js/_acf-tinymce.js
@@ -108,12 +108,22 @@
 			init.setup = function ( ed ) {
 				ed.on( 'change', function ( e ) {
 					ed.save(); // save to textarea
+					if ( ! $textarea.closest( '.attachment-info' ).length ) {
+						$textarea.trigger( 'change' );
+					}
 					$textarea.trigger( 'change' );
+				} );
+
+				ed.on( 'blur', function ( e ) {
+					if ( $textarea.closest( '.attachment-info' ).length ) {
+						ed.save();
+						$textarea.trigger( 'change' );
+					}
 				} );
 
 				// Fix bug where Gutenberg does not hear "mouseup" event and tries to select multiple blocks.
 				ed.on( 'mouseup', function ( e ) {
-					var event = new MouseEvent( 'mouseup' );
+					const event = new MouseEvent( 'mouseup' );
 					window.dispatchEvent( event );
 				} );
 

--- a/assets/src/js/_acf-validation.js
+++ b/assets/src/js/_acf-validation.js
@@ -1177,9 +1177,10 @@
 										new CustomEvent(
 											'acf/block/has-error',
 											{
-												acfBlocksWithValidationErrors: [
-													block,
-												],
+												detail: {
+													acfBlocksWithValidationErrors:
+														block.clientId,
+												},
 											}
 										)
 									);

--- a/assets/src/js/_field-group-field.js
+++ b/assets/src/js/_field-group-field.js
@@ -407,11 +407,21 @@
 
 			// update label
 			$handle.find( '.li-field-label strong a' ).html( label );
+			let shouldConvertToLowercase = name === name.toLowerCase();
+			shouldConvertToLowercase = acf.applyFilters(
+				'convert_field_name_to_lowercase',
+				shouldConvertToLowercase,
+				this
+			);
 
 			// update name
 			$handle
 				.find( '.li-field-name' )
-				.html( this.makeCopyable( acf.strSanitize( name ) ) );
+				.html(
+					this.makeCopyable(
+						acf.strSanitize( name, shouldConvertToLowercase )
+					)
+				);
 
 			// update type
 			const iconName = acf.strSlugify( this.getType() );

--- a/assets/src/js/pro/_acf-blocks-src.js
+++ b/assets/src/js/pro/_acf-blocks-src.js
@@ -1,0 +1,2144 @@
+const md5 = require( 'md5' );
+
+( ( $, undefined ) => {
+	// Dependencies.
+	const {
+		BlockControls,
+		InspectorControls,
+		InnerBlocks,
+		useBlockProps,
+		AlignmentToolbar,
+		BlockVerticalAlignmentToolbar,
+	} = wp.blockEditor;
+
+	const { ToolbarGroup, ToolbarButton, Placeholder, Spinner } = wp.components;
+	const { Fragment } = wp.element;
+	const { Component } = React;
+	const { useSelect } = wp.data;
+	const { createHigherOrderComponent } = wp.compose;
+
+	// Potentially experimental dependencies.
+	const BlockAlignmentMatrixToolbar =
+		wp.blockEditor.__experimentalBlockAlignmentMatrixToolbar ||
+		wp.blockEditor.BlockAlignmentMatrixToolbar;
+	// Gutenberg v10.x begins transition from Toolbar components to Control components.
+	const BlockAlignmentMatrixControl =
+		wp.blockEditor.__experimentalBlockAlignmentMatrixControl ||
+		wp.blockEditor.BlockAlignmentMatrixControl;
+	const BlockFullHeightAlignmentControl =
+		wp.blockEditor.__experimentalBlockFullHeightAligmentControl ||
+		wp.blockEditor.__experimentalBlockFullHeightAlignmentControl ||
+		wp.blockEditor.BlockFullHeightAlignmentControl;
+	const useInnerBlocksProps =
+		wp.blockEditor.__experimentalUseInnerBlocksProps ||
+		wp.blockEditor.useInnerBlocksProps;
+
+	/**
+	 * Storage for registered block types.
+	 *
+	 * @since ACF 5.8.0
+	 * @var object
+	 */
+	const blockTypes = {};
+
+	/**
+	 * Data storage for Block Instances and their DynamicHTML components.
+	 * This is temporarily stored on the ACF object, but this will be replaced later.
+	 * Developers should not rely on reading or using any aspect of acf.blockInstances.
+	 *
+	 * @since ACF 6.3
+	 */
+	acf.blockInstances = {};
+
+	/**
+	 * Returns a block type for the given name.
+	 *
+	 * @date	20/2/19
+	 * @since	ACF 5.8.0
+	 *
+	 * @param	string name The block name.
+	 * @return	(object|false)
+	 */
+	function getBlockType( name ) {
+		return blockTypes[ name ] || false;
+	}
+
+	/**
+	 * Returns a block version for a given block name
+	 *
+	 * @date 8/6/22
+	 * @since ACF 6.0
+	 *
+	 * @param string name The block name
+	 * @return int
+	 */
+	function getBlockVersion( name ) {
+		const blockType = getBlockType( name );
+		return blockType.acf_block_version || 1;
+	}
+
+	/**
+	 * Returns a block's validate property. Default true.
+	 *
+	 * @since ACF 6.3
+	 *
+	 * @param string name The block name
+	 * @return boolean
+	 */
+	function blockSupportsValidation( name ) {
+		const blockType = getBlockType( name );
+		return blockType.validate;
+	}
+
+	/**
+	 * Returns true if a block (identified by client ID) is nested in a query loop block.
+	 *
+	 * @date 17/1/22
+	 * @since ACF 5.12
+	 *
+	 * @param {string} clientId A block client ID
+	 * @return boolean
+	 */
+	function isBlockInQueryLoop( clientId ) {
+		const parents = wp.data
+			.select( 'core/block-editor' )
+			.getBlockParents( clientId );
+		const parentsData = wp.data
+			.select( 'core/block-editor' )
+			.getBlocksByClientId( parents );
+		return parentsData.filter( ( block ) => block.name === 'core/query' )
+			.length;
+	}
+
+	/**
+	 * Returns true if we're currently inside the WP 5.9+ site editor.
+	 *
+	 * @date 08/02/22
+	 * @since ACF 5.12
+	 *
+	 * @return boolean
+	 */
+	function isSiteEditor() {
+		return (
+			document.querySelectorAll( 'iframe[name="editor-canvas"]' ).length >
+			0
+		);
+	}
+
+	/**
+	 * Returns true if the block editor is currently showing the desktop device type preview.
+	 *
+	 * This function will always return true in the site editor as it uses the
+	 * edit-post store rather than the edit-site store.
+	 *
+	 * @date 15/02/22
+	 * @since ACF 5.12
+	 *
+	 * @return boolean
+	 */
+	function isDesktopPreviewDeviceType() {
+		const editPostStore = select( 'core/edit-post' );
+
+		// Return true if the edit post store isn't available (such as in the widget editor)
+		if ( ! editPostStore ) return true;
+
+		// Check if function exists (experimental or not) and return true if it's Desktop, or doesn't exist.
+		if ( editPostStore.__experimentalGetPreviewDeviceType ) {
+			return (
+				'Desktop' === editPostStore.__experimentalGetPreviewDeviceType()
+			);
+		} else if ( editPostStore.getPreviewDeviceType ) {
+			return 'Desktop' === editPostStore.getPreviewDeviceType();
+		} else {
+			return true;
+		}
+	}
+
+	/**
+	 * Returns true if the block editor is currently in template edit mode.
+	 *
+	 * @date 16/02/22
+	 * @since ACF 5.12
+	 *
+	 * @return boolean
+	 */
+	function isEditingTemplate() {
+		const editPostStore = select( 'core/edit-post' );
+
+		// Return false if the edit post store isn't available (such as in the widget editor)
+		if ( ! editPostStore ) return false;
+
+		// Return false if the function doesn't exist
+		if ( ! editPostStore.isEditingTemplate ) return false;
+
+		return editPostStore.isEditingTemplate();
+	}
+
+	/**
+	 * Returns true if we're currently inside an iFramed non-desktop device preview type (WP5.9+)
+	 *
+	 * @date 15/02/22
+	 * @since ACF 5.12
+	 *
+	 * @return boolean
+	 */
+	function isiFramedMobileDevicePreview() {
+		return (
+			$( 'iframe[name=editor-canvas]' ).length &&
+			! isDesktopPreviewDeviceType()
+		);
+	}
+
+	/**
+	 * Registers a block type.
+	 *
+	 * @date	19/2/19
+	 * @since	ACF 5.8.0
+	 *
+	 * @param	object blockType The block type settings localized from PHP.
+	 * @return	object The result from wp.blocks.registerBlockType().
+	 */
+	function registerBlockType( blockType ) {
+		// Bail early if is excluded post_type.
+		const allowedTypes = blockType.post_types || [];
+		if ( allowedTypes.length ) {
+			// Always allow block to appear on "Edit reusable Block" screen.
+			allowedTypes.push( 'wp_block' );
+
+			// Check post type.
+			const postType = acf.get( 'postType' );
+			if ( ! allowedTypes.includes( postType ) ) {
+				return false;
+			}
+		}
+
+		// Handle svg HTML.
+		if (
+			typeof blockType.icon === 'string' &&
+			blockType.icon.substr( 0, 4 ) === '<svg'
+		) {
+			const iconHTML = blockType.icon;
+			blockType.icon = <Div>{ iconHTML }</Div>;
+		}
+
+		// Remove icon if empty to allow for default "block".
+		// Avoids JS error preventing block from being registered.
+		if ( ! blockType.icon ) {
+			delete blockType.icon;
+		}
+
+		// Check category exists and fallback to "common".
+		const category = wp.blocks
+			.getCategories()
+			.filter( ( { slug } ) => slug === blockType.category )
+			.pop();
+		if ( ! category ) {
+			//console.warn( `The block "${blockType.name}" is registered with an unknown category "${blockType.category}".` );
+			blockType.category = 'common';
+		}
+
+		// Merge in block settings before local additions.
+		blockType = acf.parseArgs( blockType, {
+			title: '',
+			name: '',
+			category: '',
+			api_version: 2,
+			acf_block_version: 1,
+		} );
+
+		// Remove all empty attribute defaults from PHP values to allow serialisation.
+		// https://github.com/WordPress/gutenberg/issues/7342
+		for ( const key in blockType.attributes ) {
+			if (
+				'default' in blockType.attributes[ key ] &&
+				blockType.attributes[ key ].default.length === 0
+			) {
+				delete blockType.attributes[ key ].default;
+			}
+		}
+
+		// Apply anchor supports to avoid block editor default writing to ID.
+		if ( blockType.supports.anchor ) {
+			blockType.attributes.anchor = {
+				type: 'string',
+			};
+		}
+
+		// Append edit and save functions.
+		let ThisBlockEdit = BlockEdit;
+		let ThisBlockSave = BlockSave;
+
+		// Apply alignText functionality.
+		if ( blockType.supports.alignText || blockType.supports.align_text ) {
+			blockType.attributes = addBackCompatAttribute(
+				blockType.attributes,
+				'align_text',
+				'string'
+			);
+			ThisBlockEdit = withAlignTextComponent( ThisBlockEdit, blockType );
+		}
+
+		// Apply alignContent functionality.
+		if (
+			blockType.supports.alignContent ||
+			blockType.supports.align_content
+		) {
+			blockType.attributes = addBackCompatAttribute(
+				blockType.attributes,
+				'align_content',
+				'string'
+			);
+			ThisBlockEdit = withAlignContentComponent(
+				ThisBlockEdit,
+				blockType
+			);
+		}
+
+		// Apply fullHeight functionality.
+		if ( blockType.supports.fullHeight || blockType.supports.full_height ) {
+			blockType.attributes = addBackCompatAttribute(
+				blockType.attributes,
+				'full_height',
+				'boolean'
+			);
+			ThisBlockEdit = withFullHeightComponent(
+				ThisBlockEdit,
+				blockType.blockType
+			);
+		}
+
+		// Set edit and save functions.
+		blockType.edit = ( props ) => {
+			// Ensure we remove our save lock if a block is removed.
+			wp.element.useEffect( () => {
+				return () => {
+					if ( ! wp.data.dispatch( 'core/editor' ) ) return;
+					wp.data
+						.dispatch( 'core/editor' )
+						.unlockPostSaving( 'acf/block/' + props.clientId );
+				};
+			}, [] );
+
+			return <ThisBlockEdit { ...props } />;
+		};
+		blockType.save = () => <ThisBlockSave />;
+
+		// Add to storage.
+		blockTypes[ blockType.name ] = blockType;
+
+		// Register with WP.
+		const result = wp.blocks.registerBlockType( blockType.name, blockType );
+
+		// Fix bug in 'core/anchor/attribute' filter overwriting attribute.
+		// Required for < WP5.9
+		// See https://github.com/WordPress/gutenberg/issues/15240
+		if ( result.attributes.anchor ) {
+			result.attributes.anchor = {
+				type: 'string',
+			};
+		}
+
+		// Return result.
+		return result;
+	}
+
+	/**
+	 * Returns the wp.data.select() response with backwards compatibility.
+	 *
+	 * @date	17/06/2020
+	 * @since	ACF 5.9.0
+	 *
+	 * @param	string selector The selector name.
+	 * @return	mixed
+	 */
+	function select( selector ) {
+		if ( selector === 'core/block-editor' ) {
+			return (
+				wp.data.select( 'core/block-editor' ) ||
+				wp.data.select( 'core/editor' )
+			);
+		}
+		return wp.data.select( selector );
+	}
+
+	/**
+	 * Returns the wp.data.dispatch() response with backwards compatibility.
+	 *
+	 * @date	17/06/2020
+	 * @since	ACF 5.9.0
+	 *
+	 * @param	string selector The selector name.
+	 * @return	mixed
+	 */
+	function dispatch( selector ) {
+		return wp.data.dispatch( selector );
+	}
+
+	/**
+	 * Returns an array of all blocks for the given args.
+	 *
+	 * @date	27/2/19
+	 * @since	ACF 5.7.13
+	 *
+	 * @param	{object} args An object of key=>value pairs used to filter results.
+	 * @return	array.
+	 */
+	function getBlocks( args ) {
+		let blocks = [];
+
+		// Local function to recurse through all child blocks and add to the blocks array.
+		const recurseBlocks = ( block ) => {
+			blocks.push( block );
+			select( 'core/block-editor' )
+				.getBlocks( block.clientId )
+				.forEach( recurseBlocks );
+		};
+
+		// Trigger initial recursion for parent level blocks.
+		select( 'core/block-editor' ).getBlocks().forEach( recurseBlocks );
+
+		// Loop over args and filter.
+		for ( const k in args ) {
+			blocks = blocks.filter(
+				( { attributes } ) => attributes[ k ] === args[ k ]
+			);
+		}
+
+		// Return results.
+		return blocks;
+	}
+
+	/**
+	 * Storage for the AJAX queue.
+	 *
+	 * @const {array}
+	 */
+	const ajaxQueue = {};
+
+	/**
+	 * Storage for cached AJAX requests for block content.
+	 *
+	 * @since ACF 5.12
+	 * @const {array}
+	 */
+	const fetchCache = {};
+
+	/**
+	 * Fetches a JSON result from the AJAX API.
+	 *
+	 * @date	28/2/19
+	 * @since	ACF 5.7.13
+	 *
+	 * @param	object block The block props.
+	 * @query	object The query args used in AJAX callback.
+	 * @return	object The AJAX promise.
+	 */
+	function fetchBlock( args ) {
+		const {
+			attributes = {},
+			context = {},
+			query = {},
+			clientId = null,
+			delay = 0,
+		} = args;
+
+		// Build a unique queue ID from block data, including the clientId for edit forms.
+		const queueId = md5(
+			JSON.stringify( { ...attributes, ...context, ...query } )
+		);
+
+		const data = ajaxQueue[ queueId ] || {
+			query: {},
+			timeout: false,
+			promise: $.Deferred(),
+			started: false,
+		};
+
+		// Append query args to storage.
+		data.query = { ...data.query, ...query };
+
+		if ( data.started ) return data.promise;
+
+		// Set fresh timeout.
+		clearTimeout( data.timeout );
+		data.timeout = setTimeout( () => {
+			data.started = true;
+			if ( fetchCache[ queueId ] ) {
+				ajaxQueue[ queueId ] = null;
+				data.promise.resolve.apply(
+					fetchCache[ queueId ][ 0 ],
+					fetchCache[ queueId ][ 1 ]
+				);
+			} else {
+				$.ajax( {
+					url: acf.get( 'ajaxurl' ),
+					dataType: 'json',
+					type: 'post',
+					cache: false,
+					data: acf.prepareForAjax( {
+						action: 'acf/ajax/fetch-block',
+						block: JSON.stringify( attributes ),
+						clientId: clientId,
+						context: JSON.stringify( context ),
+						query: data.query,
+					} ),
+				} )
+					.always( () => {
+						// Clean up queue after AJAX request is complete.
+						ajaxQueue[ queueId ] = null;
+					} )
+					.done( function () {
+						fetchCache[ queueId ] = [ this, arguments ];
+						data.promise.resolve.apply( this, arguments );
+					} )
+					.fail( function () {
+						data.promise.reject.apply( this, arguments );
+					} );
+			}
+		}, delay );
+
+		// Update storage.
+		ajaxQueue[ queueId ] = data;
+
+		// Return promise.
+		return data.promise;
+	}
+
+	/**
+	 * Returns true if both object are the same.
+	 *
+	 * @date	19/05/2020
+	 * @since	ACF 5.9.0
+	 *
+	 * @param	object obj1
+	 * @param	object obj2
+	 * @return	bool
+	 */
+	function compareObjects( obj1, obj2 ) {
+		return JSON.stringify( obj1 ) === JSON.stringify( obj2 );
+	}
+
+	/**
+	 * Converts HTML into a React element.
+	 *
+	 * @date	19/05/2020
+	 * @since	ACF 5.9.0
+	 *
+	 * @param	string html The HTML to convert.
+	 * @param	int acfBlockVersion The ACF block version number.
+	 * @return	object Result of React.createElement().
+	 */
+	acf.parseJSX = ( html, acfBlockVersion ) => {
+		// Apply a temporary wrapper for the jQuery parse to prevent text nodes triggering errors.
+		html = '<div>' + html + '</div>';
+		// Correctly balance InnerBlocks tags for jQuery's initial parse.
+		html = html.replace(
+			/<InnerBlocks([^>]+)?\/>/,
+			'<InnerBlocks$1></InnerBlocks>'
+		);
+		return parseNode( $( html )[ 0 ], acfBlockVersion, 0 ).props.children;
+	};
+
+	/**
+	 * Converts a DOM node into a React element.
+	 *
+	 * @date	19/05/2020
+	 * @since	ACF 5.9.0
+	 *
+	 * @param	DOM node The DOM node.
+	 * @param	int acfBlockVersion The ACF block version number.
+	 * @param	int level The recursion level.
+	 * @return	object Result of React.createElement().
+	 */
+	function parseNode( node, acfBlockVersion, level = 0 ) {
+		// Get node name.
+		const nodeName = parseNodeName(
+			node.nodeName.toLowerCase(),
+			acfBlockVersion
+		);
+		if ( ! nodeName ) {
+			return null;
+		}
+
+		// Get node attributes in React friendly format.
+		const nodeAttrs = {};
+
+		if ( level === 1 && nodeName !== 'ACFInnerBlocks' ) {
+			// Top level (after stripping away the container div), create a ref for passing through to ACF's JS API.
+			nodeAttrs.ref = React.createRef();
+		}
+
+		acf.arrayArgs( node.attributes )
+			.map( parseNodeAttr )
+			.forEach( ( { name, value } ) => {
+				nodeAttrs[ name ] = value;
+			} );
+
+		if ( 'ACFInnerBlocks' === nodeName ) {
+			return <ACFInnerBlocks { ...nodeAttrs } />;
+		}
+
+		// Define args for React.createElement().
+		const args = [ nodeName, nodeAttrs ];
+		acf.arrayArgs( node.childNodes ).forEach( ( child ) => {
+			if ( child instanceof Text ) {
+				const text = child.textContent;
+				if ( text ) {
+					args.push( text );
+				}
+			} else {
+				args.push( parseNode( child, acfBlockVersion, level + 1 ) );
+			}
+		} );
+
+		// Return element.
+		return React.createElement.apply( this, args );
+	}
+
+	/**
+	 * Converts a node or attribute name into it's JSX compliant name
+	 *
+	 * @date     05/07/2021
+	 * @since    ACF 5.9.8
+	 *
+	 * @param    string name The node or attribute name.
+	 * @return  string
+	 */
+	function getJSXName( name ) {
+		const replacement = acf.isget( acf, 'jsxNameReplacements', name );
+		if ( replacement ) return replacement;
+		return name;
+	}
+
+	/**
+	 * A react Component for inline scripts.
+	 *
+	 * This Component uses a combination of React references and jQuery to append the
+	 * inline <script> HTML each time the component is rendered.
+	 *
+	 * @date	29/05/2020
+	 * @since	ACF 5.9.0
+	 *
+	 * @param	type Var Description.
+	 * @return	type Description.
+	 */
+	class Script extends Component {
+		render() {
+			return <div ref={ ( el ) => ( this.el = el ) } />;
+		}
+		setHTML( html ) {
+			$( this.el ).html( `<script>${ html }</script>` );
+		}
+		componentDidUpdate() {
+			this.setHTML( this.props.children );
+		}
+		componentDidMount() {
+			this.setHTML( this.props.children );
+		}
+	}
+
+	/**
+	 * Converts the given name into a React friendly name or component.
+	 *
+	 * @date	19/05/2020
+	 * @since	ACF 5.9.0
+	 *
+	 * @param	string name The node name in lowercase.
+	 * @param	int acfBlockVersion The ACF block version number.
+	 * @return	mixed
+	 */
+	function parseNodeName( name, acfBlockVersion ) {
+		switch ( name ) {
+			case 'innerblocks':
+				if ( acfBlockVersion < 2 ) {
+					return InnerBlocks;
+				}
+				return 'ACFInnerBlocks';
+			case 'script':
+				return Script;
+			case '#comment':
+				return null;
+			default:
+				// Replace names for JSX counterparts.
+				name = getJSXName( name );
+		}
+		return name;
+	}
+
+	/**
+	 * Functional component for ACFInnerBlocks.
+	 *
+	 * @since ACF 6.0.0
+	 *
+	 * @param obj props element properties.
+	 * @return DOM element
+	 */
+	function ACFInnerBlocks( props ) {
+		const { className = 'acf-innerblocks-container' } = props;
+		const innerBlockProps = useInnerBlocksProps(
+			{ className: className },
+			props
+		);
+
+		return <div { ...innerBlockProps }>{ innerBlockProps.children }</div>;
+	}
+
+	/**
+	 * Converts the given attribute into a React friendly name and value object.
+	 *
+	 * @date	19/05/2020
+	 * @since	ACF 5.9.0
+	 *
+	 * @param	obj nodeAttr The node attribute.
+	 * @return	obj
+	 */
+	function parseNodeAttr( nodeAttr ) {
+		let name = nodeAttr.name;
+		let value = nodeAttr.value;
+
+		// Allow overrides for third party libraries who might use specific attributes.
+		let shortcut = acf.applyFilters(
+			'acf_blocks_parse_node_attr',
+			false,
+			nodeAttr
+		);
+
+		if ( shortcut ) return shortcut;
+
+		switch ( name ) {
+			// Class.
+			case 'class':
+				name = 'className';
+				break;
+
+			// Style.
+			case 'style':
+				const css = {};
+				value.split( ';' ).forEach( ( s ) => {
+					const pos = s.indexOf( ':' );
+					if ( pos > 0 ) {
+						let ruleName = s.substr( 0, pos ).trim();
+						const ruleValue = s.substr( pos + 1 ).trim();
+
+						// Rename core properties, but not CSS variables.
+						if ( ruleName.charAt( 0 ) !== '-' ) {
+							ruleName = acf.strCamelCase( ruleName );
+						}
+						css[ ruleName ] = ruleValue;
+					}
+				} );
+				value = css;
+				break;
+
+			// Default.
+			default:
+				// No formatting needed for "data-x" attributes.
+				if ( name.indexOf( 'data-' ) === 0 ) {
+					break;
+				}
+
+				// Replace names for JSX counterparts.
+				name = getJSXName( name );
+
+				// Convert JSON values.
+				const c1 = value.charAt( 0 );
+				if ( c1 === '[' || c1 === '{' ) {
+					value = JSON.parse( value );
+				}
+
+				// Convert bool values.
+				if ( value === 'true' || value === 'false' ) {
+					value = value === 'true';
+				}
+				break;
+		}
+		return {
+			name,
+			value,
+		};
+	}
+
+	/**
+	 * Higher Order Component used to set default block attribute values.
+	 *
+	 * By modifying block attributes directly, instead of defining defaults in registerBlockType(),
+	 * WordPress will include them always within the saved block serialized JSON.
+	 *
+	 * @date	31/07/2020
+	 * @since	ACF 5.9.0
+	 *
+	 * @param	Component BlockListBlock The BlockListBlock Component.
+	 * @return	Component
+	 */
+	const withDefaultAttributes = createHigherOrderComponent(
+		( BlockListBlock ) =>
+			class WrappedBlockEdit extends Component {
+				constructor( props ) {
+					super( props );
+
+					// Extract vars.
+					const { name, attributes } = this.props;
+
+					// Only run on ACF Blocks.
+					const blockType = getBlockType( name );
+					if ( ! blockType ) {
+						return;
+					}
+
+					// Check and remove any empty string attributes to match PHP behaviour.
+					Object.keys( attributes ).forEach( ( key ) => {
+						if ( attributes[ key ] === '' ) {
+							delete attributes[ key ];
+						}
+					} );
+
+					// Backward compatibility attribute replacement.
+					const upgrades = {
+						full_height: 'fullHeight',
+						align_content: 'alignContent',
+						align_text: 'alignText',
+					};
+
+					Object.keys( upgrades ).forEach( ( key ) => {
+						if ( attributes[ key ] !== undefined ) {
+							attributes[ upgrades[ key ] ] = attributes[ key ];
+						} else if (
+							attributes[ upgrades[ key ] ] === undefined
+						) {
+							//Check for a default
+							if ( blockType[ key ] !== undefined ) {
+								attributes[ upgrades[ key ] ] =
+									blockType[ key ];
+							}
+						}
+						delete blockType[ key ];
+						delete attributes[ key ];
+					} );
+
+					// Set default attributes for those undefined.
+					for ( let attribute in blockType.attributes ) {
+						if (
+							attributes[ attribute ] === undefined &&
+							blockType[ attribute ] !== undefined
+						) {
+							attributes[ attribute ] = blockType[ attribute ];
+						}
+					}
+				}
+				render() {
+					return <BlockListBlock { ...this.props } />;
+				}
+			},
+		'withDefaultAttributes'
+	);
+	wp.hooks.addFilter(
+		'editor.BlockListBlock',
+		'acf/with-default-attributes',
+		withDefaultAttributes
+	);
+
+	/**
+	 * The BlockSave functional component.
+	 *
+	 * @date	08/07/2020
+	 * @since	ACF 5.9.0
+	 */
+	function BlockSave() {
+		return <InnerBlocks.Content />;
+	}
+
+	/**
+	 * The BlockEdit component.
+	 *
+	 * @date	19/2/19
+	 * @since	ACF 5.7.12
+	 */
+	class BlockEdit extends Component {
+		constructor( props ) {
+			super( props );
+			this.setup();
+		}
+
+		setup() {
+			const { name, attributes, clientId } = this.props;
+			const blockType = getBlockType( name );
+
+			// Restrict current mode.
+			function restrictMode( modes ) {
+				if ( ! modes.includes( attributes.mode ) ) {
+					attributes.mode = modes[ 0 ];
+				}
+			}
+
+			if ( isBlockInQueryLoop( clientId ) || isSiteEditor() ) {
+				restrictMode( [ 'preview' ] );
+			} else {
+				switch ( blockType.mode ) {
+					case 'edit':
+						restrictMode( [ 'edit', 'preview' ] );
+						break;
+					case 'preview':
+						restrictMode( [ 'preview', 'edit' ] );
+						break;
+					default:
+						restrictMode( [ 'auto' ] );
+						break;
+				}
+			}
+		}
+
+		render() {
+			const { name, attributes, setAttributes, clientId } = this.props;
+			const blockType = getBlockType( name );
+			const forcePreview =
+				isBlockInQueryLoop( clientId ) || isSiteEditor();
+			let { mode } = attributes;
+
+			if ( forcePreview ) {
+				mode = 'preview';
+			}
+
+			// Show toggle only for edit/preview modes and for blocks not in a query loop/FSE.
+			let showToggle = blockType.supports.mode;
+			if ( mode === 'auto' || forcePreview ) {
+				showToggle = false;
+			}
+
+			// Configure toggle variables.
+			const toggleText =
+				mode === 'preview'
+					? acf.__( 'Switch to Edit' )
+					: acf.__( 'Switch to Preview' );
+			const toggleIcon =
+				mode === 'preview' ? 'edit' : 'welcome-view-site';
+			function toggleMode() {
+				setAttributes( {
+					mode: mode === 'preview' ? 'edit' : 'preview',
+				} );
+			}
+
+			// Return template.
+			return (
+				<Fragment>
+					<BlockControls>
+						{ showToggle && (
+							<ToolbarGroup>
+								<ToolbarButton
+									className="components-icon-button components-toolbar__control"
+									label={ toggleText }
+									icon={ toggleIcon }
+									onClick={ toggleMode }
+								/>
+							</ToolbarGroup>
+						) }
+					</BlockControls>
+
+					<InspectorControls>
+						{ mode === 'preview' && (
+							<div className="acf-block-component acf-block-panel">
+								<BlockForm { ...this.props } />
+							</div>
+						) }
+					</InspectorControls>
+
+					<BlockBody { ...this.props } />
+				</Fragment>
+			);
+		}
+	}
+
+	/**
+	 * The BlockBody functional component.
+	 *
+	 * @since	ACF 5.7.12
+	 */
+	function BlockBody( props ) {
+		const { attributes, isSelected, name, clientId } = props;
+		const { mode } = attributes;
+
+		const index = useSelect( ( select ) => {
+			const rootClientId =
+				select( 'core/block-editor' ).getBlockRootClientId( clientId );
+			return select( 'core/block-editor' ).getBlockIndex(
+				clientId,
+				rootClientId
+			);
+		} );
+
+		let showForm = true;
+		let additionalClasses = 'acf-block-component acf-block-body';
+
+		if ( ( mode === 'auto' && ! isSelected ) || mode === 'preview' ) {
+			additionalClasses += ' acf-block-preview';
+			showForm = false;
+		}
+
+		// Setup block cache if required, and update mode.
+		if ( ! ( clientId in acf.blockInstances ) ) {
+			acf.blockInstances[ clientId ] = {
+				validation_errors: false,
+				mode: mode,
+			};
+		}
+		acf.blockInstances[ clientId ].mode = mode;
+
+		if ( ! isSelected ) {
+			if (
+				blockSupportsValidation( name ) &&
+				acf.blockInstances[ clientId ].validation_errors
+			) {
+				additionalClasses += ' acf-block-has-validation-error';
+			}
+			acf.blockInstances[ clientId ].has_been_deselected = true;
+		}
+
+		if ( getBlockVersion( name ) > 1 ) {
+			return (
+				<div { ...useBlockProps( { className: additionalClasses } ) }>
+					{ showForm ? (
+						<BlockForm { ...props } index={ index } />
+					) : (
+						<BlockPreview { ...props } index={ index } />
+					) }
+				</div>
+			);
+		} else {
+			return (
+				<div { ...useBlockProps() }>
+					<div className="acf-block-component acf-block-body">
+						{ showForm ? (
+							<BlockForm { ...props } index={ index } />
+						) : (
+							<BlockPreview { ...props } index={ index } />
+						) }
+					</div>
+				</div>
+			);
+		}
+	}
+
+	/**
+	 * A react component to append HTMl.
+	 *
+	 * @date	19/2/19
+	 * @since	ACF 5.7.12
+	 *
+	 * @param	string children The html to insert.
+	 * @return	void
+	 */
+	class Div extends Component {
+		render() {
+			return (
+				<div
+					dangerouslySetInnerHTML={ { __html: this.props.children } }
+				/>
+			);
+		}
+	}
+
+	/**
+	 * DynamicHTML Class.
+	 *
+	 * A react componenet to load and insert dynamic HTML.
+	 *
+	 * @date	19/2/19
+	 * @since	ACF 5.7.12
+	 *
+	 * @param	void
+	 * @return	void
+	 */
+	class DynamicHTML extends Component {
+		constructor( props ) {
+			super( props );
+
+			// Bind callbacks.
+			this.setRef = this.setRef.bind( this );
+
+			// Define default props and call setup().
+			this.id = '';
+			this.el = false;
+			this.subscribed = true;
+			this.renderMethod = 'jQuery';
+			this.passedValidation = false;
+			this.setup( props );
+
+			// Load state.
+			this.loadState();
+		}
+
+		setup( props ) {
+			const constructor = this.constructor.name;
+			const clientId = props.clientId;
+			if ( ! ( clientId in acf.blockInstances ) ) {
+				acf.blockInstances[ clientId ] = {
+					validation_errors: false,
+					mode: props.mode,
+				};
+			}
+			if ( ! ( constructor in acf.blockInstances[ clientId ] ) ) {
+				acf.blockInstances[ clientId ][ constructor ] = {};
+			}
+		}
+
+		fetch() {
+			// Do nothing.
+		}
+
+		maybePreload( blockId, clientId, form ) {
+			acf.debug( 'Preload check', blockId, clientId, form );
+
+			// Early return if block is in query loop.
+			if ( isBlockInQueryLoop( this.props.clientId ) ) {
+				acf.debug( 'Preload failed: Block is in query loop.' );
+				return false;
+			}
+
+			const preloadedBlocks = acf.get( 'preloadedBlocks' );
+
+			// Early return if no preloaded blocks exist.
+			if ( ! preloadedBlocks || ! preloadedBlocks[ blockId ] ) {
+				acf.debug( 'Preload failed: Block not preloaded.' );
+				return false;
+			}
+
+			// Create a copy to avoid mutating the original preloaded data.
+			const preloadedBlock = { ...preloadedBlocks[ blockId ] };
+
+			// Ensure we only preload the correct block state (form or preview).
+			if (
+				( form && ! preloadedBlock.form ) ||
+				( ! form && preloadedBlock.form )
+			) {
+				acf.debug(
+					'Preload failed: Correct state not preloaded.',
+					form ? 'form' : 'preview'
+				);
+				return false;
+			}
+
+			// Replace blockId with clientId in HTML.
+			preloadedBlock.html = preloadedBlock.html.replaceAll(
+				blockId,
+				clientId
+			);
+
+			// Replace blockId in validation errors.
+			if (
+				preloadedBlock.validation &&
+				preloadedBlock.validation.errors
+			) {
+				preloadedBlock.validation.errors =
+					preloadedBlock.validation.errors.map( ( error ) => {
+						error.input = error.input.replaceAll( blockId, clientId );
+						return error;
+					} );
+			}
+
+			// Return preloaded object.
+			acf.debug( 'Preload successful', preloadedBlock );
+			return preloadedBlock;
+		}
+
+		loadState() {
+			const client = acf.blockInstances[ this.props.clientId ] || {};
+			this.state = client[ this.constructor.name ] || {};
+		}
+		setState( state ) {
+			acf.blockInstances[ this.props.clientId ][ this.constructor.name ] =
+				{
+					...this.state,
+					...state,
+				};
+
+			// Update component state if subscribed.
+			// - Allows AJAX callback to update store without modifying state of an unmounted component.
+			if ( this.subscribed || acf.get( 'StrictMode' ) ) {
+				super.setState( state );
+			}
+
+			acf.debug(
+				'SetState',
+				Object.assign( {}, this ),
+				this.props.clientId,
+				this.constructor.name,
+				Object.assign(
+					{},
+					acf.blockInstances[ this.props.clientId ][
+						this.constructor.name
+					]
+				)
+			);
+		}
+
+		setHtml( html ) {
+			html = html ? html.trim() : '';
+
+			// Bail early if html has not changed.
+			if ( html === this.state.html ) {
+				return;
+			}
+
+			// Update state.
+			const state = {
+				html,
+			};
+
+			if ( this.renderMethod === 'jsx' ) {
+				state.jsx = acf.parseJSX(
+					html,
+					getBlockVersion( this.props.name )
+				);
+
+				// Handle templates which don't contain any valid JSX parsable elements.
+				if ( ! state.jsx ) {
+					console.warn(
+						'Your ACF block template contains no valid HTML elements. Appending a empty div to prevent React JS errors.'
+					);
+					state.html += '<div></div>';
+					state.jsx = acf.parseJSX(
+						state.html,
+						getBlockVersion( this.props.name )
+					);
+				}
+
+				// If we've got an object (as an array) find the first valid React ref.
+				if ( Array.isArray( state.jsx ) ) {
+					let refElement = state.jsx.find( ( element ) =>
+						React.isValidElement( element )
+					);
+					state.ref = refElement.ref;
+				} else {
+					state.ref = state.jsx.ref;
+				}
+				state.$el = $( this.el );
+			} else {
+				state.$el = $( html );
+			}
+			this.setState( state );
+		}
+
+		setRef( el ) {
+			this.el = el;
+		}
+
+		render() {
+			// Render JSX.
+			if ( this.state.jsx ) {
+				// If we're a v2+ block, use the jsx element itself as our ref.
+				if ( getBlockVersion( this.props.name ) > 1 ) {
+					this.setRef( this.state.jsx );
+					return this.state.jsx;
+				} else {
+					return <div ref={ this.setRef }>{ this.state.jsx }</div>;
+				}
+			}
+
+			// Return HTML.
+			return (
+				<div ref={ this.setRef }>
+					<Placeholder>
+						<Spinner />
+					</Placeholder>
+				</div>
+			);
+		}
+
+		shouldComponentUpdate( { index }, { html } ) {
+			if ( index !== this.props.index ) {
+				this.componentWillMove();
+			}
+			return html !== this.state.html;
+		}
+
+		display( context ) {
+			// This method is called after setting new HTML and the Component render.
+			// The jQuery render method simply needs to move $el into place.
+			if ( this.renderMethod === 'jQuery' ) {
+				const $el = this.state.$el;
+				const $prevParent = $el.parent();
+				const $thisParent = $( this.el );
+
+				// Move $el into place.
+				// Skip this in StrictMode unless context is 'append' or component is subscribed.
+				if (
+					! (
+						acf.get( 'StrictMode' ) &&
+						context !== 'append' &&
+						! this.subscribed
+					)
+				) {
+					$thisParent.html( $el );
+				}
+
+				// Special case for reusable blocks.
+				// Multiple instances of the same reusable block share the same block id.
+				// This causes all instances to share the same state (cool), which unfortunately
+				// pulls $el back and forth between the last rendered reusable block.
+				// This simple fix leaves a "clone" behind :)
+				if (
+					$prevParent.length &&
+					$prevParent[ 0 ] !== $thisParent[ 0 ]
+				) {
+					$prevParent.html( $el.clone() );
+				}
+			}
+
+			// Lock block if required.
+			if ( this.getValidationErrors() && this.isNotNewlyAdded() ) {
+				this.lockBlockForSaving();
+			} else {
+				this.unlockBlockForSaving();
+			}
+
+			// Call context specific method.
+			switch ( context ) {
+				case 'append':
+					this.componentDidAppend();
+					break;
+				case 'remount':
+					this.componentDidRemount();
+					break;
+			}
+		}
+
+		validate() {
+			// Do nothing.
+		}
+
+		componentDidMount() {
+			// Fetch on first load.
+			if ( this.state.html === undefined ) {
+				this.fetch();
+
+				// Or remount existing HTML.
+			} else {
+				this.display( 'remount' );
+			}
+		}
+
+		componentDidUpdate( prevProps, prevState ) {
+			// HTML has changed.
+			this.display( 'append' );
+		}
+
+		componentDidAppend() {
+			acf.doAction( 'append', this.state.$el );
+		}
+
+		componentWillUnmount() {
+			// Only skip unmount action if in StrictMode AND component is not subscribed
+			if ( ! acf.get( 'StrictMode' ) || this.subscribed ) {
+				acf.doAction( 'unmount', this.state.$el );
+			}
+
+			// Unsubscribe this component from state
+			this.subscribed = false;
+		}
+
+		componentDidRemount() {
+			this.subscribed = true;
+
+			// Use setTimeout to avoid incorrect timing of events.
+			// React will unmount and mount components in DOM order.
+			// This means a new component can be mounted before an old one is unmounted.
+			// ACF shares $el across new/old components which is un-React-like.
+			// This timout ensures that unmounting occurs before remounting.
+			setTimeout( () => {
+				acf.doAction( 'remount', this.state.$el );
+			} );
+		}
+
+		componentWillMove() {
+			acf.doAction( 'unmount', this.state.$el );
+			setTimeout( () => {
+				acf.doAction( 'remount', this.state.$el );
+			} );
+		}
+
+		isNotNewlyAdded() {
+			return (
+				acf.blockInstances[ this.props.clientId ].has_been_deselected ||
+				false
+			);
+		}
+
+		hasShownValidation() {
+			return (
+				acf.blockInstances[ this.props.clientId ].shown_validation ||
+				false
+			);
+		}
+
+		setShownValidation() {
+			acf.blockInstances[ this.props.clientId ].shown_validation = true;
+		}
+
+		setValidationErrors( errors ) {
+			acf.blockInstances[ this.props.clientId ].validation_errors =
+				errors;
+		}
+
+		getValidationErrors() {
+			return acf.blockInstances[ this.props.clientId ].validation_errors;
+		}
+
+		getMode() {
+			return acf.blockInstances[ this.props.clientId ].mode;
+		}
+
+		lockBlockForSaving() {
+			if ( ! wp.data.dispatch( 'core/editor' ) ) return;
+			wp.data
+				.dispatch( 'core/editor' )
+				.lockPostSaving( 'acf/block/' + this.props.clientId );
+		}
+
+		unlockBlockForSaving() {
+			if ( ! wp.data.dispatch( 'core/editor' ) ) return;
+			wp.data
+				.dispatch( 'core/editor' )
+				.unlockPostSaving( 'acf/block/' + this.props.clientId );
+		}
+
+		displayValidation( $formEl ) {
+			if ( ! blockSupportsValidation( this.props.name ) ) {
+				acf.debug( 'Block does not support validation' );
+				return;
+			}
+			if ( ! $formEl || $formEl.hasClass( 'acf-empty-block-fields' ) ) {
+				acf.debug( 'There is no edit form available to validate.' );
+				return;
+			}
+
+			const errors = this.getValidationErrors();
+			acf.debug(
+				'Starting handle validation',
+				Object.assign( {}, this ),
+				Object.assign( {}, $formEl ),
+				errors
+			);
+
+			this.setShownValidation();
+
+			let validator = acf.getBlockFormValidator( $formEl );
+			validator.clearErrors();
+
+			acf.doAction( 'blocks/validation/pre_apply', errors );
+			if ( errors ) {
+				validator.addErrors( errors );
+				validator.showErrors( 'after' );
+
+				this.lockBlockForSaving();
+			} else {
+				// remove previous error message
+				if ( validator.has( 'notice' ) ) {
+					validator.get( 'notice' ).update( {
+						type: 'success',
+						text: acf.__( 'Validation successful' ),
+						timeout: 1000,
+					} );
+					validator.set( 'notice', null );
+				}
+
+				this.unlockBlockForSaving();
+			}
+			acf.doAction( 'blocks/validation/post_apply', errors );
+		}
+	}
+
+	/**
+	 * BlockForm Class.
+	 *
+	 * A react componenet to handle the block form.
+	 *
+	 * @date	19/2/19
+	 * @since	ACF 5.7.12
+	 *
+	 * @param	string id the block id.
+	 * @return	void
+	 */
+	class BlockForm extends DynamicHTML {
+		setup( props ) {
+			this.id = `BlockForm-${ props.clientId }`;
+			super.setup( props );
+		}
+
+		fetch( validate_only = false, data = false ) {
+			// Extract props.
+			const { context, clientId, name } = this.props;
+			let { attributes } = this.props;
+
+			let query = { form: true };
+			if ( validate_only ) {
+				query = { validate: true };
+				attributes.data = data;
+			}
+
+			const hash = createBlockAttributesHash( attributes, context );
+
+			acf.debug( 'BlockForm fetch', attributes, query );
+
+			// Try preloaded data first.
+			const preloaded = this.maybePreload( hash, clientId, true );
+
+			if ( preloaded ) {
+				this.setHtml(
+					acf.applyFilters(
+						'blocks/form/render',
+						preloaded.html,
+						true
+					)
+				);
+				if ( preloaded.validation )
+					this.setValidationErrors( preloaded.validation.errors );
+				return;
+			}
+
+			if ( ! blockSupportsValidation( name ) ) {
+				query.validate = false;
+			}
+
+			// Request AJAX and update HTML on complete.
+			fetchBlock( {
+				attributes,
+				context,
+				clientId,
+				query,
+			} ).done( ( { data } ) => {
+				acf.debug( 'fetch block form promise' );
+
+				if ( ! data ) {
+					this.setHtml(
+						`<div class="acf-block-fields acf-fields acf-empty-block-fields">${ acf.__(
+							'Error loading block form'
+						) }</div>`
+					);
+					return;
+				}
+
+				if ( data.form ) {
+					this.setHtml(
+						acf.applyFilters(
+							'blocks/form/render',
+							data.form.replaceAll( data.clientId, clientId ),
+							false
+						)
+					);
+				}
+
+				if ( data.validation )
+					this.setValidationErrors( data.validation.errors );
+
+				if ( this.isNotNewlyAdded() ) {
+					acf.debug(
+						"Block has already shown it's invalid. The form needs to show validation errors"
+					);
+					this.validate();
+				}
+			} );
+		}
+
+		validate( loadState = true ) {
+			if ( loadState ) {
+				this.loadState();
+			}
+
+			acf.debug(
+				'BlockForm calling validate with state',
+				Object.assign( {}, this )
+			);
+			super.displayValidation( this.state.$el );
+		}
+
+		shouldComponentUpdate( nextProps, nextState ) {
+			if (
+				blockSupportsValidation( this.props.name ) &&
+				this.state.$el &&
+				this.isNotNewlyAdded() &&
+				! this.hasShownValidation()
+			) {
+				this.validate( false ); // Shouldn't update state in shouldComponentUpdate.
+			}
+
+			return super.shouldComponentUpdate( nextProps, nextState );
+		}
+
+		componentWillUnmount() {
+			super.componentWillUnmount();
+
+			//TODO: either delete this, or clear validations here (if that's a sensible idea)
+
+			acf.debug( 'BlockForm Component did unmount' );
+		}
+
+		componentDidRemount() {
+			super.componentDidRemount();
+
+			acf.debug( 'BlockForm component did remount' );
+
+			const { $el } = this.state;
+
+			if (
+				blockSupportsValidation( this.props.name ) &&
+				this.isNotNewlyAdded()
+			) {
+				acf.debug(
+					"Block has already shown it's invalid. The form needs to show validation errors"
+				);
+				this.validate();
+			}
+
+			// Make sure our on append events are registered.
+			if ( $el.data( 'acf-events-added' ) !== true ) {
+				this.componentDidAppend();
+			}
+		}
+
+		componentDidAppend() {
+			super.componentDidAppend();
+
+			acf.debug( 'BlockForm component did append' );
+
+			// Extract props.
+			const { attributes, setAttributes, clientId, name } = this.props;
+			const thisBlockForm = this;
+			const { $el } = this.state;
+
+			// Callback for updating block data and validation status if we're in an edit only mode.
+			function serializeData( silent = false ) {
+				const data = acf.serialize( $el, `acf-block_${ clientId }` );
+
+				if ( silent ) {
+					attributes.data = data;
+				} else {
+					setAttributes( {
+						data,
+					} );
+				}
+
+				if (
+					blockSupportsValidation( name ) &&
+					! silent &&
+					thisBlockForm.getMode() === 'edit'
+				) {
+					acf.debug(
+						'No block preview currently available. Need to trigger a validation only fetch.'
+					);
+					thisBlockForm.fetch( true, data );
+				}
+			}
+
+			// Add events.
+			let timeout = false;
+			$el.on( 'change keyup', () => {
+				clearTimeout( timeout );
+				timeout = setTimeout( serializeData, 300 );
+			} );
+
+			// Log initialization for remount check on the persistent element.
+			$el.data( 'acf-events-added', true );
+
+			// Ensure newly added block is saved with data.
+			// Do it silently to avoid triggering a preview render.
+			if ( ! attributes.data ) {
+				serializeData( true );
+			}
+		}
+	}
+
+	/**
+	 * BlockPreview Class.
+	 *
+	 * A react componenet to handle the block preview.
+	 *
+	 * @date	19/2/19
+	 * @since	ACF 5.7.12
+	 *
+	 * @param	string id the block id.
+	 * @return	void
+	 */
+	class BlockPreview extends DynamicHTML {
+		setup( props ) {
+			const blockType = getBlockType( props.name );
+			const contextPostId = acf.isget( this.props, 'context', 'postId' );
+
+			this.id = `BlockPreview-${ props.clientId }`;
+
+			super.setup( props );
+
+			// Apply the contextPostId to the ID if set to stop query loop ID duplication.
+			if ( contextPostId ) {
+				this.id = `BlockPreview-${ props.clientId }-${ contextPostId }`;
+			}
+
+			if ( blockType.supports.jsx ) {
+				this.renderMethod = 'jsx';
+			}
+		}
+
+		fetch( args = {} ) {
+			const {
+				attributes = this.props.attributes,
+				clientId = this.props.clientId,
+				context = this.props.context,
+				delay = 0,
+			} = args;
+
+			const { name } = this.props;
+
+			// Remember attributes used to fetch HTML.
+			this.setState( {
+				prevAttributes: attributes,
+				prevContext: context,
+			} );
+
+			const hash = createBlockAttributesHash( attributes, context );
+
+			// Try preloaded data first.
+			let preloaded = this.maybePreload( hash, clientId, false );
+
+			if ( preloaded ) {
+				if ( getBlockVersion( name ) == 1 ) {
+					preloaded.html =
+						'<div class="acf-block-preview">' +
+						preloaded.html +
+						'</div>';
+				}
+				this.setHtml(
+					acf.applyFilters(
+						'blocks/preview/render',
+						preloaded.html,
+						true
+					)
+				);
+				if ( preloaded.validation )
+					this.setValidationErrors( preloaded.validation.errors );
+				return;
+			}
+
+			let query = { preview: true };
+
+			if ( ! blockSupportsValidation( name ) ) {
+				query.validate = false;
+			}
+
+			// Request AJAX and update HTML on complete.
+			fetchBlock( {
+				attributes,
+				context,
+				clientId,
+				query,
+				delay,
+			} ).done( ( { data } ) => {
+				if ( ! data ) {
+					this.setHtml(
+						`<div class="acf-block-fields acf-fields acf-empty-block-fields">${ acf.__(
+							'Error previewing block'
+						) }</div>`
+					);
+					return;
+				}
+
+				let replaceHtml = data.preview.replaceAll(
+					data.clientId,
+					clientId
+				);
+				if ( getBlockVersion( name ) == 1 ) {
+					replaceHtml =
+						'<div class="acf-block-preview">' +
+						replaceHtml +
+						'</div>';
+				}
+				acf.debug( 'fetch block render promise' );
+				this.setHtml(
+					acf.applyFilters(
+						'blocks/preview/render',
+						replaceHtml,
+						false
+					)
+				);
+				if ( data.validation ) {
+					this.setValidationErrors( data.validation.errors );
+				}
+				if ( this.isNotNewlyAdded() ) {
+					this.validate();
+				}
+			} );
+		}
+
+		validate() {
+			// Check we've got a block form for this instance.
+			const client = acf.blockInstances[ this.props.clientId ] || {};
+			const blockFormState = client.BlockForm || false;
+			if ( blockFormState ) {
+				super.displayValidation( blockFormState.$el );
+			}
+		}
+
+		componentDidAppend() {
+			super.componentDidAppend();
+			this.renderBlockPreviewEvent();
+		}
+
+		shouldComponentUpdate( nextProps, nextState ) {
+			const nextAttributes = nextProps.attributes;
+			const thisAttributes = this.props.attributes;
+
+			// Update preview if block data has changed.
+			if (
+				! compareObjects( nextAttributes, thisAttributes ) ||
+				! compareObjects( nextProps.context, this.props.context )
+			) {
+				let delay = 0;
+
+				// Delay fetch when editing className or anchor to simulate consistent logic to custom fields.
+				if ( nextAttributes.className !== thisAttributes.className ) {
+					delay = 300;
+				}
+				if ( nextAttributes.anchor !== thisAttributes.anchor ) {
+					delay = 300;
+				}
+
+				acf.debug(
+					'Triggering fetch from block preview shouldComponentUpdate'
+				);
+
+				this.fetch( {
+					attributes: nextAttributes,
+					context: nextProps.context,
+					delay,
+				} );
+			}
+			return super.shouldComponentUpdate( nextProps, nextState );
+		}
+
+		renderBlockPreviewEvent() {
+			// Extract props.
+			const { attributes, name } = this.props;
+			const { $el, ref } = this.state;
+			var blockElement;
+
+			// Generate action friendly type.
+			const type = attributes.name.replace( 'acf/', '' );
+
+			if ( ref && ref.current ) {
+				// We've got a react ref from a JSX container. Use the parent as the blockElement
+				blockElement = $( ref.current ).parent();
+			} else if ( getBlockVersion( name ) == 1 ) {
+				blockElement = $el;
+			} else {
+				blockElement = $el.parents( '.acf-block-preview' );
+			}
+
+			// Do action.
+			acf.doAction( 'render_block_preview', blockElement, attributes );
+			acf.doAction(
+				`render_block_preview/type=${ type }`,
+				blockElement,
+				attributes
+			);
+		}
+
+		componentDidRemount() {
+			super.componentDidRemount();
+
+			acf.debug(
+				'Checking if fetch is required in BlockPreview componentDidRemount',
+				Object.assign( {}, this.state.prevAttributes ),
+				Object.assign( {}, this.props.attributes ),
+				Object.assign( {}, this.state.prevContext ),
+				Object.assign( {}, this.props.context )
+			);
+
+			// Update preview if data has changed since last render (changing from "edit" to "preview").
+			if (
+				! compareObjects(
+					this.state.prevAttributes,
+					this.props.attributes
+				) ||
+				! compareObjects( this.state.prevContext, this.props.context )
+			) {
+				acf.debug(
+					'Triggering block preview fetch from componentDidRemount'
+				);
+				this.fetch();
+			}
+
+			// Fire the block preview event so blocks can reinit JS elements.
+			// React reusing DOM elements covers any potential race condition from the above fetch.
+			this.renderBlockPreviewEvent();
+		}
+	}
+
+	/**
+	 * Initializes ACF Blocks logic and registration.
+	 *
+	 * @since ACF 5.9.0
+	 */
+	function initialize() {
+		// Add support for WordPress versions before 5.2.
+		if ( ! wp.blockEditor ) {
+			wp.blockEditor = wp.editor;
+		}
+
+		// Register block types.
+		const blockTypes = acf.get( 'blockTypes' );
+		if ( blockTypes ) {
+			// Only register blocks with version <= 2 (v3+ blocks are registered separately).
+			blockTypes.forEach( ( blockType ) => {
+				parseInt( blockType.acf_block_version ) <= 2 &&
+					registerBlockType( blockType );
+			} );
+		}
+	}
+
+	// Run the initialize callback during the "prepare" action.
+	// This ensures that all localized data is available and that blocks are registered before the WP editor has been instantiated.
+	acf.addAction( 'prepare', initialize );
+
+	/**
+	 * Returns a valid vertical alignment.
+	 *
+	 * @date	07/08/2020
+	 * @since	ACF 5.9.0
+	 *
+	 * @param	string align A vertical alignment.
+	 * @return	string
+	 */
+	function validateVerticalAlignment( align ) {
+		const ALIGNMENTS = [ 'top', 'center', 'bottom' ];
+		const DEFAULT = 'top';
+		return ALIGNMENTS.includes( align ) ? align : DEFAULT;
+	}
+
+	/**
+	 * Returns a valid horizontal alignment.
+	 *
+	 * @date	07/08/2020
+	 * @since	ACF 5.9.0
+	 *
+	 * @param	string align A horizontal alignment.
+	 * @return	string
+	 */
+	function validateHorizontalAlignment( align ) {
+		const ALIGNMENTS = [ 'left', 'center', 'right' ];
+		const DEFAULT = acf.get( 'rtl' ) ? 'right' : 'left';
+		return ALIGNMENTS.includes( align ) ? align : DEFAULT;
+	}
+
+	/**
+	 * Returns a valid matrix alignment.
+	 *
+	 * Written for "upgrade-path" compatibility from vertical alignment to matrix alignment.
+	 *
+	 * @date	07/08/2020
+	 * @since	ACF 5.9.0
+	 *
+	 * @param	string align A matrix alignment.
+	 * @return	string
+	 */
+	function validateMatrixAlignment( align ) {
+		const DEFAULT = 'center center';
+		if ( align ) {
+			const [ y, x ] = align.split( ' ' );
+			return `${ validateVerticalAlignment(
+				y
+			) } ${ validateHorizontalAlignment( x ) }`;
+		}
+		return DEFAULT;
+	}
+
+	/**
+	 * A higher order component adding alignContent editing functionality.
+	 *
+	 * @date	08/07/2020
+	 * @since	ACF 5.9.0
+	 *
+	 * @param	component OriginalBlockEdit The original BlockEdit component.
+	 * @param	object blockType The block type settings.
+	 * @return	component
+	 */
+	function withAlignContentComponent( OriginalBlockEdit, blockType ) {
+		// Determine alignment vars
+		let type =
+			blockType.supports.align_content || blockType.supports.alignContent;
+		let AlignmentComponent;
+		let validateAlignment;
+		switch ( type ) {
+			case 'matrix':
+				AlignmentComponent =
+					BlockAlignmentMatrixControl || BlockAlignmentMatrixToolbar;
+				validateAlignment = validateMatrixAlignment;
+				break;
+			default:
+				AlignmentComponent = BlockVerticalAlignmentToolbar;
+				validateAlignment = validateVerticalAlignment;
+				break;
+		}
+
+		// Ensure alignment component exists.
+		if ( AlignmentComponent === undefined ) {
+			console.warn(
+				`The "${ type }" alignment component was not found.`
+			);
+			return OriginalBlockEdit;
+		}
+
+		// Ensure correct block attribute data is sent in intial preview AJAX request.
+		blockType.alignContent = validateAlignment( blockType.alignContent );
+
+		// Return wrapped component.
+		return class WrappedBlockEdit extends Component {
+			render() {
+				const { attributes, setAttributes } = this.props;
+				const { alignContent } = attributes;
+				function onChangeAlignContent( alignContent ) {
+					setAttributes( {
+						alignContent: validateAlignment( alignContent ),
+					} );
+				}
+				return (
+					<Fragment>
+						<BlockControls group="block">
+							<AlignmentComponent
+								label={ acf.__( 'Change content alignment' ) }
+								value={ validateAlignment( alignContent ) }
+								onChange={ onChangeAlignContent }
+							/>
+						</BlockControls>
+						<OriginalBlockEdit { ...this.props } />
+					</Fragment>
+				);
+			}
+		};
+	}
+
+	/**
+	 * A higher order component adding alignText editing functionality.
+	 *
+	 * @date	08/07/2020
+	 * @since	ACF 5.9.0
+	 *
+	 * @param	component OriginalBlockEdit The original BlockEdit component.
+	 * @param	object blockType The block type settings.
+	 * @return	component
+	 */
+	function withAlignTextComponent( OriginalBlockEdit, blockType ) {
+		const validateAlignment = validateHorizontalAlignment;
+
+		// Ensure correct block attribute data is sent in intial preview AJAX request.
+		blockType.alignText = validateAlignment( blockType.alignText );
+
+		// Return wrapped component.
+		return class WrappedBlockEdit extends Component {
+			render() {
+				const { attributes, setAttributes } = this.props;
+				const { alignText } = attributes;
+
+				function onChangeAlignText( alignText ) {
+					setAttributes( {
+						alignText: validateAlignment( alignText ),
+					} );
+				}
+
+				return (
+					<Fragment>
+						<BlockControls group="block">
+							<AlignmentToolbar
+								value={ validateAlignment( alignText ) }
+								onChange={ onChangeAlignText }
+							/>
+						</BlockControls>
+						<OriginalBlockEdit { ...this.props } />
+					</Fragment>
+				);
+			}
+		};
+	}
+
+	/**
+	 * A higher order component adding full height support.
+	 *
+	 * @date	19/07/2021
+	 * @since	ACF 5.10.0
+	 *
+	 * @param	component OriginalBlockEdit The original BlockEdit component.
+	 * @param	object blockType The block type settings.
+	 * @return	component
+	 */
+	function withFullHeightComponent( OriginalBlockEdit, blockType ) {
+		if ( ! BlockFullHeightAlignmentControl ) return OriginalBlockEdit;
+
+		// Return wrapped component.
+		return class WrappedBlockEdit extends Component {
+			render() {
+				const { attributes, setAttributes } = this.props;
+				const { fullHeight } = attributes;
+
+				function onToggleFullHeight( fullHeight ) {
+					setAttributes( {
+						fullHeight,
+					} );
+				}
+
+				return (
+					<Fragment>
+						<BlockControls group="block">
+							<BlockFullHeightAlignmentControl
+								isActive={ fullHeight }
+								onToggle={ onToggleFullHeight }
+							/>
+						</BlockControls>
+						<OriginalBlockEdit { ...this.props } />
+					</Fragment>
+				);
+			}
+		};
+	}
+
+	/**
+	 * Appends a backwards compatibility attribute for conversion.
+	 *
+	 * @since	ACF 6.0
+	 *
+	 * @param	object attributes The block type attributes.
+	 * @return	object
+	 */
+	function addBackCompatAttribute( attributes, new_attribute, type ) {
+		attributes[ new_attribute ] = {
+			type: type,
+		};
+		return attributes;
+	}
+
+	/**
+	 * Create a block hash from attributes
+	 *
+	 * @since ACF 6.0
+	 *
+	 * @param object attributes The block type attributes.
+	 * @param object context The current block context object.
+	 * @return string
+	 */
+	function createBlockAttributesHash( attributes, context ) {
+		attributes[ '_acf_context' ] = sortObjectByKey( context );
+		return md5( JSON.stringify( sortObjectByKey( attributes ) ) );
+	}
+
+	/**
+	 * Key sort an object
+	 *
+	 * @since ACF 6.3.1
+	 *
+	 * @param object toSort The object to be sorted
+	 * @return object
+	 */
+	function sortObjectByKey( toSort ) {
+		return Object.keys( toSort )
+			.sort()
+			.reduce( ( acc, currValue ) => {
+				acc[ currValue ] = toSort[ currValue ];
+				return acc;
+			}, {} );
+	}
+} )( jQuery );

--- a/assets/src/js/pro/_acf-blocks-v3.js
+++ b/assets/src/js/pro/_acf-blocks-v3.js
@@ -4,10 +4,10 @@
  */
 
 // Import utilities
-import './blocks-v3/utils/post-locking';
+// import './blocks-v3/utils/post-locking';
 
 // Import JSX parser and expose on acf global
-import './blocks-v3/components/jsx-parser';
+// import './blocks-v3/components/jsx-parser';
 
 // Import block registration (initializes automatically via acf.addAction)
-import './blocks-v3/register-block-type-v3';
+// import './blocks-v3/register-block-type-v3';

--- a/assets/src/js/pro/_acf-blocks.js
+++ b/assets/src/js/pro/_acf-blocks.js
@@ -1086,52 +1086,57 @@ const md5 = require( 'md5' );
 
 		maybePreload( blockId, clientId, form ) {
 			acf.debug( 'Preload check', blockId, clientId, form );
-			if ( ! isBlockInQueryLoop( this.props.clientId ) ) {
-				const preloadedBlocks = acf.get( 'preloadedBlocks' );
-				const modeText = form ? 'form' : 'preview';
 
-				if ( preloadedBlocks && preloadedBlocks[ blockId ] ) {
-					// Ensure we only preload the correct block state (form or preview).
-					if (
-						( form && ! preloadedBlocks[ blockId ].form ) ||
-						( ! form && preloadedBlocks[ blockId ].form )
-					) {
-						acf.debug( 'Preload failed: state not preloaded.' );
-						return false;
-					}
-
-					// Set HTML to the preloaded version.
-					preloadedBlocks[ blockId ].html = preloadedBlocks[
-						blockId
-					].html.replaceAll( blockId, clientId );
-
-					// Replace blockId in errors.
-					if (
-						preloadedBlocks[ blockId ].validation &&
-						preloadedBlocks[ blockId ].validation.errors
-					) {
-						preloadedBlocks[ blockId ].validation.errors =
-							preloadedBlocks[ blockId ].validation.errors.map(
-								( error ) => {
-									error.input = error.input.replaceAll(
-										blockId,
-										clientId
-									);
-									return error;
-								}
-							);
-					}
-
-					// Return preloaded object.
-					acf.debug(
-						'Preload successful',
-						preloadedBlocks[ blockId ]
-					);
-					return preloadedBlocks[ blockId ];
-				}
+			// Early return if block is in query loop.
+			if ( isBlockInQueryLoop( this.props.clientId ) ) {
+				acf.debug( 'Preload failed: Block is in query loop.' );
+				return false;
 			}
-			acf.debug( 'Preload failed: not preloaded.' );
-			return false;
+
+			const preloadedBlocks = acf.get( 'preloadedBlocks' );
+
+			// Early return if no preloaded blocks exist.
+			if ( ! preloadedBlocks || ! preloadedBlocks[ blockId ] ) {
+				acf.debug( 'Preload failed: Block not preloaded.' );
+				return false;
+			}
+
+			// Create a copy to avoid mutating the original preloaded data.
+			const preloadedBlock = { ...preloadedBlocks[ blockId ] };
+
+			// Ensure we only preload the correct block state (form or preview).
+			if (
+				( form && ! preloadedBlock.form ) ||
+				( ! form && preloadedBlock.form )
+			) {
+				acf.debug(
+					'Preload failed: Correct state not preloaded.',
+					form ? 'form' : 'preview'
+				);
+				return false;
+			}
+
+			// Replace blockId with clientId in HTML.
+			preloadedBlock.html = preloadedBlock.html.replaceAll(
+				blockId,
+				clientId
+			);
+
+			// Replace blockId in validation errors.
+			if (
+				preloadedBlock.validation &&
+				preloadedBlock.validation.errors
+			) {
+				preloadedBlock.validation.errors =
+					preloadedBlock.validation.errors.map( ( error ) => {
+						error.input = error.input.replaceAll( blockId, clientId );
+						return error;
+					} );
+			}
+
+			// Return preloaded object.
+			acf.debug( 'Preload successful', preloadedBlock );
+			return preloadedBlock;
 		}
 
 		loadState() {
@@ -1254,7 +1259,16 @@ const md5 = require( 'md5' );
 				const $thisParent = $( this.el );
 
 				// Move $el into place.
-				$thisParent.html( $el );
+				// Skip this in StrictMode unless context is 'append' or component is subscribed.
+				if (
+					! (
+						acf.get( 'StrictMode' ) &&
+						context !== 'append' &&
+						! this.subscribed
+					)
+				) {
+					$thisParent.html( $el );
+				}
 
 				// Special case for reusable blocks.
 				// Multiple instances of the same reusable block share the same block id.
@@ -1870,12 +1884,11 @@ const md5 = require( 'md5' );
 		// Register block types.
 		const blockTypes = acf.get( 'blockTypes' );
 		if ( blockTypes ) {
-			// Only register blocks with version < 3 (v3 blocks are registered separately).
-			blockTypes
-				.filter(
-					( blockType ) => parseInt( blockType.acf_block_version ) < 3
-				)
-				.map( registerBlockType );
+			// Only register blocks with version <= 2 (v3+ blocks are registered separately).
+			blockTypes.forEach( ( blockType ) => {
+				parseInt( blockType.acf_block_version ) <= 2 &&
+					registerBlockType( blockType );
+			} );
 		}
 	}
 

--- a/assets/src/js/pro/_acf-blocks.js
+++ b/assets/src/js/pro/_acf-blocks.js
@@ -1,2144 +1,5163 @@
-const md5 = require( 'md5' );
-
-( ( $, undefined ) => {
-	// Dependencies.
-	const {
-		BlockControls,
-		InspectorControls,
-		InnerBlocks,
-		useBlockProps,
-		AlignmentToolbar,
-		BlockVerticalAlignmentToolbar,
-	} = wp.blockEditor;
-
-	const { ToolbarGroup, ToolbarButton, Placeholder, Spinner } = wp.components;
-	const { Fragment } = wp.element;
-	const { Component } = React;
-	const { useSelect } = wp.data;
-	const { createHigherOrderComponent } = wp.compose;
-
-	// Potentially experimental dependencies.
-	const BlockAlignmentMatrixToolbar =
-		wp.blockEditor.__experimentalBlockAlignmentMatrixToolbar ||
-		wp.blockEditor.BlockAlignmentMatrixToolbar;
-	// Gutenberg v10.x begins transition from Toolbar components to Control components.
-	const BlockAlignmentMatrixControl =
-		wp.blockEditor.__experimentalBlockAlignmentMatrixControl ||
-		wp.blockEditor.BlockAlignmentMatrixControl;
-	const BlockFullHeightAlignmentControl =
-		wp.blockEditor.__experimentalBlockFullHeightAligmentControl ||
-		wp.blockEditor.__experimentalBlockFullHeightAlignmentControl ||
-		wp.blockEditor.BlockFullHeightAlignmentControl;
-	const useInnerBlocksProps =
-		wp.blockEditor.__experimentalUseInnerBlocksProps ||
-		wp.blockEditor.useInnerBlocksProps;
-
-	/**
-	 * Storage for registered block types.
-	 *
-	 * @since ACF 5.8.0
-	 * @var object
-	 */
-	const blockTypes = {};
-
-	/**
-	 * Data storage for Block Instances and their DynamicHTML components.
-	 * This is temporarily stored on the ACF object, but this will be replaced later.
-	 * Developers should not rely on reading or using any aspect of acf.blockInstances.
-	 *
-	 * @since ACF 6.3
-	 */
-	acf.blockInstances = {};
-
-	/**
-	 * Returns a block type for the given name.
-	 *
-	 * @date	20/2/19
-	 * @since	ACF 5.8.0
-	 *
-	 * @param	string name The block name.
-	 * @return	(object|false)
-	 */
-	function getBlockType( name ) {
-		return blockTypes[ name ] || false;
-	}
-
-	/**
-	 * Returns a block version for a given block name
-	 *
-	 * @date 8/6/22
-	 * @since ACF 6.0
-	 *
-	 * @param string name The block name
-	 * @return int
-	 */
-	function getBlockVersion( name ) {
-		const blockType = getBlockType( name );
-		return blockType.acf_block_version || 1;
-	}
-
-	/**
-	 * Returns a block's validate property. Default true.
-	 *
-	 * @since ACF 6.3
-	 *
-	 * @param string name The block name
-	 * @return boolean
-	 */
-	function blockSupportsValidation( name ) {
-		const blockType = getBlockType( name );
-		return blockType.validate;
-	}
-
-	/**
-	 * Returns true if a block (identified by client ID) is nested in a query loop block.
-	 *
-	 * @date 17/1/22
-	 * @since ACF 5.12
-	 *
-	 * @param {string} clientId A block client ID
-	 * @return boolean
-	 */
-	function isBlockInQueryLoop( clientId ) {
-		const parents = wp.data
-			.select( 'core/block-editor' )
-			.getBlockParents( clientId );
-		const parentsData = wp.data
-			.select( 'core/block-editor' )
-			.getBlocksByClientId( parents );
-		return parentsData.filter( ( block ) => block.name === 'core/query' )
-			.length;
-	}
-
-	/**
-	 * Returns true if we're currently inside the WP 5.9+ site editor.
-	 *
-	 * @date 08/02/22
-	 * @since ACF 5.12
-	 *
-	 * @return boolean
-	 */
-	function isSiteEditor() {
-		return (
-			document.querySelectorAll( 'iframe[name="editor-canvas"]' ).length >
-			0
-		);
-	}
-
-	/**
-	 * Returns true if the block editor is currently showing the desktop device type preview.
-	 *
-	 * This function will always return true in the site editor as it uses the
-	 * edit-post store rather than the edit-site store.
-	 *
-	 * @date 15/02/22
-	 * @since ACF 5.12
-	 *
-	 * @return boolean
-	 */
-	function isDesktopPreviewDeviceType() {
-		const editPostStore = select( 'core/edit-post' );
-
-		// Return true if the edit post store isn't available (such as in the widget editor)
-		if ( ! editPostStore ) return true;
-
-		// Check if function exists (experimental or not) and return true if it's Desktop, or doesn't exist.
-		if ( editPostStore.__experimentalGetPreviewDeviceType ) {
-			return (
-				'Desktop' === editPostStore.__experimentalGetPreviewDeviceType()
-			);
-		} else if ( editPostStore.getPreviewDeviceType ) {
-			return 'Desktop' === editPostStore.getPreviewDeviceType();
-		} else {
-			return true;
-		}
-	}
-
-	/**
-	 * Returns true if the block editor is currently in template edit mode.
-	 *
-	 * @date 16/02/22
-	 * @since ACF 5.12
-	 *
-	 * @return boolean
-	 */
-	function isEditingTemplate() {
-		const editPostStore = select( 'core/edit-post' );
-
-		// Return false if the edit post store isn't available (such as in the widget editor)
-		if ( ! editPostStore ) return false;
-
-		// Return false if the function doesn't exist
-		if ( ! editPostStore.isEditingTemplate ) return false;
-
-		return editPostStore.isEditingTemplate();
-	}
-
-	/**
-	 * Returns true if we're currently inside an iFramed non-desktop device preview type (WP5.9+)
-	 *
-	 * @date 15/02/22
-	 * @since ACF 5.12
-	 *
-	 * @return boolean
-	 */
-	function isiFramedMobileDevicePreview() {
-		return (
-			$( 'iframe[name=editor-canvas]' ).length &&
-			! isDesktopPreviewDeviceType()
-		);
-	}
-
-	/**
-	 * Registers a block type.
-	 *
-	 * @date	19/2/19
-	 * @since	ACF 5.8.0
-	 *
-	 * @param	object blockType The block type settings localized from PHP.
-	 * @return	object The result from wp.blocks.registerBlockType().
-	 */
-	function registerBlockType( blockType ) {
-		// Bail early if is excluded post_type.
-		const allowedTypes = blockType.post_types || [];
-		if ( allowedTypes.length ) {
-			// Always allow block to appear on "Edit reusable Block" screen.
-			allowedTypes.push( 'wp_block' );
-
-			// Check post type.
-			const postType = acf.get( 'postType' );
-			if ( ! allowedTypes.includes( postType ) ) {
-				return false;
-			}
-		}
-
-		// Handle svg HTML.
-		if (
-			typeof blockType.icon === 'string' &&
-			blockType.icon.substr( 0, 4 ) === '<svg'
-		) {
-			const iconHTML = blockType.icon;
-			blockType.icon = <Div>{ iconHTML }</Div>;
-		}
-
-		// Remove icon if empty to allow for default "block".
-		// Avoids JS error preventing block from being registered.
-		if ( ! blockType.icon ) {
-			delete blockType.icon;
-		}
-
-		// Check category exists and fallback to "common".
-		const category = wp.blocks
-			.getCategories()
-			.filter( ( { slug } ) => slug === blockType.category )
-			.pop();
-		if ( ! category ) {
-			//console.warn( `The block "${blockType.name}" is registered with an unknown category "${blockType.category}".` );
-			blockType.category = 'common';
-		}
-
-		// Merge in block settings before local additions.
-		blockType = acf.parseArgs( blockType, {
-			title: '',
-			name: '',
-			category: '',
-			api_version: 2,
-			acf_block_version: 1,
-		} );
-
-		// Remove all empty attribute defaults from PHP values to allow serialisation.
-		// https://github.com/WordPress/gutenberg/issues/7342
-		for ( const key in blockType.attributes ) {
-			if (
-				'default' in blockType.attributes[ key ] &&
-				blockType.attributes[ key ].default.length === 0
-			) {
-				delete blockType.attributes[ key ].default;
-			}
-		}
-
-		// Apply anchor supports to avoid block editor default writing to ID.
-		if ( blockType.supports.anchor ) {
-			blockType.attributes.anchor = {
-				type: 'string',
-			};
-		}
-
-		// Append edit and save functions.
-		let ThisBlockEdit = BlockEdit;
-		let ThisBlockSave = BlockSave;
-
-		// Apply alignText functionality.
-		if ( blockType.supports.alignText || blockType.supports.align_text ) {
-			blockType.attributes = addBackCompatAttribute(
-				blockType.attributes,
-				'align_text',
-				'string'
-			);
-			ThisBlockEdit = withAlignTextComponent( ThisBlockEdit, blockType );
-		}
-
-		// Apply alignContent functionality.
-		if (
-			blockType.supports.alignContent ||
-			blockType.supports.align_content
-		) {
-			blockType.attributes = addBackCompatAttribute(
-				blockType.attributes,
-				'align_content',
-				'string'
-			);
-			ThisBlockEdit = withAlignContentComponent(
-				ThisBlockEdit,
-				blockType
-			);
-		}
-
-		// Apply fullHeight functionality.
-		if ( blockType.supports.fullHeight || blockType.supports.full_height ) {
-			blockType.attributes = addBackCompatAttribute(
-				blockType.attributes,
-				'full_height',
-				'boolean'
-			);
-			ThisBlockEdit = withFullHeightComponent(
-				ThisBlockEdit,
-				blockType.blockType
-			);
-		}
-
-		// Set edit and save functions.
-		blockType.edit = ( props ) => {
-			// Ensure we remove our save lock if a block is removed.
-			wp.element.useEffect( () => {
-				return () => {
-					if ( ! wp.data.dispatch( 'core/editor' ) ) return;
-					wp.data
-						.dispatch( 'core/editor' )
-						.unlockPostSaving( 'acf/block/' + props.clientId );
-				};
-			}, [] );
-
-			return <ThisBlockEdit { ...props } />;
-		};
-		blockType.save = () => <ThisBlockSave />;
-
-		// Add to storage.
-		blockTypes[ blockType.name ] = blockType;
-
-		// Register with WP.
-		const result = wp.blocks.registerBlockType( blockType.name, blockType );
-
-		// Fix bug in 'core/anchor/attribute' filter overwriting attribute.
-		// Required for < WP5.9
-		// See https://github.com/WordPress/gutenberg/issues/15240
-		if ( result.attributes.anchor ) {
-			result.attributes.anchor = {
-				type: 'string',
-			};
-		}
-
-		// Return result.
-		return result;
-	}
-
-	/**
-	 * Returns the wp.data.select() response with backwards compatibility.
-	 *
-	 * @date	17/06/2020
-	 * @since	ACF 5.9.0
-	 *
-	 * @param	string selector The selector name.
-	 * @return	mixed
-	 */
-	function select( selector ) {
-		if ( selector === 'core/block-editor' ) {
-			return (
-				wp.data.select( 'core/block-editor' ) ||
-				wp.data.select( 'core/editor' )
-			);
-		}
-		return wp.data.select( selector );
-	}
-
-	/**
-	 * Returns the wp.data.dispatch() response with backwards compatibility.
-	 *
-	 * @date	17/06/2020
-	 * @since	ACF 5.9.0
-	 *
-	 * @param	string selector The selector name.
-	 * @return	mixed
-	 */
-	function dispatch( selector ) {
-		return wp.data.dispatch( selector );
-	}
-
-	/**
-	 * Returns an array of all blocks for the given args.
-	 *
-	 * @date	27/2/19
-	 * @since	ACF 5.7.13
-	 *
-	 * @param	{object} args An object of key=>value pairs used to filter results.
-	 * @return	array.
-	 */
-	function getBlocks( args ) {
-		let blocks = [];
-
-		// Local function to recurse through all child blocks and add to the blocks array.
-		const recurseBlocks = ( block ) => {
-			blocks.push( block );
-			select( 'core/block-editor' )
-				.getBlocks( block.clientId )
-				.forEach( recurseBlocks );
-		};
-
-		// Trigger initial recursion for parent level blocks.
-		select( 'core/block-editor' ).getBlocks().forEach( recurseBlocks );
-
-		// Loop over args and filter.
-		for ( const k in args ) {
-			blocks = blocks.filter(
-				( { attributes } ) => attributes[ k ] === args[ k ]
-			);
-		}
-
-		// Return results.
-		return blocks;
-	}
-
-	/**
-	 * Storage for the AJAX queue.
-	 *
-	 * @const {array}
-	 */
-	const ajaxQueue = {};
-
-	/**
-	 * Storage for cached AJAX requests for block content.
-	 *
-	 * @since ACF 5.12
-	 * @const {array}
-	 */
-	const fetchCache = {};
-
-	/**
-	 * Fetches a JSON result from the AJAX API.
-	 *
-	 * @date	28/2/19
-	 * @since	ACF 5.7.13
-	 *
-	 * @param	object block The block props.
-	 * @query	object The query args used in AJAX callback.
-	 * @return	object The AJAX promise.
-	 */
-	function fetchBlock( args ) {
-		const {
-			attributes = {},
-			context = {},
-			query = {},
-			clientId = null,
-			delay = 0,
-		} = args;
-
-		// Build a unique queue ID from block data, including the clientId for edit forms.
-		const queueId = md5(
-			JSON.stringify( { ...attributes, ...context, ...query } )
-		);
-
-		const data = ajaxQueue[ queueId ] || {
-			query: {},
-			timeout: false,
-			promise: $.Deferred(),
-			started: false,
-		};
-
-		// Append query args to storage.
-		data.query = { ...data.query, ...query };
-
-		if ( data.started ) return data.promise;
-
-		// Set fresh timeout.
-		clearTimeout( data.timeout );
-		data.timeout = setTimeout( () => {
-			data.started = true;
-			if ( fetchCache[ queueId ] ) {
-				ajaxQueue[ queueId ] = null;
-				data.promise.resolve.apply(
-					fetchCache[ queueId ][ 0 ],
-					fetchCache[ queueId ][ 1 ]
-				);
-			} else {
-				$.ajax( {
-					url: acf.get( 'ajaxurl' ),
-					dataType: 'json',
-					type: 'post',
-					cache: false,
-					data: acf.prepareForAjax( {
-						action: 'acf/ajax/fetch-block',
-						block: JSON.stringify( attributes ),
-						clientId: clientId,
-						context: JSON.stringify( context ),
-						query: data.query,
-					} ),
-				} )
-					.always( () => {
-						// Clean up queue after AJAX request is complete.
-						ajaxQueue[ queueId ] = null;
-					} )
-					.done( function () {
-						fetchCache[ queueId ] = [ this, arguments ];
-						data.promise.resolve.apply( this, arguments );
-					} )
-					.fail( function () {
-						data.promise.reject.apply( this, arguments );
-					} );
-			}
-		}, delay );
-
-		// Update storage.
-		ajaxQueue[ queueId ] = data;
-
-		// Return promise.
-		return data.promise;
-	}
-
-	/**
-	 * Returns true if both object are the same.
-	 *
-	 * @date	19/05/2020
-	 * @since	ACF 5.9.0
-	 *
-	 * @param	object obj1
-	 * @param	object obj2
-	 * @return	bool
-	 */
-	function compareObjects( obj1, obj2 ) {
-		return JSON.stringify( obj1 ) === JSON.stringify( obj2 );
-	}
-
-	/**
-	 * Converts HTML into a React element.
-	 *
-	 * @date	19/05/2020
-	 * @since	ACF 5.9.0
-	 *
-	 * @param	string html The HTML to convert.
-	 * @param	int acfBlockVersion The ACF block version number.
-	 * @return	object Result of React.createElement().
-	 */
-	acf.parseJSX = ( html, acfBlockVersion ) => {
-		// Apply a temporary wrapper for the jQuery parse to prevent text nodes triggering errors.
-		html = '<div>' + html + '</div>';
-		// Correctly balance InnerBlocks tags for jQuery's initial parse.
-		html = html.replace(
-			/<InnerBlocks([^>]+)?\/>/,
-			'<InnerBlocks$1></InnerBlocks>'
-		);
-		return parseNode( $( html )[ 0 ], acfBlockVersion, 0 ).props.children;
-	};
-
-	/**
-	 * Converts a DOM node into a React element.
-	 *
-	 * @date	19/05/2020
-	 * @since	ACF 5.9.0
-	 *
-	 * @param	DOM node The DOM node.
-	 * @param	int acfBlockVersion The ACF block version number.
-	 * @param	int level The recursion level.
-	 * @return	object Result of React.createElement().
-	 */
-	function parseNode( node, acfBlockVersion, level = 0 ) {
-		// Get node name.
-		const nodeName = parseNodeName(
-			node.nodeName.toLowerCase(),
-			acfBlockVersion
-		);
-		if ( ! nodeName ) {
-			return null;
-		}
-
-		// Get node attributes in React friendly format.
-		const nodeAttrs = {};
-
-		if ( level === 1 && nodeName !== 'ACFInnerBlocks' ) {
-			// Top level (after stripping away the container div), create a ref for passing through to ACF's JS API.
-			nodeAttrs.ref = React.createRef();
-		}
-
-		acf.arrayArgs( node.attributes )
-			.map( parseNodeAttr )
-			.forEach( ( { name, value } ) => {
-				nodeAttrs[ name ] = value;
-			} );
-
-		if ( 'ACFInnerBlocks' === nodeName ) {
-			return <ACFInnerBlocks { ...nodeAttrs } />;
-		}
-
-		// Define args for React.createElement().
-		const args = [ nodeName, nodeAttrs ];
-		acf.arrayArgs( node.childNodes ).forEach( ( child ) => {
-			if ( child instanceof Text ) {
-				const text = child.textContent;
-				if ( text ) {
-					args.push( text );
-				}
-			} else {
-				args.push( parseNode( child, acfBlockVersion, level + 1 ) );
-			}
-		} );
-
-		// Return element.
-		return React.createElement.apply( this, args );
-	}
-
-	/**
-	 * Converts a node or attribute name into it's JSX compliant name
-	 *
-	 * @date     05/07/2021
-	 * @since    ACF 5.9.8
-	 *
-	 * @param    string name The node or attribute name.
-	 * @return  string
-	 */
-	function getJSXName( name ) {
-		const replacement = acf.isget( acf, 'jsxNameReplacements', name );
-		if ( replacement ) return replacement;
-		return name;
-	}
-
-	/**
-	 * A react Component for inline scripts.
-	 *
-	 * This Component uses a combination of React references and jQuery to append the
-	 * inline <script> HTML each time the component is rendered.
-	 *
-	 * @date	29/05/2020
-	 * @since	ACF 5.9.0
-	 *
-	 * @param	type Var Description.
-	 * @return	type Description.
-	 */
-	class Script extends Component {
-		render() {
-			return <div ref={ ( el ) => ( this.el = el ) } />;
-		}
-		setHTML( html ) {
-			$( this.el ).html( `<script>${ html }</script>` );
-		}
-		componentDidUpdate() {
-			this.setHTML( this.props.children );
-		}
-		componentDidMount() {
-			this.setHTML( this.props.children );
-		}
-	}
-
-	/**
-	 * Converts the given name into a React friendly name or component.
-	 *
-	 * @date	19/05/2020
-	 * @since	ACF 5.9.0
-	 *
-	 * @param	string name The node name in lowercase.
-	 * @param	int acfBlockVersion The ACF block version number.
-	 * @return	mixed
-	 */
-	function parseNodeName( name, acfBlockVersion ) {
-		switch ( name ) {
-			case 'innerblocks':
-				if ( acfBlockVersion < 2 ) {
-					return InnerBlocks;
-				}
-				return 'ACFInnerBlocks';
-			case 'script':
-				return Script;
-			case '#comment':
-				return null;
-			default:
-				// Replace names for JSX counterparts.
-				name = getJSXName( name );
-		}
-		return name;
-	}
-
-	/**
-	 * Functional component for ACFInnerBlocks.
-	 *
-	 * @since ACF 6.0.0
-	 *
-	 * @param obj props element properties.
-	 * @return DOM element
-	 */
-	function ACFInnerBlocks( props ) {
-		const { className = 'acf-innerblocks-container' } = props;
-		const innerBlockProps = useInnerBlocksProps(
-			{ className: className },
-			props
-		);
-
-		return <div { ...innerBlockProps }>{ innerBlockProps.children }</div>;
-	}
-
-	/**
-	 * Converts the given attribute into a React friendly name and value object.
-	 *
-	 * @date	19/05/2020
-	 * @since	ACF 5.9.0
-	 *
-	 * @param	obj nodeAttr The node attribute.
-	 * @return	obj
-	 */
-	function parseNodeAttr( nodeAttr ) {
-		let name = nodeAttr.name;
-		let value = nodeAttr.value;
-
-		// Allow overrides for third party libraries who might use specific attributes.
-		let shortcut = acf.applyFilters(
-			'acf_blocks_parse_node_attr',
-			false,
-			nodeAttr
-		);
-
-		if ( shortcut ) return shortcut;
-
-		switch ( name ) {
-			// Class.
-			case 'class':
-				name = 'className';
-				break;
-
-			// Style.
-			case 'style':
-				const css = {};
-				value.split( ';' ).forEach( ( s ) => {
-					const pos = s.indexOf( ':' );
-					if ( pos > 0 ) {
-						let ruleName = s.substr( 0, pos ).trim();
-						const ruleValue = s.substr( pos + 1 ).trim();
-
-						// Rename core properties, but not CSS variables.
-						if ( ruleName.charAt( 0 ) !== '-' ) {
-							ruleName = acf.strCamelCase( ruleName );
-						}
-						css[ ruleName ] = ruleValue;
-					}
-				} );
-				value = css;
-				break;
-
-			// Default.
-			default:
-				// No formatting needed for "data-x" attributes.
-				if ( name.indexOf( 'data-' ) === 0 ) {
-					break;
-				}
-
-				// Replace names for JSX counterparts.
-				name = getJSXName( name );
-
-				// Convert JSON values.
-				const c1 = value.charAt( 0 );
-				if ( c1 === '[' || c1 === '{' ) {
-					value = JSON.parse( value );
-				}
-
-				// Convert bool values.
-				if ( value === 'true' || value === 'false' ) {
-					value = value === 'true';
-				}
-				break;
-		}
-		return {
-			name,
-			value,
-		};
-	}
-
-	/**
-	 * Higher Order Component used to set default block attribute values.
-	 *
-	 * By modifying block attributes directly, instead of defining defaults in registerBlockType(),
-	 * WordPress will include them always within the saved block serialized JSON.
-	 *
-	 * @date	31/07/2020
-	 * @since	ACF 5.9.0
-	 *
-	 * @param	Component BlockListBlock The BlockListBlock Component.
-	 * @return	Component
-	 */
-	const withDefaultAttributes = createHigherOrderComponent(
-		( BlockListBlock ) =>
-			class WrappedBlockEdit extends Component {
-				constructor( props ) {
-					super( props );
-
-					// Extract vars.
-					const { name, attributes } = this.props;
-
-					// Only run on ACF Blocks.
-					const blockType = getBlockType( name );
-					if ( ! blockType ) {
-						return;
-					}
-
-					// Check and remove any empty string attributes to match PHP behaviour.
-					Object.keys( attributes ).forEach( ( key ) => {
-						if ( attributes[ key ] === '' ) {
-							delete attributes[ key ];
-						}
-					} );
-
-					// Backward compatibility attribute replacement.
-					const upgrades = {
-						full_height: 'fullHeight',
-						align_content: 'alignContent',
-						align_text: 'alignText',
+( () => {
+	var e = {
+			20: ( e, t, n ) => {
+				'use strict';
+				var r = n( 540 ),
+					o = Symbol.for( 'react.element' ),
+					i = Symbol.for( 'react.fragment' ),
+					a = Object.prototype.hasOwnProperty,
+					s =
+						r.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+							.ReactCurrentOwner,
+					l = { key: ! 0, ref: ! 0, __self: ! 0, __source: ! 0 };
+				function c( e, t, n ) {
+					var r,
+						i = {},
+						c = null,
+						d = null;
+					for ( r in ( void 0 !== n && ( c = '' + n ),
+					void 0 !== t.key && ( c = '' + t.key ),
+					void 0 !== t.ref && ( d = t.ref ),
+					t ) )
+						a.call( t, r ) &&
+							! l.hasOwnProperty( r ) &&
+							( i[ r ] = t[ r ] );
+					if ( e && e.defaultProps )
+						for ( r in ( t = e.defaultProps ) )
+							void 0 === i[ r ] && ( i[ r ] = t[ r ] );
+					return {
+						$$typeof: o,
+						type: e,
+						key: c,
+						ref: d,
+						props: i,
+						_owner: s.current,
 					};
-
-					Object.keys( upgrades ).forEach( ( key ) => {
-						if ( attributes[ key ] !== undefined ) {
-							attributes[ upgrades[ key ] ] = attributes[ key ];
-						} else if (
-							attributes[ upgrades[ key ] ] === undefined
-						) {
-							//Check for a default
-							if ( blockType[ key ] !== undefined ) {
-								attributes[ upgrades[ key ] ] =
-									blockType[ key ];
-							}
-						}
-						delete blockType[ key ];
-						delete attributes[ key ];
-					} );
-
-					// Set default attributes for those undefined.
-					for ( let attribute in blockType.attributes ) {
-						if (
-							attributes[ attribute ] === undefined &&
-							blockType[ attribute ] !== undefined
-						) {
-							attributes[ attribute ] = blockType[ attribute ];
-						}
-					}
 				}
-				render() {
-					return <BlockListBlock { ...this.props } />;
-				}
+				( t.Fragment = i ), ( t.jsx = c ), ( t.jsxs = c );
 			},
-		'withDefaultAttributes'
-	);
-	wp.hooks.addFilter(
-		'editor.BlockListBlock',
-		'acf/with-default-attributes',
-		withDefaultAttributes
-	);
-
-	/**
-	 * The BlockSave functional component.
-	 *
-	 * @date	08/07/2020
-	 * @since	ACF 5.9.0
-	 */
-	function BlockSave() {
-		return <InnerBlocks.Content />;
-	}
-
-	/**
-	 * The BlockEdit component.
-	 *
-	 * @date	19/2/19
-	 * @since	ACF 5.7.12
-	 */
-	class BlockEdit extends Component {
-		constructor( props ) {
-			super( props );
-			this.setup();
-		}
-
-		setup() {
-			const { name, attributes, clientId } = this.props;
-			const blockType = getBlockType( name );
-
-			// Restrict current mode.
-			function restrictMode( modes ) {
-				if ( ! modes.includes( attributes.mode ) ) {
-					attributes.mode = modes[ 0 ];
+			138: () => {
+				jQuery,
+					( acf.jsxNameReplacements = {
+						'accent-height': 'accentHeight',
+						accentheight: 'accentHeight',
+						'accept-charset': 'acceptCharset',
+						acceptcharset: 'acceptCharset',
+						accesskey: 'accessKey',
+						'alignment-baseline': 'alignmentBaseline',
+						alignmentbaseline: 'alignmentBaseline',
+						allowedblocks: 'allowedBlocks',
+						allowfullscreen: 'allowFullScreen',
+						allowreorder: 'allowReorder',
+						'arabic-form': 'arabicForm',
+						arabicform: 'arabicForm',
+						attributename: 'attributeName',
+						attributetype: 'attributeType',
+						autocapitalize: 'autoCapitalize',
+						autocomplete: 'autoComplete',
+						autocorrect: 'autoCorrect',
+						autofocus: 'autoFocus',
+						autoplay: 'autoPlay',
+						autoreverse: 'autoReverse',
+						autosave: 'autoSave',
+						basefrequency: 'baseFrequency',
+						'baseline-shift': 'baselineShift',
+						baselineshift: 'baselineShift',
+						baseprofile: 'baseProfile',
+						calcmode: 'calcMode',
+						'cap-height': 'capHeight',
+						capheight: 'capHeight',
+						cellpadding: 'cellPadding',
+						cellspacing: 'cellSpacing',
+						charset: 'charSet',
+						class: 'className',
+						classid: 'classID',
+						classname: 'className',
+						'clip-path': 'clipPath',
+						'clip-rule': 'clipRule',
+						clippath: 'clipPath',
+						clippathunits: 'clipPathUnits',
+						cliprule: 'clipRule',
+						'color-interpolation': 'colorInterpolation',
+						'color-interpolation-filters':
+							'colorInterpolationFilters',
+						'color-profile': 'colorProfile',
+						'color-rendering': 'colorRendering',
+						colorinterpolation: 'colorInterpolation',
+						colorinterpolationfilters: 'colorInterpolationFilters',
+						colorprofile: 'colorProfile',
+						colorrendering: 'colorRendering',
+						colspan: 'colSpan',
+						contenteditable: 'contentEditable',
+						contentscripttype: 'contentScriptType',
+						contentstyletype: 'contentStyleType',
+						contextmenu: 'contextMenu',
+						controlslist: 'controlsList',
+						crossorigin: 'crossOrigin',
+						dangerouslysetinnerhtml: 'dangerouslySetInnerHTML',
+						datetime: 'dateTime',
+						defaultchecked: 'defaultChecked',
+						defaultvalue: 'defaultValue',
+						diffuseconstant: 'diffuseConstant',
+						disablepictureinpicture: 'disablePictureInPicture',
+						disableremoteplayback: 'disableRemotePlayback',
+						'dominant-baseline': 'dominantBaseline',
+						dominantbaseline: 'dominantBaseline',
+						edgemode: 'edgeMode',
+						'enable-background': 'enableBackground',
+						enablebackground: 'enableBackground',
+						enctype: 'encType',
+						enterkeyhint: 'enterKeyHint',
+						externalresourcesrequired: 'externalResourcesRequired',
+						'fill-opacity': 'fillOpacity',
+						'fill-rule': 'fillRule',
+						fillopacity: 'fillOpacity',
+						fillrule: 'fillRule',
+						filterres: 'filterRes',
+						filterunits: 'filterUnits',
+						'flood-color': 'floodColor',
+						'flood-opacity': 'floodOpacity',
+						floodcolor: 'floodColor',
+						floodopacity: 'floodOpacity',
+						'font-family': 'fontFamily',
+						'font-size': 'fontSize',
+						'font-size-adjust': 'fontSizeAdjust',
+						'font-stretch': 'fontStretch',
+						'font-style': 'fontStyle',
+						'font-variant': 'fontVariant',
+						'font-weight': 'fontWeight',
+						fontfamily: 'fontFamily',
+						fontsize: 'fontSize',
+						fontsizeadjust: 'fontSizeAdjust',
+						fontstretch: 'fontStretch',
+						fontstyle: 'fontStyle',
+						fontvariant: 'fontVariant',
+						fontweight: 'fontWeight',
+						for: 'htmlFor',
+						foreignobject: 'foreignObject',
+						formaction: 'formAction',
+						formenctype: 'formEncType',
+						formmethod: 'formMethod',
+						formnovalidate: 'formNoValidate',
+						formtarget: 'formTarget',
+						frameborder: 'frameBorder',
+						'glyph-name': 'glyphName',
+						'glyph-orientation-horizontal':
+							'glyphOrientationHorizontal',
+						'glyph-orientation-vertical':
+							'glyphOrientationVertical',
+						glyphname: 'glyphName',
+						glyphorientationhorizontal:
+							'glyphOrientationHorizontal',
+						glyphorientationvertical: 'glyphOrientationVertical',
+						glyphref: 'glyphRef',
+						gradienttransform: 'gradientTransform',
+						gradientunits: 'gradientUnits',
+						'horiz-adv-x': 'horizAdvX',
+						'horiz-origin-x': 'horizOriginX',
+						horizadvx: 'horizAdvX',
+						horizoriginx: 'horizOriginX',
+						hreflang: 'hrefLang',
+						htmlfor: 'htmlFor',
+						'http-equiv': 'httpEquiv',
+						httpequiv: 'httpEquiv',
+						'image-rendering': 'imageRendering',
+						imagerendering: 'imageRendering',
+						innerhtml: 'innerHTML',
+						inputmode: 'inputMode',
+						itemid: 'itemID',
+						itemprop: 'itemProp',
+						itemref: 'itemRef',
+						itemscope: 'itemScope',
+						itemtype: 'itemType',
+						kernelmatrix: 'kernelMatrix',
+						kernelunitlength: 'kernelUnitLength',
+						keyparams: 'keyParams',
+						keypoints: 'keyPoints',
+						keysplines: 'keySplines',
+						keytimes: 'keyTimes',
+						keytype: 'keyType',
+						lengthadjust: 'lengthAdjust',
+						'letter-spacing': 'letterSpacing',
+						letterspacing: 'letterSpacing',
+						'lighting-color': 'lightingColor',
+						lightingcolor: 'lightingColor',
+						limitingconeangle: 'limitingConeAngle',
+						marginheight: 'marginHeight',
+						marginwidth: 'marginWidth',
+						'marker-end': 'markerEnd',
+						'marker-mid': 'markerMid',
+						'marker-start': 'markerStart',
+						markerend: 'markerEnd',
+						markerheight: 'markerHeight',
+						markermid: 'markerMid',
+						markerstart: 'markerStart',
+						markerunits: 'markerUnits',
+						markerwidth: 'markerWidth',
+						maskcontentunits: 'maskContentUnits',
+						maskunits: 'maskUnits',
+						maxlength: 'maxLength',
+						mediagroup: 'mediaGroup',
+						minlength: 'minLength',
+						nomodule: 'noModule',
+						novalidate: 'noValidate',
+						numoctaves: 'numOctaves',
+						'overline-position': 'overlinePosition',
+						'overline-thickness': 'overlineThickness',
+						overlineposition: 'overlinePosition',
+						overlinethickness: 'overlineThickness',
+						'paint-order': 'paintOrder',
+						paintorder: 'paintOrder',
+						'panose-1': 'panose1',
+						pathlength: 'pathLength',
+						patterncontentunits: 'patternContentUnits',
+						patterntransform: 'patternTransform',
+						patternunits: 'patternUnits',
+						playsinline: 'playsInline',
+						'pointer-events': 'pointerEvents',
+						pointerevents: 'pointerEvents',
+						pointsatx: 'pointsAtX',
+						pointsaty: 'pointsAtY',
+						pointsatz: 'pointsAtZ',
+						preservealpha: 'preserveAlpha',
+						preserveaspectratio: 'preserveAspectRatio',
+						primitiveunits: 'primitiveUnits',
+						radiogroup: 'radioGroup',
+						readonly: 'readOnly',
+						referrerpolicy: 'referrerPolicy',
+						refx: 'refX',
+						refy: 'refY',
+						'rendering-intent': 'renderingIntent',
+						renderingintent: 'renderingIntent',
+						repeatcount: 'repeatCount',
+						repeatdur: 'repeatDur',
+						requiredextensions: 'requiredExtensions',
+						requiredfeatures: 'requiredFeatures',
+						rowspan: 'rowSpan',
+						'shape-rendering': 'shapeRendering',
+						shaperendering: 'shapeRendering',
+						specularconstant: 'specularConstant',
+						specularexponent: 'specularExponent',
+						spellcheck: 'spellCheck',
+						spreadmethod: 'spreadMethod',
+						srcdoc: 'srcDoc',
+						srclang: 'srcLang',
+						srcset: 'srcSet',
+						startoffset: 'startOffset',
+						stddeviation: 'stdDeviation',
+						stitchtiles: 'stitchTiles',
+						'stop-color': 'stopColor',
+						'stop-opacity': 'stopOpacity',
+						stopcolor: 'stopColor',
+						stopopacity: 'stopOpacity',
+						'strikethrough-position': 'strikethroughPosition',
+						'strikethrough-thickness': 'strikethroughThickness',
+						strikethroughposition: 'strikethroughPosition',
+						strikethroughthickness: 'strikethroughThickness',
+						'stroke-dasharray': 'strokeDasharray',
+						'stroke-dashoffset': 'strokeDashoffset',
+						'stroke-linecap': 'strokeLinecap',
+						'stroke-linejoin': 'strokeLinejoin',
+						'stroke-miterlimit': 'strokeMiterlimit',
+						'stroke-opacity': 'strokeOpacity',
+						'stroke-width': 'strokeWidth',
+						strokedasharray: 'strokeDasharray',
+						strokedashoffset: 'strokeDashoffset',
+						strokelinecap: 'strokeLinecap',
+						strokelinejoin: 'strokeLinejoin',
+						strokemiterlimit: 'strokeMiterlimit',
+						strokeopacity: 'strokeOpacity',
+						strokewidth: 'strokeWidth',
+						suppresscontenteditablewarning:
+							'suppressContentEditableWarning',
+						suppresshydrationwarning: 'suppressHydrationWarning',
+						surfacescale: 'surfaceScale',
+						systemlanguage: 'systemLanguage',
+						tabindex: 'tabIndex',
+						tablevalues: 'tableValues',
+						targetx: 'targetX',
+						targety: 'targetY',
+						templatelock: 'templateLock',
+						'text-anchor': 'textAnchor',
+						'text-decoration': 'textDecoration',
+						'text-rendering': 'textRendering',
+						textanchor: 'textAnchor',
+						textdecoration: 'textDecoration',
+						textlength: 'textLength',
+						textrendering: 'textRendering',
+						'underline-position': 'underlinePosition',
+						'underline-thickness': 'underlineThickness',
+						underlineposition: 'underlinePosition',
+						underlinethickness: 'underlineThickness',
+						'unicode-bidi': 'unicodeBidi',
+						'unicode-range': 'unicodeRange',
+						unicodebidi: 'unicodeBidi',
+						unicoderange: 'unicodeRange',
+						'units-per-em': 'unitsPerEm',
+						unitsperem: 'unitsPerEm',
+						usemap: 'useMap',
+						'v-alphabetic': 'vAlphabetic',
+						'v-hanging': 'vHanging',
+						'v-ideographic': 'vIdeographic',
+						'v-mathematical': 'vMathematical',
+						valphabetic: 'vAlphabetic',
+						'vector-effect': 'vectorEffect',
+						vectoreffect: 'vectorEffect',
+						'vert-adv-y': 'vertAdvY',
+						'vert-origin-x': 'vertOriginX',
+						'vert-origin-y': 'vertOriginY',
+						vertadvy: 'vertAdvY',
+						vertoriginx: 'vertOriginX',
+						vertoriginy: 'vertOriginY',
+						vhanging: 'vHanging',
+						videographic: 'vIdeographic',
+						viewbox: 'viewBox',
+						viewtarget: 'viewTarget',
+						vmathematical: 'vMathematical',
+						'word-spacing': 'wordSpacing',
+						wordspacing: 'wordSpacing',
+						'writing-mode': 'writingMode',
+						writingmode: 'writingMode',
+						'x-height': 'xHeight',
+						xchannelselector: 'xChannelSelector',
+						xheight: 'xHeight',
+						'xlink:actuate': 'xlinkActuate',
+						'xlink:arcrole': 'xlinkArcrole',
+						'xlink:href': 'xlinkHref',
+						'xlink:role': 'xlinkRole',
+						'xlink:show': 'xlinkShow',
+						'xlink:title': 'xlinkTitle',
+						'xlink:type': 'xlinkType',
+						xlinkactuate: 'xlinkActuate',
+						xlinkarcrole: 'xlinkArcrole',
+						xlinkhref: 'xlinkHref',
+						xlinkrole: 'xlinkRole',
+						xlinkshow: 'xlinkShow',
+						xlinktitle: 'xlinkTitle',
+						xlinktype: 'xlinkType',
+						'xml:base': 'xmlBase',
+						'xml:lang': 'xmlLang',
+						'xml:space': 'xmlSpace',
+						xmlbase: 'xmlBase',
+						xmllang: 'xmlLang',
+						'xmlns:xlink': 'xmlnsXlink',
+						xmlnsxlink: 'xmlnsXlink',
+						xmlspace: 'xmlSpace',
+						ychannelselector: 'yChannelSelector',
+						zoomandpan: 'zoomAndPan',
+					} );
+			},
+			151: ( e ) => {
+				var t = {
+					utf8: {
+						stringToBytes: function ( e ) {
+							return t.bin.stringToBytes(
+								unescape( encodeURIComponent( e ) )
+							);
+						},
+						bytesToString: function ( e ) {
+							return decodeURIComponent(
+								escape( t.bin.bytesToString( e ) )
+							);
+						},
+					},
+					bin: {
+						stringToBytes: function ( e ) {
+							for ( var t = [], n = 0; n < e.length; n++ )
+								t.push( 255 & e.charCodeAt( n ) );
+							return t;
+						},
+						bytesToString: function ( e ) {
+							for ( var t = [], n = 0; n < e.length; n++ )
+								t.push( String.fromCharCode( e[ n ] ) );
+							return t.join( '' );
+						},
+					},
+				};
+				e.exports = t;
+			},
+			206: ( e ) => {
+				function t( e ) {
+					return (
+						!! e.constructor &&
+						'function' == typeof e.constructor.isBuffer &&
+						e.constructor.isBuffer( e )
+					);
 				}
-			}
+				e.exports = function ( e ) {
+					return (
+						null != e &&
+						( t( e ) ||
+							( function ( e ) {
+								return (
+									'function' == typeof e.readFloatLE &&
+									'function' == typeof e.slice &&
+									t( e.slice( 0, 0 ) )
+								);
+							} )( e ) ||
+							!! e._isBuffer )
+					);
+				};
+			},
+			287: ( e, t ) => {
+				'use strict';
+				var n = Symbol.for( 'react.element' ),
+					r = Symbol.for( 'react.portal' ),
+					o = Symbol.for( 'react.fragment' ),
+					i = Symbol.for( 'react.strict_mode' ),
+					a = Symbol.for( 'react.profiler' ),
+					s = Symbol.for( 'react.provider' ),
+					l = Symbol.for( 'react.context' ),
+					c = Symbol.for( 'react.forward_ref' ),
+					d = Symbol.for( 'react.suspense' ),
+					u = Symbol.for( 'react.memo' ),
+					p = Symbol.for( 'react.lazy' ),
+					f = Symbol.iterator,
+					h = {
+						isMounted: function () {
+							return ! 1;
+						},
+						enqueueForceUpdate: function () {},
+						enqueueReplaceState: function () {},
+						enqueueSetState: function () {},
+					},
+					m = Object.assign,
+					b = {};
+				function g( e, t, n ) {
+					( this.props = e ),
+						( this.context = t ),
+						( this.refs = b ),
+						( this.updater = n || h );
+				}
+				function k() {}
+				function v( e, t, n ) {
+					( this.props = e ),
+						( this.context = t ),
+						( this.refs = b ),
+						( this.updater = n || h );
+				}
+				( g.prototype.isReactComponent = {} ),
+					( g.prototype.setState = function ( e, t ) {
+						if (
+							'object' != typeof e &&
+							'function' != typeof e &&
+							null != e
+						)
+							throw Error(
+								'setState(...): takes an object of state variables to update or a function which returns an object of state variables.'
+							);
+						this.updater.enqueueSetState( this, e, t, 'setState' );
+					} ),
+					( g.prototype.forceUpdate = function ( e ) {
+						this.updater.enqueueForceUpdate(
+							this,
+							e,
+							'forceUpdate'
+						);
+					} ),
+					( k.prototype = g.prototype );
+				var y = ( v.prototype = new k() );
+				( y.constructor = v ),
+					m( y, g.prototype ),
+					( y.isPureReactComponent = ! 0 );
+				var x = Array.isArray,
+					w = Object.prototype.hasOwnProperty,
+					E = { current: null },
+					_ = { key: ! 0, ref: ! 0, __self: ! 0, __source: ! 0 };
+				function C( e, t, r ) {
+					var o,
+						i = {},
+						a = null,
+						s = null;
+					if ( null != t )
+						for ( o in ( void 0 !== t.ref && ( s = t.ref ),
+						void 0 !== t.key && ( a = '' + t.key ),
+						t ) )
+							w.call( t, o ) &&
+								! _.hasOwnProperty( o ) &&
+								( i[ o ] = t[ o ] );
+					var l = arguments.length - 2;
+					if ( 1 === l ) i.children = r;
+					else if ( 1 < l ) {
+						for ( var c = Array( l ), d = 0; d < l; d++ )
+							c[ d ] = arguments[ d + 2 ];
+						i.children = c;
+					}
+					if ( e && e.defaultProps )
+						for ( o in ( l = e.defaultProps ) )
+							void 0 === i[ o ] && ( i[ o ] = l[ o ] );
+					return {
+						$$typeof: n,
+						type: e,
+						key: a,
+						ref: s,
+						props: i,
+						_owner: E.current,
+					};
+				}
+				function j( e ) {
+					return (
+						'object' == typeof e && null !== e && e.$$typeof === n
+					);
+				}
+				var I = /\/+/g;
+				function S( e, t ) {
+					return 'object' == typeof e && null !== e && null != e.key
+						? ( function ( e ) {
+								var t = { '=': '=0', ':': '=2' };
+								return (
+									'$' +
+									e.replace( /[=:]/g, function ( e ) {
+										return t[ e ];
+									} )
+								);
+						  } )( '' + e.key )
+						: t.toString( 36 );
+				}
+				function A( e, t, o, i, a ) {
+					var s = typeof e;
+					( 'undefined' !== s && 'boolean' !== s ) || ( e = null );
+					var l = ! 1;
+					if ( null === e ) l = ! 0;
+					else
+						switch ( s ) {
+							case 'string':
+							case 'number':
+								l = ! 0;
+								break;
+							case 'object':
+								switch ( e.$$typeof ) {
+									case n:
+									case r:
+										l = ! 0;
+								}
+						}
+					if ( l )
+						return (
+							( a = a( ( l = e ) ) ),
+							( e = '' === i ? '.' + S( l, 0 ) : i ),
+							x( a )
+								? ( ( o = '' ),
+								  null != e &&
+										( o = e.replace( I, '$&/' ) + '/' ),
+								  A( a, t, o, '', function ( e ) {
+										return e;
+								  } ) )
+								: null != a &&
+								  ( j( a ) &&
+										( a = ( function ( e, t ) {
+											return {
+												$$typeof: n,
+												type: e.type,
+												key: t,
+												ref: e.ref,
+												props: e.props,
+												_owner: e._owner,
+											};
+										} )(
+											a,
+											o +
+												( ! a.key ||
+												( l && l.key === a.key )
+													? ''
+													: ( '' + a.key ).replace(
+															I,
+															'$&/'
+													  ) + '/' ) +
+												e
+										) ),
+								  t.push( a ) ),
+							1
+						);
+					if (
+						( ( l = 0 ), ( i = '' === i ? '.' : i + ':' ), x( e ) )
+					)
+						for ( var c = 0; c < e.length; c++ ) {
+							var d = i + S( ( s = e[ c ] ), c );
+							l += A( s, t, o, d, a );
+						}
+					else if (
+						( ( d = ( function ( e ) {
+							return null === e || 'object' != typeof e
+								? null
+								: 'function' ==
+								  typeof ( e =
+										( f && e[ f ] ) || e[ '@@iterator' ] )
+								? e
+								: null;
+						} )( e ) ),
+						'function' == typeof d )
+					)
+						for (
+							e = d.call( e ), c = 0;
+							! ( s = e.next() ).done;
 
-			if ( isBlockInQueryLoop( clientId ) || isSiteEditor() ) {
-				restrictMode( [ 'preview' ] );
-			} else {
-				switch ( blockType.mode ) {
-					case 'edit':
-						restrictMode( [ 'edit', 'preview' ] );
+						)
+							l += A(
+								( s = s.value ),
+								t,
+								o,
+								( d = i + S( s, c++ ) ),
+								a
+							);
+					else if ( 'object' === s )
+						throw (
+							( ( t = String( e ) ),
+							Error(
+								'Objects are not valid as a React child (found: ' +
+									( '[object Object]' === t
+										? 'object with keys {' +
+										  Object.keys( e ).join( ', ' ) +
+										  '}'
+										: t ) +
+									'). If you meant to render a collection of children, use an array instead.'
+							) )
+						);
+					return l;
+				}
+				function T( e, t, n ) {
+					if ( null == e ) return e;
+					var r = [],
+						o = 0;
+					return (
+						A( e, r, '', '', function ( e ) {
+							return t.call( n, e, o++ );
+						} ),
+						r
+					);
+				}
+				function B( e ) {
+					if ( -1 === e._status ) {
+						var t = e._result;
+						( t = t() ).then(
+							function ( t ) {
+								( 0 !== e._status && -1 !== e._status ) ||
+									( ( e._status = 1 ), ( e._result = t ) );
+							},
+							function ( t ) {
+								( 0 !== e._status && -1 !== e._status ) ||
+									( ( e._status = 2 ), ( e._result = t ) );
+							}
+						),
+							-1 === e._status &&
+								( ( e._status = 0 ), ( e._result = t ) );
+					}
+					if ( 1 === e._status ) return e._result.default;
+					throw e._result;
+				}
+				var F = { current: null },
+					O = { transition: null },
+					N = {
+						ReactCurrentDispatcher: F,
+						ReactCurrentBatchConfig: O,
+						ReactCurrentOwner: E,
+					};
+				function R() {
+					throw Error(
+						'act(...) is not supported in production builds of React.'
+					);
+				}
+				( t.Children = {
+					map: T,
+					forEach: function ( e, t, n ) {
+						T(
+							e,
+							function () {
+								t.apply( this, arguments );
+							},
+							n
+						);
+					},
+					count: function ( e ) {
+						var t = 0;
+						return (
+							T( e, function () {
+								t++;
+							} ),
+							t
+						);
+					},
+					toArray: function ( e ) {
+						return (
+							T( e, function ( e ) {
+								return e;
+							} ) || []
+						);
+					},
+					only: function ( e ) {
+						if ( ! j( e ) )
+							throw Error(
+								'React.Children.only expected to receive a single React element child.'
+							);
+						return e;
+					},
+				} ),
+					( t.Component = g ),
+					( t.Fragment = o ),
+					( t.Profiler = a ),
+					( t.PureComponent = v ),
+					( t.StrictMode = i ),
+					( t.Suspense = d ),
+					( t.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED =
+						N ),
+					( t.act = R ),
+					( t.cloneElement = function ( e, t, r ) {
+						if ( null == e )
+							throw Error(
+								'React.cloneElement(...): The argument must be a React element, but you passed ' +
+									e +
+									'.'
+							);
+						var o = m( {}, e.props ),
+							i = e.key,
+							a = e.ref,
+							s = e._owner;
+						if ( null != t ) {
+							if (
+								( void 0 !== t.ref &&
+									( ( a = t.ref ), ( s = E.current ) ),
+								void 0 !== t.key && ( i = '' + t.key ),
+								e.type && e.type.defaultProps )
+							)
+								var l = e.type.defaultProps;
+							for ( c in t )
+								w.call( t, c ) &&
+									! _.hasOwnProperty( c ) &&
+									( o[ c ] =
+										void 0 === t[ c ] && void 0 !== l
+											? l[ c ]
+											: t[ c ] );
+						}
+						var c = arguments.length - 2;
+						if ( 1 === c ) o.children = r;
+						else if ( 1 < c ) {
+							l = Array( c );
+							for ( var d = 0; d < c; d++ )
+								l[ d ] = arguments[ d + 2 ];
+							o.children = l;
+						}
+						return {
+							$$typeof: n,
+							type: e.type,
+							key: i,
+							ref: a,
+							props: o,
+							_owner: s,
+						};
+					} ),
+					( t.createContext = function ( e ) {
+						return (
+							( ( e = {
+								$$typeof: l,
+								_currentValue: e,
+								_currentValue2: e,
+								_threadCount: 0,
+								Provider: null,
+								Consumer: null,
+								_defaultValue: null,
+								_globalName: null,
+							} ).Provider = { $$typeof: s, _context: e } ),
+							( e.Consumer = e )
+						);
+					} ),
+					( t.createElement = C ),
+					( t.createFactory = function ( e ) {
+						var t = C.bind( null, e );
+						return ( t.type = e ), t;
+					} ),
+					( t.createRef = function () {
+						return { current: null };
+					} ),
+					( t.forwardRef = function ( e ) {
+						return { $$typeof: c, render: e };
+					} ),
+					( t.isValidElement = j ),
+					( t.lazy = function ( e ) {
+						return {
+							$$typeof: p,
+							_payload: { _status: -1, _result: e },
+							_init: B,
+						};
+					} ),
+					( t.memo = function ( e, t ) {
+						return {
+							$$typeof: u,
+							type: e,
+							compare: void 0 === t ? null : t,
+						};
+					} ),
+					( t.startTransition = function ( e ) {
+						var t = O.transition;
+						O.transition = {};
+						try {
+							e();
+						} finally {
+							O.transition = t;
+						}
+					} ),
+					( t.unstable_act = R ),
+					( t.useCallback = function ( e, t ) {
+						return F.current.useCallback( e, t );
+					} ),
+					( t.useContext = function ( e ) {
+						return F.current.useContext( e );
+					} ),
+					( t.useDebugValue = function () {} ),
+					( t.useDeferredValue = function ( e ) {
+						return F.current.useDeferredValue( e );
+					} ),
+					( t.useEffect = function ( e, t ) {
+						return F.current.useEffect( e, t );
+					} ),
+					( t.useId = function () {
+						return F.current.useId();
+					} ),
+					( t.useImperativeHandle = function ( e, t, n ) {
+						return F.current.useImperativeHandle( e, t, n );
+					} ),
+					( t.useInsertionEffect = function ( e, t ) {
+						return F.current.useInsertionEffect( e, t );
+					} ),
+					( t.useLayoutEffect = function ( e, t ) {
+						return F.current.useLayoutEffect( e, t );
+					} ),
+					( t.useMemo = function ( e, t ) {
+						return F.current.useMemo( e, t );
+					} ),
+					( t.useReducer = function ( e, t, n ) {
+						return F.current.useReducer( e, t, n );
+					} ),
+					( t.useRef = function ( e ) {
+						return F.current.useRef( e );
+					} ),
+					( t.useState = function ( e ) {
+						return F.current.useState( e );
+					} ),
+					( t.useSyncExternalStore = function ( e, t, n ) {
+						return F.current.useSyncExternalStore( e, t, n );
+					} ),
+					( t.useTransition = function () {
+						return F.current.useTransition();
+					} ),
+					( t.version = '18.3.1' );
+			},
+			503: ( e, t, n ) => {
+				var r, o, i, a, s;
+				( r = n( 939 ) ),
+					( o = n( 151 ).utf8 ),
+					( i = n( 206 ) ),
+					( a = n( 151 ).bin ),
+					( ( s = function ( e, t ) {
+						e.constructor == String
+							? ( e =
+									t && 'binary' === t.encoding
+										? a.stringToBytes( e )
+										: o.stringToBytes( e ) )
+							: i( e )
+							? ( e = Array.prototype.slice.call( e, 0 ) )
+							: Array.isArray( e ) ||
+							  e.constructor === Uint8Array ||
+							  ( e = e.toString() );
+						for (
+							var n = r.bytesToWords( e ),
+								l = 8 * e.length,
+								c = 1732584193,
+								d = -271733879,
+								u = -1732584194,
+								p = 271733878,
+								f = 0;
+							f < n.length;
+							f++
+						)
+							n[ f ] =
+								( 16711935 &
+									( ( n[ f ] << 8 ) | ( n[ f ] >>> 24 ) ) ) |
+								( 4278255360 &
+									( ( n[ f ] << 24 ) | ( n[ f ] >>> 8 ) ) );
+						( n[ l >>> 5 ] |= 128 << l % 32 ),
+							( n[ 14 + ( ( ( l + 64 ) >>> 9 ) << 4 ) ] = l );
+						var h = s._ff,
+							m = s._gg,
+							b = s._hh,
+							g = s._ii;
+						for ( f = 0; f < n.length; f += 16 ) {
+							var k = c,
+								v = d,
+								y = u,
+								x = p;
+							( c = h( c, d, u, p, n[ f + 0 ], 7, -680876936 ) ),
+								( p = h(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 1 ],
+									12,
+									-389564586
+								) ),
+								( u = h(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 2 ],
+									17,
+									606105819
+								) ),
+								( d = h(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 3 ],
+									22,
+									-1044525330
+								) ),
+								( c = h(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 4 ],
+									7,
+									-176418897
+								) ),
+								( p = h(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 5 ],
+									12,
+									1200080426
+								) ),
+								( u = h(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 6 ],
+									17,
+									-1473231341
+								) ),
+								( d = h(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 7 ],
+									22,
+									-45705983
+								) ),
+								( c = h(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 8 ],
+									7,
+									1770035416
+								) ),
+								( p = h(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 9 ],
+									12,
+									-1958414417
+								) ),
+								( u = h(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 10 ],
+									17,
+									-42063
+								) ),
+								( d = h(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 11 ],
+									22,
+									-1990404162
+								) ),
+								( c = h(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 12 ],
+									7,
+									1804603682
+								) ),
+								( p = h(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 13 ],
+									12,
+									-40341101
+								) ),
+								( u = h(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 14 ],
+									17,
+									-1502002290
+								) ),
+								( c = m(
+									c,
+									( d = h(
+										d,
+										u,
+										p,
+										c,
+										n[ f + 15 ],
+										22,
+										1236535329
+									) ),
+									u,
+									p,
+									n[ f + 1 ],
+									5,
+									-165796510
+								) ),
+								( p = m(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 6 ],
+									9,
+									-1069501632
+								) ),
+								( u = m(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 11 ],
+									14,
+									643717713
+								) ),
+								( d = m(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 0 ],
+									20,
+									-373897302
+								) ),
+								( c = m(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 5 ],
+									5,
+									-701558691
+								) ),
+								( p = m(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 10 ],
+									9,
+									38016083
+								) ),
+								( u = m(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 15 ],
+									14,
+									-660478335
+								) ),
+								( d = m(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 4 ],
+									20,
+									-405537848
+								) ),
+								( c = m(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 9 ],
+									5,
+									568446438
+								) ),
+								( p = m(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 14 ],
+									9,
+									-1019803690
+								) ),
+								( u = m(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 3 ],
+									14,
+									-187363961
+								) ),
+								( d = m(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 8 ],
+									20,
+									1163531501
+								) ),
+								( c = m(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 13 ],
+									5,
+									-1444681467
+								) ),
+								( p = m(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 2 ],
+									9,
+									-51403784
+								) ),
+								( u = m(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 7 ],
+									14,
+									1735328473
+								) ),
+								( c = b(
+									c,
+									( d = m(
+										d,
+										u,
+										p,
+										c,
+										n[ f + 12 ],
+										20,
+										-1926607734
+									) ),
+									u,
+									p,
+									n[ f + 5 ],
+									4,
+									-378558
+								) ),
+								( p = b(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 8 ],
+									11,
+									-2022574463
+								) ),
+								( u = b(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 11 ],
+									16,
+									1839030562
+								) ),
+								( d = b(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 14 ],
+									23,
+									-35309556
+								) ),
+								( c = b(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 1 ],
+									4,
+									-1530992060
+								) ),
+								( p = b(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 4 ],
+									11,
+									1272893353
+								) ),
+								( u = b(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 7 ],
+									16,
+									-155497632
+								) ),
+								( d = b(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 10 ],
+									23,
+									-1094730640
+								) ),
+								( c = b(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 13 ],
+									4,
+									681279174
+								) ),
+								( p = b(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 0 ],
+									11,
+									-358537222
+								) ),
+								( u = b(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 3 ],
+									16,
+									-722521979
+								) ),
+								( d = b(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 6 ],
+									23,
+									76029189
+								) ),
+								( c = b(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 9 ],
+									4,
+									-640364487
+								) ),
+								( p = b(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 12 ],
+									11,
+									-421815835
+								) ),
+								( u = b(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 15 ],
+									16,
+									530742520
+								) ),
+								( c = g(
+									c,
+									( d = b(
+										d,
+										u,
+										p,
+										c,
+										n[ f + 2 ],
+										23,
+										-995338651
+									) ),
+									u,
+									p,
+									n[ f + 0 ],
+									6,
+									-198630844
+								) ),
+								( p = g(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 7 ],
+									10,
+									1126891415
+								) ),
+								( u = g(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 14 ],
+									15,
+									-1416354905
+								) ),
+								( d = g(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 5 ],
+									21,
+									-57434055
+								) ),
+								( c = g(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 12 ],
+									6,
+									1700485571
+								) ),
+								( p = g(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 3 ],
+									10,
+									-1894986606
+								) ),
+								( u = g(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 10 ],
+									15,
+									-1051523
+								) ),
+								( d = g(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 1 ],
+									21,
+									-2054922799
+								) ),
+								( c = g(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 8 ],
+									6,
+									1873313359
+								) ),
+								( p = g(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 15 ],
+									10,
+									-30611744
+								) ),
+								( u = g(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 6 ],
+									15,
+									-1560198380
+								) ),
+								( d = g(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 13 ],
+									21,
+									1309151649
+								) ),
+								( c = g(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 4 ],
+									6,
+									-145523070
+								) ),
+								( p = g(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 11 ],
+									10,
+									-1120210379
+								) ),
+								( u = g(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 2 ],
+									15,
+									718787259
+								) ),
+								( d = g(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 9 ],
+									21,
+									-343485551
+								) ),
+								( c = ( c + k ) >>> 0 ),
+								( d = ( d + v ) >>> 0 ),
+								( u = ( u + y ) >>> 0 ),
+								( p = ( p + x ) >>> 0 );
+						}
+						return r.endian( [ c, d, u, p ] );
+					} )._ff = function ( e, t, n, r, o, i, a ) {
+						var s =
+							e + ( ( t & n ) | ( ~t & r ) ) + ( o >>> 0 ) + a;
+						return ( ( s << i ) | ( s >>> ( 32 - i ) ) ) + t;
+					} ),
+					( s._gg = function ( e, t, n, r, o, i, a ) {
+						var s =
+							e + ( ( t & r ) | ( n & ~r ) ) + ( o >>> 0 ) + a;
+						return ( ( s << i ) | ( s >>> ( 32 - i ) ) ) + t;
+					} ),
+					( s._hh = function ( e, t, n, r, o, i, a ) {
+						var s = e + ( t ^ n ^ r ) + ( o >>> 0 ) + a;
+						return ( ( s << i ) | ( s >>> ( 32 - i ) ) ) + t;
+					} ),
+					( s._ii = function ( e, t, n, r, o, i, a ) {
+						var s = e + ( n ^ ( t | ~r ) ) + ( o >>> 0 ) + a;
+						return ( ( s << i ) | ( s >>> ( 32 - i ) ) ) + t;
+					} ),
+					( s._blocksize = 16 ),
+					( s._digestsize = 16 ),
+					( e.exports = function ( e, t ) {
+						if ( null == e )
+							throw new Error( 'Illegal argument ' + e );
+						var n = r.wordsToBytes( s( e, t ) );
+						return t && t.asBytes
+							? n
+							: t && t.asString
+							? a.bytesToString( n )
+							: r.bytesToHex( n );
+					} );
+			},
+			540: ( e, t, n ) => {
+				'use strict';
+				e.exports = n( 287 );
+			},
+			848: ( e, t, n ) => {
+				'use strict';
+				e.exports = n( 20 );
+			},
+			939: ( e ) => {
+				var t, n;
+				( t =
+					'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/' ),
+					( n = {
+						rotl: function ( e, t ) {
+							return ( e << t ) | ( e >>> ( 32 - t ) );
+						},
+						rotr: function ( e, t ) {
+							return ( e << ( 32 - t ) ) | ( e >>> t );
+						},
+						endian: function ( e ) {
+							if ( e.constructor == Number )
+								return (
+									( 16711935 & n.rotl( e, 8 ) ) |
+									( 4278255360 & n.rotl( e, 24 ) )
+								);
+							for ( var t = 0; t < e.length; t++ )
+								e[ t ] = n.endian( e[ t ] );
+							return e;
+						},
+						randomBytes: function ( e ) {
+							for ( var t = []; e > 0; e-- )
+								t.push( Math.floor( 256 * Math.random() ) );
+							return t;
+						},
+						bytesToWords: function ( e ) {
+							for (
+								var t = [], n = 0, r = 0;
+								n < e.length;
+								n++, r += 8
+							)
+								t[ r >>> 5 ] |= e[ n ] << ( 24 - ( r % 32 ) );
+							return t;
+						},
+						wordsToBytes: function ( e ) {
+							for ( var t = [], n = 0; n < 32 * e.length; n += 8 )
+								t.push(
+									( e[ n >>> 5 ] >>> ( 24 - ( n % 32 ) ) ) &
+										255
+								);
+							return t;
+						},
+						bytesToHex: function ( e ) {
+							for ( var t = [], n = 0; n < e.length; n++ )
+								t.push( ( e[ n ] >>> 4 ).toString( 16 ) ),
+									t.push( ( 15 & e[ n ] ).toString( 16 ) );
+							return t.join( '' );
+						},
+						hexToBytes: function ( e ) {
+							for ( var t = [], n = 0; n < e.length; n += 2 )
+								t.push( parseInt( e.substr( n, 2 ), 16 ) );
+							return t;
+						},
+						bytesToBase64: function ( e ) {
+							for ( var n = [], r = 0; r < e.length; r += 3 )
+								for (
+									var o =
+											( e[ r ] << 16 ) |
+											( e[ r + 1 ] << 8 ) |
+											e[ r + 2 ],
+										i = 0;
+									i < 4;
+									i++
+								)
+									8 * r + 6 * i <= 8 * e.length
+										? n.push(
+												t.charAt(
+													( o >>>
+														( 6 * ( 3 - i ) ) ) &
+														63
+												)
+										  )
+										: n.push( '=' );
+							return n.join( '' );
+						},
+						base64ToBytes: function ( e ) {
+							e = e.replace( /[^A-Z0-9+\/]/gi, '' );
+							for (
+								var n = [], r = 0, o = 0;
+								r < e.length;
+								o = ++r % 4
+							)
+								0 != o &&
+									n.push(
+										( ( t.indexOf( e.charAt( r - 1 ) ) &
+											( Math.pow( 2, -2 * o + 8 ) -
+												1 ) ) <<
+											( 2 * o ) ) |
+											( t.indexOf( e.charAt( r ) ) >>>
+												( 6 - 2 * o ) )
+									);
+							return n;
+						},
+					} ),
+					( e.exports = n );
+			},
+		},
+		t = {};
+	function n( r ) {
+		var o = t[ r ];
+		if ( void 0 !== o ) return o.exports;
+		var i = ( t[ r ] = { exports: {} } );
+		return e[ r ]( i, i.exports, n ), i.exports;
+	}
+	( () => {
+		'use strict';
+		n( 138 );
+		var e = n( 848 );
+		const t = n( 503 );
+		( ( n, r ) => {
+			const {
+					BlockControls: o,
+					InspectorControls: i,
+					InnerBlocks: a,
+					useBlockProps: s,
+					AlignmentToolbar: l,
+					BlockVerticalAlignmentToolbar: c,
+				} = wp.blockEditor,
+				{
+					ToolbarGroup: d,
+					ToolbarButton: u,
+					Placeholder: p,
+					Spinner: f,
+				} = wp.components,
+				{ Fragment: h } = wp.element,
+				{ Component: m } = React,
+				{ useSelect: b } = wp.data,
+				{ createHigherOrderComponent: g } = wp.compose,
+				k =
+					wp.blockEditor.__experimentalBlockAlignmentMatrixToolbar ||
+					wp.blockEditor.BlockAlignmentMatrixToolbar,
+				v =
+					wp.blockEditor.__experimentalBlockAlignmentMatrixControl ||
+					wp.blockEditor.BlockAlignmentMatrixControl,
+				y =
+					wp.blockEditor
+						.__experimentalBlockFullHeightAligmentControl ||
+					wp.blockEditor
+						.__experimentalBlockFullHeightAlignmentControl ||
+					wp.blockEditor.BlockFullHeightAlignmentControl,
+				x =
+					wp.blockEditor.__experimentalUseInnerBlocksProps ||
+					wp.blockEditor.useInnerBlocksProps,
+				w = {};
+			function E( e ) {
+				return w[ e ] || ! 1;
+			}
+			function _( e ) {
+				return E( e ).acf_block_version || 1;
+			}
+			function C( e ) {
+				return E( e ).validate;
+			}
+			function j( e ) {
+				const t = wp.data
+					.select( 'core/block-editor' )
+					.getBlockParents( e );
+				return wp.data
+					.select( 'core/block-editor' )
+					.getBlocksByClientId( t )
+					.filter( ( e ) => 'core/query' === e.name ).length;
+			}
+			function I() {
+				return (
+					document.querySelectorAll( 'iframe[name="editor-canvas"]' )
+						.length > 0
+				);
+			}
+			function S( t ) {
+				const n = t.post_types || [];
+				if ( n.length ) {
+					n.push( 'wp_block' );
+					const e = acf.get( 'postType' );
+					if ( ! n.includes( e ) ) return ! 1;
+				}
+				if (
+					'string' == typeof t.icon &&
+					'<svg' === t.icon.substr( 0, 4 )
+				) {
+					const n = t.icon;
+					t.icon = ( 0, e.jsx )( $, { children: n } );
+				}
+				t.icon || delete t.icon,
+					wp.blocks
+						.getCategories()
+						.filter( ( { slug: e } ) => e === t.category )
+						.pop() || ( t.category = 'common' ),
+					( t = acf.parseArgs( t, {
+						title: '',
+						name: '',
+						category: '',
+						api_version: 2,
+						acf_block_version: 1,
+					} ) );
+				for ( const e in t.attributes )
+					'default' in t.attributes[ e ] &&
+						0 === t.attributes[ e ].default.length &&
+						delete t.attributes[ e ].default;
+				t.supports.anchor &&
+					( t.attributes.anchor = { type: 'string' } );
+				let i = L,
+					a = H;
+				var s;
+				( t.supports.alignText || t.supports.align_text ) &&
+					( ( t.attributes = Y(
+						t.attributes,
+						'align_text',
+						'string'
+					) ),
+					( i = ( function ( t, n ) {
+						const r = J;
+						return (
+							( n.alignText = r( n.alignText ) ),
+							class extends m {
+								render() {
+									const { attributes: n, setAttributes: i } =
+											this.props,
+										{ alignText: a } = n;
+									return ( 0, e.jsxs )( h, {
+										children: [
+											( 0, e.jsx )( o, {
+												group: 'block',
+												children: ( 0, e.jsx )( l, {
+													value: r( a ),
+													onChange: function ( e ) {
+														i( {
+															alignText: r( e ),
+														} );
+													},
+												} ),
+											} ),
+											( 0, e.jsx )( t, {
+												...this.props,
+											} ),
+										],
+									} );
+								}
+							}
+						);
+					} )( i, t ) ) ),
+					( t.supports.alignContent || t.supports.align_content ) &&
+						( ( t.attributes = Y(
+							t.attributes,
+							'align_content',
+							'string'
+						) ),
+						( i = ( function ( t, n ) {
+							let i,
+								a,
+								s =
+									n.supports.align_content ||
+									n.supports.alignContent;
+							return (
+								'matrix' === s
+									? ( ( i = v || k ), ( a = X ) )
+									: ( ( i = c ), ( a = W ) ),
+								i === r
+									? ( console.warn(
+											`The "${ s }" alignment component was not found.`
+									  ),
+									  t )
+									: ( ( n.alignContent = a(
+											n.alignContent
+									  ) ),
+									  class extends m {
+											render() {
+												const {
+														attributes: n,
+														setAttributes: r,
+													} = this.props,
+													{ alignContent: s } = n;
+												return ( 0, e.jsxs )( h, {
+													children: [
+														( 0, e.jsx )( o, {
+															group: 'block',
+															children: ( 0,
+															e.jsx )( i, {
+																label: acf.__(
+																	'Change content alignment'
+																),
+																value: a( s ),
+																onChange:
+																	function (
+																		e
+																	) {
+																		r( {
+																			alignContent:
+																				a(
+																					e
+																				),
+																		} );
+																	},
+															} ),
+														} ),
+														( 0, e.jsx )( t, {
+															...this.props,
+														} ),
+													],
+												} );
+											}
+									  } )
+							);
+						} )( i, t ) ) ),
+					( t.supports.fullHeight || t.supports.full_height ) &&
+						( ( t.attributes = Y(
+							t.attributes,
+							'full_height',
+							'boolean'
+						) ),
+						( s = i ),
+						t.blockType,
+						( i = y
+							? class extends m {
+									render() {
+										const {
+												attributes: t,
+												setAttributes: n,
+											} = this.props,
+											{ fullHeight: r } = t;
+										return ( 0, e.jsxs )( h, {
+											children: [
+												( 0, e.jsx )( o, {
+													group: 'block',
+													children: ( 0, e.jsx )( y, {
+														isActive: r,
+														onToggle: function (
+															e
+														) {
+															n( {
+																fullHeight: e,
+															} );
+														},
+													} ),
+												} ),
+												( 0, e.jsx )( s, {
+													...this.props,
+												} ),
+											],
+										} );
+									}
+							  }
+							: s ) ),
+					( t.edit = ( t ) => (
+						wp.element.useEffect(
+							() => () => {
+								wp.data.dispatch( 'core/editor' ) &&
+									wp.data
+										.dispatch( 'core/editor' )
+										.unlockPostSaving(
+											'acf/block/' + t.clientId
+										);
+							},
+							[]
+						),
+						( 0, e.jsx )( i, { ...t } )
+					) ),
+					( t.save = () => ( 0, e.jsx )( a, {} ) ),
+					( w[ t.name ] = t );
+				const d = wp.blocks.registerBlockType( t.name, t );
+				return (
+					d.attributes.anchor &&
+						( d.attributes.anchor = { type: 'string' } ),
+					d
+				);
+			}
+			acf.blockInstances = {};
+			const A = {},
+				T = {};
+			function B( e ) {
+				const {
+						attributes: r = {},
+						context: o = {},
+						query: i = {},
+						clientId: a = null,
+						delay: s = 0,
+					} = e,
+					l = t( JSON.stringify( { ...r, ...o, ...i } ) ),
+					c = A[ l ] || {
+						query: {},
+						timeout: ! 1,
+						promise: n.Deferred(),
+						started: ! 1,
+					};
+				return (
+					( c.query = { ...c.query, ...i } ),
+					c.started ||
+						( clearTimeout( c.timeout ),
+						( c.timeout = setTimeout( () => {
+							( c.started = ! 0 ),
+								T[ l ]
+									? ( ( A[ l ] = null ),
+									  c.promise.resolve.apply(
+											T[ l ][ 0 ],
+											T[ l ][ 1 ]
+									  ) )
+									: n
+											.ajax( {
+												url: acf.get( 'ajaxurl' ),
+												dataType: 'json',
+												type: 'post',
+												cache: ! 1,
+												data: acf.prepareForAjax( {
+													action: 'acf/ajax/fetch-block',
+													block: JSON.stringify( r ),
+													clientId: a,
+													context:
+														JSON.stringify( o ),
+													query: c.query,
+												} ),
+											} )
+											.always( () => {
+												A[ l ] = null;
+											} )
+											.done( function () {
+												( T[ l ] = [
+													this,
+													arguments,
+												] ),
+													c.promise.resolve.apply(
+														this,
+														arguments
+													);
+											} )
+											.fail( function () {
+												c.promise.reject.apply(
+													this,
+													arguments
+												);
+											} );
+						}, s ) ),
+						( A[ l ] = c ) ),
+					c.promise
+				);
+			}
+			function F( e, t ) {
+				return JSON.stringify( e ) === JSON.stringify( t );
+			}
+			function O( t, n, r = 0 ) {
+				const o = ( function ( e, t ) {
+					switch ( e ) {
+						case 'innerblocks':
+							return t < 2 ? a : 'ACFInnerBlocks';
+						case 'script':
+							return q;
+						case '#comment':
+							return null;
+						default:
+							e = N( e );
+					}
+					return e;
+				} )( t.nodeName.toLowerCase(), n );
+				if ( ! o ) return null;
+				const i = {};
+				if (
+					( 1 === r &&
+						'ACFInnerBlocks' !== o &&
+						( i.ref = React.createRef() ),
+					acf
+						.arrayArgs( t.attributes )
+						.map( P )
+						.forEach( ( { name: e, value: t } ) => {
+							i[ e ] = t;
+						} ),
+					'ACFInnerBlocks' === o )
+				)
+					return ( 0, e.jsx )( R, { ...i } );
+				const s = [ o, i ];
+				return (
+					acf.arrayArgs( t.childNodes ).forEach( ( e ) => {
+						if ( e instanceof Text ) {
+							const t = e.textContent;
+							t && s.push( t );
+						} else s.push( O( e, n, r + 1 ) );
+					} ),
+					React.createElement.apply( this, s )
+				);
+			}
+			function N( e ) {
+				return acf.isget( acf, 'jsxNameReplacements', e ) || e;
+			}
+			function R( t ) {
+				const { className: n = 'acf-innerblocks-container' } = t,
+					r = x( { className: n }, t );
+				return ( 0, e.jsx )( 'div', { ...r, children: r.children } );
+			}
+			function P( e ) {
+				let t = e.name,
+					n = e.value,
+					r = acf.applyFilters(
+						'acf_blocks_parse_node_attr',
+						! 1,
+						e
+					);
+				if ( r ) return r;
+				switch ( t ) {
+					case 'class':
+						t = 'className';
 						break;
-					case 'preview':
-						restrictMode( [ 'preview', 'edit' ] );
+					case 'style':
+						const e = {};
+						n.split( ';' ).forEach( ( t ) => {
+							const n = t.indexOf( ':' );
+							if ( n > 0 ) {
+								let r = t.substr( 0, n ).trim();
+								const o = t.substr( n + 1 ).trim();
+								'-' !== r.charAt( 0 ) &&
+									( r = acf.strCamelCase( r ) ),
+									( e[ r ] = o );
+							}
+						} ),
+							( n = e );
 						break;
 					default:
-						restrictMode( [ 'auto' ] );
-						break;
+						if ( 0 === t.indexOf( 'data-' ) ) break;
+						t = N( t );
+						const r = n.charAt( 0 );
+						( '[' !== r && '{' !== r ) || ( n = JSON.parse( n ) ),
+							( 'true' !== n && 'false' !== n ) ||
+								( n = 'true' === n );
+				}
+				return { name: t, value: n };
+			}
+			acf.parseJSX = ( e, t ) => (
+				( e = ( e = '<div>' + e + '</div>' ).replace(
+					/<InnerBlocks([^>]+)?\/>/,
+					'<InnerBlocks$1></InnerBlocks>'
+				) ),
+				O( n( e )[ 0 ], t, 0 ).props.children
+			);
+			const M = g(
+				( t ) =>
+					class extends m {
+						constructor( e ) {
+							super( e );
+							const { name: t, attributes: n } = this.props,
+								o = E( t );
+							if ( ! o ) return;
+							Object.keys( n ).forEach( ( e ) => {
+								'' === n[ e ] && delete n[ e ];
+							} );
+							const i = {
+								full_height: 'fullHeight',
+								align_content: 'alignContent',
+								align_text: 'alignText',
+							};
+							Object.keys( i ).forEach( ( e ) => {
+								n[ e ] !== r
+									? ( n[ i[ e ] ] = n[ e ] )
+									: n[ i[ e ] ] === r &&
+									  o[ e ] !== r &&
+									  ( n[ i[ e ] ] = o[ e ] ),
+									delete o[ e ],
+									delete n[ e ];
+							} );
+							for ( let e in o.attributes )
+								n[ e ] === r &&
+									o[ e ] !== r &&
+									( n[ e ] = o[ e ] );
+						}
+						render() {
+							return ( 0, e.jsx )( t, { ...this.props } );
+						}
+					},
+				'withDefaultAttributes'
+			);
+			function H() {
+				return ( 0, e.jsx )( a.Content, {} );
+			}
+			wp.hooks.addFilter(
+				'editor.BlockListBlock',
+				'acf/with-default-attributes',
+				M
+			);
+			class L extends m {
+				constructor( e ) {
+					super( e ), this.setup();
+				}
+				setup() {
+					const { name: e, attributes: t, clientId: n } = this.props,
+						r = E( e );
+					function o( e ) {
+						e.includes( t.mode ) || ( t.mode = e[ 0 ] );
+					}
+					if ( j( n ) || I() ) o( [ 'preview' ] );
+					else
+						switch ( r.mode ) {
+							case 'edit':
+								o( [ 'edit', 'preview' ] );
+								break;
+							case 'preview':
+								o( [ 'preview', 'edit' ] );
+								break;
+							default:
+								o( [ 'auto' ] );
+						}
+				}
+				render() {
+					const {
+							name: t,
+							attributes: n,
+							setAttributes: r,
+							clientId: a,
+						} = this.props,
+						s = E( t ),
+						l = j( a ) || I();
+					let { mode: c } = n;
+					l && ( c = 'preview' );
+					let p = s.supports.mode;
+					( 'auto' === c || l ) && ( p = ! 1 );
+					const f =
+							'preview' === c
+								? acf.__( 'Switch to Edit' )
+								: acf.__( 'Switch to Preview' ),
+						m = 'preview' === c ? 'edit' : 'welcome-view-site';
+					return ( 0, e.jsxs )( h, {
+						children: [
+							( 0, e.jsx )( o, {
+								children:
+									p &&
+									( 0, e.jsx )( d, {
+										children: ( 0, e.jsx )( u, {
+											className:
+												'components-icon-button components-toolbar__control',
+											label: f,
+											icon: m,
+											onClick: function () {
+												r( {
+													mode:
+														'preview' === c
+															? 'edit'
+															: 'preview',
+												} );
+											},
+										} ),
+									} ),
+							} ),
+							( 0, e.jsx )( i, {
+								children:
+									'preview' === c &&
+									( 0, e.jsx )( 'div', {
+										className:
+											'acf-block-component acf-block-panel',
+										children: ( 0, e.jsx )( U, {
+											...this.props,
+										} ),
+									} ),
+							} ),
+							( 0, e.jsx )( D, { ...this.props } ),
+						],
+					} );
 				}
 			}
-		}
-
-		render() {
-			const { name, attributes, setAttributes, clientId } = this.props;
-			const blockType = getBlockType( name );
-			const forcePreview =
-				isBlockInQueryLoop( clientId ) || isSiteEditor();
-			let { mode } = attributes;
-
-			if ( forcePreview ) {
-				mode = 'preview';
-			}
-
-			// Show toggle only for edit/preview modes and for blocks not in a query loop/FSE.
-			let showToggle = blockType.supports.mode;
-			if ( mode === 'auto' || forcePreview ) {
-				showToggle = false;
-			}
-
-			// Configure toggle variables.
-			const toggleText =
-				mode === 'preview'
-					? acf.__( 'Switch to Edit' )
-					: acf.__( 'Switch to Preview' );
-			const toggleIcon =
-				mode === 'preview' ? 'edit' : 'welcome-view-site';
-			function toggleMode() {
-				setAttributes( {
-					mode: mode === 'preview' ? 'edit' : 'preview',
-				} );
-			}
-
-			// Return template.
-			return (
-				<Fragment>
-					<BlockControls>
-						{ showToggle && (
-							<ToolbarGroup>
-								<ToolbarButton
-									className="components-icon-button components-toolbar__control"
-									label={ toggleText }
-									icon={ toggleIcon }
-									onClick={ toggleMode }
-								/>
-							</ToolbarGroup>
-						) }
-					</BlockControls>
-
-					<InspectorControls>
-						{ mode === 'preview' && (
-							<div className="acf-block-component acf-block-panel">
-								<BlockForm { ...this.props } />
-							</div>
-						) }
-					</InspectorControls>
-
-					<BlockBody { ...this.props } />
-				</Fragment>
-			);
-		}
-	}
-
-	/**
-	 * The BlockBody functional component.
-	 *
-	 * @since	ACF 5.7.12
-	 */
-	function BlockBody( props ) {
-		const { attributes, isSelected, name, clientId } = props;
-		const { mode } = attributes;
-
-		const index = useSelect( ( select ) => {
-			const rootClientId =
-				select( 'core/block-editor' ).getBlockRootClientId( clientId );
-			return select( 'core/block-editor' ).getBlockIndex(
-				clientId,
-				rootClientId
-			);
-		} );
-
-		let showForm = true;
-		let additionalClasses = 'acf-block-component acf-block-body';
-
-		if ( ( mode === 'auto' && ! isSelected ) || mode === 'preview' ) {
-			additionalClasses += ' acf-block-preview';
-			showForm = false;
-		}
-
-		// Setup block cache if required, and update mode.
-		if ( ! ( clientId in acf.blockInstances ) ) {
-			acf.blockInstances[ clientId ] = {
-				validation_errors: false,
-				mode: mode,
-			};
-		}
-		acf.blockInstances[ clientId ].mode = mode;
-
-		if ( ! isSelected ) {
-			if (
-				blockSupportsValidation( name ) &&
-				acf.blockInstances[ clientId ].validation_errors
-			) {
-				additionalClasses += ' acf-block-has-validation-error';
-			}
-			acf.blockInstances[ clientId ].has_been_deselected = true;
-		}
-
-		if ( getBlockVersion( name ) > 1 ) {
-			return (
-				<div { ...useBlockProps( { className: additionalClasses } ) }>
-					{ showForm ? (
-						<BlockForm { ...props } index={ index } />
-					) : (
-						<BlockPreview { ...props } index={ index } />
-					) }
-				</div>
-			);
-		} else {
-			return (
-				<div { ...useBlockProps() }>
-					<div className="acf-block-component acf-block-body">
-						{ showForm ? (
-							<BlockForm { ...props } index={ index } />
-						) : (
-							<BlockPreview { ...props } index={ index } />
-						) }
-					</div>
-				</div>
-			);
-		}
-	}
-
-	/**
-	 * A react component to append HTMl.
-	 *
-	 * @date	19/2/19
-	 * @since	ACF 5.7.12
-	 *
-	 * @param	string children The html to insert.
-	 * @return	void
-	 */
-	class Div extends Component {
-		render() {
-			return (
-				<div
-					dangerouslySetInnerHTML={ { __html: this.props.children } }
-				/>
-			);
-		}
-	}
-
-	/**
-	 * DynamicHTML Class.
-	 *
-	 * A react componenet to load and insert dynamic HTML.
-	 *
-	 * @date	19/2/19
-	 * @since	ACF 5.7.12
-	 *
-	 * @param	void
-	 * @return	void
-	 */
-	class DynamicHTML extends Component {
-		constructor( props ) {
-			super( props );
-
-			// Bind callbacks.
-			this.setRef = this.setRef.bind( this );
-
-			// Define default props and call setup().
-			this.id = '';
-			this.el = false;
-			this.subscribed = true;
-			this.renderMethod = 'jQuery';
-			this.passedValidation = false;
-			this.setup( props );
-
-			// Load state.
-			this.loadState();
-		}
-
-		setup( props ) {
-			const constructor = this.constructor.name;
-			const clientId = props.clientId;
-			if ( ! ( clientId in acf.blockInstances ) ) {
-				acf.blockInstances[ clientId ] = {
-					validation_errors: false,
-					mode: props.mode,
-				};
-			}
-			if ( ! ( constructor in acf.blockInstances[ clientId ] ) ) {
-				acf.blockInstances[ clientId ][ constructor ] = {};
-			}
-		}
-
-		fetch() {
-			// Do nothing.
-		}
-
-		maybePreload( blockId, clientId, form ) {
-			acf.debug( 'Preload check', blockId, clientId, form );
-
-			// Early return if block is in query loop.
-			if ( isBlockInQueryLoop( this.props.clientId ) ) {
-				acf.debug( 'Preload failed: Block is in query loop.' );
-				return false;
-			}
-
-			const preloadedBlocks = acf.get( 'preloadedBlocks' );
-
-			// Early return if no preloaded blocks exist.
-			if ( ! preloadedBlocks || ! preloadedBlocks[ blockId ] ) {
-				acf.debug( 'Preload failed: Block not preloaded.' );
-				return false;
-			}
-
-			// Create a copy to avoid mutating the original preloaded data.
-			const preloadedBlock = { ...preloadedBlocks[ blockId ] };
-
-			// Ensure we only preload the correct block state (form or preview).
-			if (
-				( form && ! preloadedBlock.form ) ||
-				( ! form && preloadedBlock.form )
-			) {
-				acf.debug(
-					'Preload failed: Correct state not preloaded.',
-					form ? 'form' : 'preview'
-				);
-				return false;
-			}
-
-			// Replace blockId with clientId in HTML.
-			preloadedBlock.html = preloadedBlock.html.replaceAll(
-				blockId,
-				clientId
-			);
-
-			// Replace blockId in validation errors.
-			if (
-				preloadedBlock.validation &&
-				preloadedBlock.validation.errors
-			) {
-				preloadedBlock.validation.errors =
-					preloadedBlock.validation.errors.map( ( error ) => {
-						error.input = error.input.replaceAll( blockId, clientId );
-						return error;
+			function D( t ) {
+				const {
+						attributes: n,
+						isSelected: r,
+						name: o,
+						clientId: i,
+					} = t,
+					{ mode: a } = n,
+					l = b( ( e ) => {
+						const t =
+							e( 'core/block-editor' ).getBlockRootClientId( i );
+						return e( 'core/block-editor' ).getBlockIndex( i, t );
 					} );
+				let c = ! 0,
+					d = 'acf-block-component acf-block-body';
+				return (
+					( ( 'auto' === a && ! r ) || 'preview' === a ) &&
+						( ( d += ' acf-block-preview' ), ( c = ! 1 ) ),
+					i in acf.blockInstances ||
+						( acf.blockInstances[ i ] = {
+							validation_errors: ! 1,
+							mode: a,
+						} ),
+					( acf.blockInstances[ i ].mode = a ),
+					r ||
+						( C( o ) &&
+							acf.blockInstances[ i ].validation_errors &&
+							( d += ' acf-block-has-validation-error' ),
+						( acf.blockInstances[ i ].has_been_deselected = ! 0 ) ),
+					_( o ) > 1
+						? ( 0, e.jsx )( 'div', {
+								...s( { className: d } ),
+								children: c
+									? ( 0, e.jsx )( U, { ...t, index: l } )
+									: ( 0, e.jsx )( z, { ...t, index: l } ),
+						  } )
+						: ( 0, e.jsx )( 'div', {
+								...s(),
+								children: ( 0, e.jsx )( 'div', {
+									className:
+										'acf-block-component acf-block-body',
+									children: c
+										? ( 0, e.jsx )( U, { ...t, index: l } )
+										: ( 0, e.jsx )( z, { ...t, index: l } ),
+								} ),
+						  } )
+				);
 			}
-
-			// Return preloaded object.
-			acf.debug( 'Preload successful', preloadedBlock );
-			return preloadedBlock;
-		}
-
-		loadState() {
-			const client = acf.blockInstances[ this.props.clientId ] || {};
-			this.state = client[ this.constructor.name ] || {};
-		}
-		setState( state ) {
-			acf.blockInstances[ this.props.clientId ][ this.constructor.name ] =
-				{
-					...this.state,
-					...state,
-				};
-
-			// Update component state if subscribed.
-			// - Allows AJAX callback to update store without modifying state of an unmounted component.
-			if ( this.subscribed || acf.get( 'StrictMode' ) ) {
-				super.setState( state );
+			class $ extends m {
+				render() {
+					return ( 0, e.jsx )( 'div', {
+						dangerouslySetInnerHTML: {
+							__html: this.props.children,
+						},
+					} );
+				}
 			}
-
-			acf.debug(
-				'SetState',
-				Object.assign( {}, this ),
-				this.props.clientId,
-				this.constructor.name,
-				Object.assign(
-					{},
-					acf.blockInstances[ this.props.clientId ][
+			class q extends m {
+				render() {
+					return ( 0, e.jsx )( 'div', {
+						ref: ( e ) => ( this.el = e ),
+					} );
+				}
+				setHTML( e ) {
+					n( this.el ).html( `<script>${ e }<\/script>` );
+				}
+				componentDidUpdate() {
+					this.setHTML( this.props.children );
+				}
+				componentDidMount() {
+					this.setHTML( this.props.children );
+				}
+			}
+			class V extends m {
+				constructor( e ) {
+					super( e ),
+						( this.setRef = this.setRef.bind( this ) ),
+						( this.id = '' ),
+						( this.el = ! 1 ),
+						( this.subscribed = ! 0 ),
+						( this.renderMethod = 'jQuery' ),
+						( this.passedValidation = ! 1 ),
+						this.setup( e ),
+						this.loadState();
+				}
+				setup( e ) {
+					const t = this.constructor.name,
+						n = e.clientId;
+					n in acf.blockInstances ||
+						( acf.blockInstances[ n ] = {
+							validation_errors: ! 1,
+							mode: e.mode,
+						} ),
+						t in acf.blockInstances[ n ] ||
+							( acf.blockInstances[ n ][ t ] = {} );
+				}
+				fetch() {}
+				maybePreload( e, t, n ) {
+					if (
+						( acf.debug( 'Preload check', e, t, n ),
+						j( this.props.clientId ) )
+					)
+						return (
+							acf.debug(
+								'Preload failed: Block is in query loop.'
+							),
+							! 1
+						);
+					const r = acf.get( 'preloadedBlocks' );
+					if ( ! r || ! r[ e ] )
+						return (
+							acf.debug( 'Preload failed: Block not preloaded.' ),
+							! 1
+						);
+					const o = { ...r[ e ] };
+					return ( n && ! o.form ) || ( ! n && o.form )
+						? ( acf.debug(
+								'Preload failed: Correct state not preloaded.',
+								n ? 'form' : 'preview'
+						  ),
+						  ! 1 )
+						: ( ( o.html = o.html.replaceAll( e, t ) ),
+						  o.validation &&
+								o.validation.errors &&
+								( o.validation.errors = o.validation.errors.map(
+									( n ) => (
+										( n.input = n.input.replaceAll(
+											e,
+											t
+										) ),
+										n
+									)
+								) ),
+						  acf.debug( 'Preload successful', o ),
+						  o );
+				}
+				loadState() {
+					const e = acf.blockInstances[ this.props.clientId ] || {};
+					this.state = e[ this.constructor.name ] || {};
+				}
+				setState( e ) {
+					( acf.blockInstances[ this.props.clientId ][
 						this.constructor.name
-					]
-				)
-			);
-		}
-
-		setHtml( html ) {
-			html = html ? html.trim() : '';
-
-			// Bail early if html has not changed.
-			if ( html === this.state.html ) {
-				return;
+					] = {
+						...this.state,
+						...e,
+					} ),
+						( this.subscribed || acf.get( 'StrictMode' ) ) &&
+							super.setState( e ),
+						acf.debug(
+							'SetState',
+							Object.assign( {}, this ),
+							this.props.clientId,
+							this.constructor.name,
+							Object.assign(
+								{},
+								acf.blockInstances[ this.props.clientId ][
+									this.constructor.name
+								]
+							)
+						);
+				}
+				setHtml( e ) {
+					if ( ( e = e ? e.trim() : '' ) === this.state.html ) return;
+					const t = { html: e };
+					if ( 'jsx' === this.renderMethod ) {
+						if (
+							( ( t.jsx = acf.parseJSX(
+								e,
+								_( this.props.name )
+							) ),
+							t.jsx ||
+								( console.warn(
+									'Your ACF block template contains no valid HTML elements. Appending a empty div to prevent React JS errors.'
+								),
+								( t.html += '<div></div>' ),
+								( t.jsx = acf.parseJSX(
+									t.html,
+									_( this.props.name )
+								) ) ),
+							Array.isArray( t.jsx ) )
+						) {
+							let e = t.jsx.find( ( e ) =>
+								React.isValidElement( e )
+							);
+							t.ref = e.ref;
+						} else t.ref = t.jsx.ref;
+						t.$el = n( this.el );
+					} else t.$el = n( e );
+					this.setState( t );
+				}
+				setRef( e ) {
+					this.el = e;
+				}
+				render() {
+					return this.state.jsx
+						? _( this.props.name ) > 1
+							? ( this.setRef( this.state.jsx ), this.state.jsx )
+							: ( 0, e.jsx )( 'div', {
+									ref: this.setRef,
+									children: this.state.jsx,
+							  } )
+						: ( 0, e.jsx )( 'div', {
+								ref: this.setRef,
+								children: ( 0, e.jsx )( p, {
+									children: ( 0, e.jsx )( f, {} ),
+								} ),
+						  } );
+				}
+				shouldComponentUpdate( { index: e }, { html: t } ) {
+					return (
+						e !== this.props.index && this.componentWillMove(),
+						t !== this.state.html
+					);
+				}
+				display( e ) {
+					if ( 'jQuery' === this.renderMethod ) {
+						const t = this.state.$el,
+							r = t.parent(),
+							o = n( this.el );
+						( acf.get( 'StrictMode' ) &&
+							'append' !== e &&
+							! this.subscribed ) ||
+							o.html( t ),
+							r.length &&
+								r[ 0 ] !== o[ 0 ] &&
+								r.html( t.clone() );
+					}
+					switch (
+						( this.getValidationErrors() && this.isNotNewlyAdded()
+							? this.lockBlockForSaving()
+							: this.unlockBlockForSaving(),
+						e )
+					) {
+						case 'append':
+							this.componentDidAppend();
+							break;
+						case 'remount':
+							this.componentDidRemount();
+					}
+				}
+				validate() {}
+				componentDidMount() {
+					this.state.html === r
+						? this.fetch()
+						: this.display( 'remount' );
+				}
+				componentDidUpdate( e, t ) {
+					this.display( 'append' );
+				}
+				componentDidAppend() {
+					acf.doAction( 'append', this.state.$el );
+				}
+				componentWillUnmount() {
+					( acf.get( 'StrictMode' ) && ! this.subscribed ) ||
+						acf.doAction( 'unmount', this.state.$el ),
+						( this.subscribed = ! 1 );
+				}
+				componentDidRemount() {
+					( this.subscribed = ! 0 ),
+						setTimeout( () => {
+							acf.doAction( 'remount', this.state.$el );
+						} );
+				}
+				componentWillMove() {
+					acf.doAction( 'unmount', this.state.$el ),
+						setTimeout( () => {
+							acf.doAction( 'remount', this.state.$el );
+						} );
+				}
+				isNotNewlyAdded() {
+					return (
+						acf.blockInstances[ this.props.clientId ]
+							.has_been_deselected || ! 1
+					);
+				}
+				hasShownValidation() {
+					return (
+						acf.blockInstances[ this.props.clientId ]
+							.shown_validation || ! 1
+					);
+				}
+				setShownValidation() {
+					acf.blockInstances[ this.props.clientId ].shown_validation =
+						! 0;
+				}
+				setValidationErrors( e ) {
+					acf.blockInstances[
+						this.props.clientId
+					].validation_errors = e;
+				}
+				getValidationErrors() {
+					return acf.blockInstances[ this.props.clientId ]
+						.validation_errors;
+				}
+				getMode() {
+					return acf.blockInstances[ this.props.clientId ].mode;
+				}
+				lockBlockForSaving() {
+					wp.data.dispatch( 'core/editor' ) &&
+						wp.data
+							.dispatch( 'core/editor' )
+							.lockPostSaving(
+								'acf/block/' + this.props.clientId
+							);
+				}
+				unlockBlockForSaving() {
+					wp.data.dispatch( 'core/editor' ) &&
+						wp.data
+							.dispatch( 'core/editor' )
+							.unlockPostSaving(
+								'acf/block/' + this.props.clientId
+							);
+				}
+				displayValidation( e ) {
+					if ( ! C( this.props.name ) )
+						return void acf.debug(
+							'Block does not support validation'
+						);
+					if ( ! e || e.hasClass( 'acf-empty-block-fields' ) )
+						return void acf.debug(
+							'There is no edit form available to validate.'
+						);
+					const t = this.getValidationErrors();
+					acf.debug(
+						'Starting handle validation',
+						Object.assign( {}, this ),
+						Object.assign( {}, e ),
+						t
+					),
+						this.setShownValidation();
+					let n = acf.getBlockFormValidator( e );
+					n.clearErrors(),
+						acf.doAction( 'blocks/validation/pre_apply', t ),
+						t
+							? ( n.addErrors( t ),
+							  n.showErrors( 'after' ),
+							  this.lockBlockForSaving() )
+							: ( n.has( 'notice' ) &&
+									( n.get( 'notice' ).update( {
+										type: 'success',
+										text: acf.__( 'Validation successful' ),
+										timeout: 1e3,
+									} ),
+									n.set( 'notice', null ) ),
+							  this.unlockBlockForSaving() ),
+						acf.doAction( 'blocks/validation/post_apply', t );
+				}
 			}
-
-			// Update state.
-			const state = {
-				html,
-			};
-
-			if ( this.renderMethod === 'jsx' ) {
-				state.jsx = acf.parseJSX(
-					html,
-					getBlockVersion( this.props.name )
+			class U extends V {
+				setup( e ) {
+					( this.id = `BlockForm-${ e.clientId }` ), super.setup( e );
+				}
+				fetch( e = ! 1, t = ! 1 ) {
+					const { context: n, clientId: r, name: o } = this.props;
+					let { attributes: i } = this.props,
+						a = { form: ! 0 };
+					e && ( ( a = { validate: ! 0 } ), ( i.data = t ) );
+					const s = G( i, n );
+					acf.debug( 'BlockForm fetch', i, a );
+					const l = this.maybePreload( s, r, ! 0 );
+					if ( l )
+						return (
+							this.setHtml(
+								acf.applyFilters(
+									'blocks/form/render',
+									l.html,
+									! 0
+								)
+							),
+							void (
+								l.validation &&
+								this.setValidationErrors( l.validation.errors )
+							)
+						);
+					C( o ) || ( a.validate = ! 1 ),
+						B( {
+							attributes: i,
+							context: n,
+							clientId: r,
+							query: a,
+						} ).done( ( { data: e } ) => {
+							acf.debug( 'fetch block form promise' ),
+								e
+									? ( e.form &&
+											this.setHtml(
+												acf.applyFilters(
+													'blocks/form/render',
+													e.form.replaceAll(
+														e.clientId,
+														r
+													),
+													! 1
+												)
+											),
+									  e.validation &&
+											this.setValidationErrors(
+												e.validation.errors
+											),
+									  this.isNotNewlyAdded() &&
+											( acf.debug(
+												"Block has already shown it's invalid. The form needs to show validation errors"
+											),
+											this.validate() ) )
+									: this.setHtml(
+											`<div class="acf-block-fields acf-fields acf-empty-block-fields">${ acf.__(
+												'Error loading block form'
+											) }</div>`
+									  );
+						} );
+				}
+				validate( e = ! 0 ) {
+					e && this.loadState(),
+						acf.debug(
+							'BlockForm calling validate with state',
+							Object.assign( {}, this )
+						),
+						super.displayValidation( this.state.$el );
+				}
+				shouldComponentUpdate( e, t ) {
+					return (
+						C( this.props.name ) &&
+							this.state.$el &&
+							this.isNotNewlyAdded() &&
+							! this.hasShownValidation() &&
+							this.validate( ! 1 ),
+						super.shouldComponentUpdate( e, t )
+					);
+				}
+				componentWillUnmount() {
+					super.componentWillUnmount(),
+						acf.debug( 'BlockForm Component did unmount' );
+				}
+				componentDidRemount() {
+					super.componentDidRemount(),
+						acf.debug( 'BlockForm component did remount' );
+					const { $el: e } = this.state;
+					C( this.props.name ) &&
+						this.isNotNewlyAdded() &&
+						( acf.debug(
+							"Block has already shown it's invalid. The form needs to show validation errors"
+						),
+						this.validate() ),
+						! 0 !== e.data( 'acf-events-added' ) &&
+							this.componentDidAppend();
+				}
+				componentDidAppend() {
+					super.componentDidAppend(),
+						acf.debug( 'BlockForm component did append' );
+					const {
+							attributes: e,
+							setAttributes: t,
+							clientId: n,
+							name: r,
+						} = this.props,
+						o = this,
+						{ $el: i } = this.state;
+					function a( a = ! 1 ) {
+						const s = acf.serialize( i, `acf-block_${ n }` );
+						a ? ( e.data = s ) : t( { data: s } ),
+							C( r ) &&
+								! a &&
+								'edit' === o.getMode() &&
+								( acf.debug(
+									'No block preview currently available. Need to trigger a validation only fetch.'
+								),
+								o.fetch( ! 0, s ) );
+					}
+					let s = ! 1;
+					i.on( 'change keyup', () => {
+						clearTimeout( s ), ( s = setTimeout( a, 300 ) );
+					} ),
+						i.data( 'acf-events-added', ! 0 ),
+						e.data || a( ! 0 );
+				}
+			}
+			class z extends V {
+				setup( e ) {
+					const t = E( e.name ),
+						n = acf.isget( this.props, 'context', 'postId' );
+					( this.id = `BlockPreview-${ e.clientId }` ),
+						super.setup( e ),
+						n &&
+							( this.id = `BlockPreview-${ e.clientId }-${ n }` ),
+						t.supports.jsx && ( this.renderMethod = 'jsx' );
+				}
+				fetch( e = {} ) {
+					const {
+							attributes: t = this.props.attributes,
+							clientId: n = this.props.clientId,
+							context: r = this.props.context,
+							delay: o = 0,
+						} = e,
+						{ name: i } = this.props;
+					this.setState( { prevAttributes: t, prevContext: r } );
+					const a = G( t, r );
+					let s = this.maybePreload( a, n, ! 1 );
+					if ( s )
+						return (
+							1 == _( i ) &&
+								( s.html =
+									'<div class="acf-block-preview">' +
+									s.html +
+									'</div>' ),
+							this.setHtml(
+								acf.applyFilters(
+									'blocks/preview/render',
+									s.html,
+									! 0
+								)
+							),
+							void (
+								s.validation &&
+								this.setValidationErrors( s.validation.errors )
+							)
+						);
+					let l = { preview: ! 0 };
+					C( i ) || ( l.validate = ! 1 ),
+						B( {
+							attributes: t,
+							context: r,
+							clientId: n,
+							query: l,
+							delay: o,
+						} ).done( ( { data: e } ) => {
+							if ( ! e )
+								return void this.setHtml(
+									`<div class="acf-block-fields acf-fields acf-empty-block-fields">${ acf.__(
+										'Error previewing block'
+									) }</div>`
+								);
+							let t = e.preview.replaceAll( e.clientId, n );
+							1 == _( i ) &&
+								( t =
+									'<div class="acf-block-preview">' +
+									t +
+									'</div>' ),
+								acf.debug( 'fetch block render promise' ),
+								this.setHtml(
+									acf.applyFilters(
+										'blocks/preview/render',
+										t,
+										! 1
+									)
+								),
+								e.validation &&
+									this.setValidationErrors(
+										e.validation.errors
+									),
+								this.isNotNewlyAdded() && this.validate();
+						} );
+				}
+				validate() {
+					const e =
+						( acf.blockInstances[ this.props.clientId ] || {} )
+							.BlockForm || ! 1;
+					e && super.displayValidation( e.$el );
+				}
+				componentDidAppend() {
+					super.componentDidAppend(), this.renderBlockPreviewEvent();
+				}
+				shouldComponentUpdate( e, t ) {
+					const n = e.attributes,
+						r = this.props.attributes;
+					if ( ! F( n, r ) || ! F( e.context, this.props.context ) ) {
+						let t = 0;
+						n.className !== r.className && ( t = 300 ),
+							n.anchor !== r.anchor && ( t = 300 ),
+							acf.debug(
+								'Triggering fetch from block preview shouldComponentUpdate'
+							),
+							this.fetch( {
+								attributes: n,
+								context: e.context,
+								delay: t,
+							} );
+					}
+					return super.shouldComponentUpdate( e, t );
+				}
+				renderBlockPreviewEvent() {
+					const { attributes: e, name: t } = this.props,
+						{ $el: r, ref: o } = this.state;
+					var i;
+					const a = e.name.replace( 'acf/', '' );
+					( i =
+						o && o.current
+							? n( o.current ).parent()
+							: 1 == _( t )
+							? r
+							: r.parents( '.acf-block-preview' ) ),
+						acf.doAction( 'render_block_preview', i, e ),
+						acf.doAction(
+							`render_block_preview/type=${ a }`,
+							i,
+							e
+						);
+				}
+				componentDidRemount() {
+					super.componentDidRemount(),
+						acf.debug(
+							'Checking if fetch is required in BlockPreview componentDidRemount',
+							Object.assign( {}, this.state.prevAttributes ),
+							Object.assign( {}, this.props.attributes ),
+							Object.assign( {}, this.state.prevContext ),
+							Object.assign( {}, this.props.context )
+						),
+						( F(
+							this.state.prevAttributes,
+							this.props.attributes
+						) &&
+							F( this.state.prevContext, this.props.context ) ) ||
+							( acf.debug(
+								'Triggering block preview fetch from componentDidRemount'
+							),
+							this.fetch() ),
+						this.renderBlockPreviewEvent();
+				}
+			}
+			function W( e ) {
+				return [ 'top', 'center', 'bottom' ].includes( e ) ? e : 'top';
+			}
+			function J( e ) {
+				const t = acf.get( 'rtl' ) ? 'right' : 'left';
+				return [ 'left', 'center', 'right' ].includes( e ) ? e : t;
+			}
+			function X( e ) {
+				if ( e ) {
+					const [ t, n ] = e.split( ' ' );
+					return `${ W( t ) } ${ J( n ) }`;
+				}
+				return 'center center';
+			}
+			function Y( e, t, n ) {
+				return ( e[ t ] = { type: n } ), e;
+			}
+			function G( e, n ) {
+				return (
+					( e._acf_context = K( n ) ), t( JSON.stringify( K( e ) ) )
 				);
-
-				// Handle templates which don't contain any valid JSX parsable elements.
-				if ( ! state.jsx ) {
-					console.warn(
-						'Your ACF block template contains no valid HTML elements. Appending a empty div to prevent React JS errors.'
-					);
-					state.html += '<div></div>';
-					state.jsx = acf.parseJSX(
-						state.html,
-						getBlockVersion( this.props.name )
-					);
-				}
-
-				// If we've got an object (as an array) find the first valid React ref.
-				if ( Array.isArray( state.jsx ) ) {
-					let refElement = state.jsx.find( ( element ) =>
-						React.isValidElement( element )
-					);
-					state.ref = refElement.ref;
-				} else {
-					state.ref = state.jsx.ref;
-				}
-				state.$el = $( this.el );
-			} else {
-				state.$el = $( html );
 			}
-			this.setState( state );
-		}
-
-		setRef( el ) {
-			this.el = el;
-		}
-
-		render() {
-			// Render JSX.
-			if ( this.state.jsx ) {
-				// If we're a v2+ block, use the jsx element itself as our ref.
-				if ( getBlockVersion( this.props.name ) > 1 ) {
-					this.setRef( this.state.jsx );
-					return this.state.jsx;
-				} else {
-					return <div ref={ this.setRef }>{ this.state.jsx }</div>;
-				}
+			function K( e ) {
+				return Object.keys( e )
+					.sort()
+					.reduce( ( t, n ) => ( ( t[ n ] = e[ n ] ), t ), {} );
 			}
-
-			// Return HTML.
-			return (
-				<div ref={ this.setRef }>
-					<Placeholder>
-						<Spinner />
-					</Placeholder>
-				</div>
-			);
-		}
-
-		shouldComponentUpdate( { index }, { html } ) {
-			if ( index !== this.props.index ) {
-				this.componentWillMove();
-			}
-			return html !== this.state.html;
-		}
-
-		display( context ) {
-			// This method is called after setting new HTML and the Component render.
-			// The jQuery render method simply needs to move $el into place.
-			if ( this.renderMethod === 'jQuery' ) {
-				const $el = this.state.$el;
-				const $prevParent = $el.parent();
-				const $thisParent = $( this.el );
-
-				// Move $el into place.
-				// Skip this in StrictMode unless context is 'append' or component is subscribed.
-				if (
-					! (
-						acf.get( 'StrictMode' ) &&
-						context !== 'append' &&
-						! this.subscribed
-					)
-				) {
-					$thisParent.html( $el );
-				}
-
-				// Special case for reusable blocks.
-				// Multiple instances of the same reusable block share the same block id.
-				// This causes all instances to share the same state (cool), which unfortunately
-				// pulls $el back and forth between the last rendered reusable block.
-				// This simple fix leaves a "clone" behind :)
-				if (
-					$prevParent.length &&
-					$prevParent[ 0 ] !== $thisParent[ 0 ]
-				) {
-					$prevParent.html( $el.clone() );
-				}
-			}
-
-			// Lock block if required.
-			if ( this.getValidationErrors() && this.isNotNewlyAdded() ) {
-				this.lockBlockForSaving();
-			} else {
-				this.unlockBlockForSaving();
-			}
-
-			// Call context specific method.
-			switch ( context ) {
-				case 'append':
-					this.componentDidAppend();
-					break;
-				case 'remount':
-					this.componentDidRemount();
-					break;
-			}
-		}
-
-		validate() {
-			// Do nothing.
-		}
-
-		componentDidMount() {
-			// Fetch on first load.
-			if ( this.state.html === undefined ) {
-				this.fetch();
-
-				// Or remount existing HTML.
-			} else {
-				this.display( 'remount' );
-			}
-		}
-
-		componentDidUpdate( prevProps, prevState ) {
-			// HTML has changed.
-			this.display( 'append' );
-		}
-
-		componentDidAppend() {
-			acf.doAction( 'append', this.state.$el );
-		}
-
-		componentWillUnmount() {
-			// Only skip unmount action if in StrictMode AND component is not subscribed
-			if ( ! acf.get( 'StrictMode' ) || this.subscribed ) {
-				acf.doAction( 'unmount', this.state.$el );
-			}
-
-			// Unsubscribe this component from state
-			this.subscribed = false;
-		}
-
-		componentDidRemount() {
-			this.subscribed = true;
-
-			// Use setTimeout to avoid incorrect timing of events.
-			// React will unmount and mount components in DOM order.
-			// This means a new component can be mounted before an old one is unmounted.
-			// ACF shares $el across new/old components which is un-React-like.
-			// This timout ensures that unmounting occurs before remounting.
-			setTimeout( () => {
-				acf.doAction( 'remount', this.state.$el );
-			} );
-		}
-
-		componentWillMove() {
-			acf.doAction( 'unmount', this.state.$el );
-			setTimeout( () => {
-				acf.doAction( 'remount', this.state.$el );
-			} );
-		}
-
-		isNotNewlyAdded() {
-			return (
-				acf.blockInstances[ this.props.clientId ].has_been_deselected ||
-				false
-			);
-		}
-
-		hasShownValidation() {
-			return (
-				acf.blockInstances[ this.props.clientId ].shown_validation ||
-				false
-			);
-		}
-
-		setShownValidation() {
-			acf.blockInstances[ this.props.clientId ].shown_validation = true;
-		}
-
-		setValidationErrors( errors ) {
-			acf.blockInstances[ this.props.clientId ].validation_errors =
-				errors;
-		}
-
-		getValidationErrors() {
-			return acf.blockInstances[ this.props.clientId ].validation_errors;
-		}
-
-		getMode() {
-			return acf.blockInstances[ this.props.clientId ].mode;
-		}
-
-		lockBlockForSaving() {
-			if ( ! wp.data.dispatch( 'core/editor' ) ) return;
-			wp.data
-				.dispatch( 'core/editor' )
-				.lockPostSaving( 'acf/block/' + this.props.clientId );
-		}
-
-		unlockBlockForSaving() {
-			if ( ! wp.data.dispatch( 'core/editor' ) ) return;
-			wp.data
-				.dispatch( 'core/editor' )
-				.unlockPostSaving( 'acf/block/' + this.props.clientId );
-		}
-
-		displayValidation( $formEl ) {
-			if ( ! blockSupportsValidation( this.props.name ) ) {
-				acf.debug( 'Block does not support validation' );
-				return;
-			}
-			if ( ! $formEl || $formEl.hasClass( 'acf-empty-block-fields' ) ) {
-				acf.debug( 'There is no edit form available to validate.' );
-				return;
-			}
-
-			const errors = this.getValidationErrors();
-			acf.debug(
-				'Starting handle validation',
-				Object.assign( {}, this ),
-				Object.assign( {}, $formEl ),
-				errors
-			);
-
-			this.setShownValidation();
-
-			let validator = acf.getBlockFormValidator( $formEl );
-			validator.clearErrors();
-
-			acf.doAction( 'blocks/validation/pre_apply', errors );
-			if ( errors ) {
-				validator.addErrors( errors );
-				validator.showErrors( 'after' );
-
-				this.lockBlockForSaving();
-			} else {
-				// remove previous error message
-				if ( validator.has( 'notice' ) ) {
-					validator.get( 'notice' ).update( {
-						type: 'success',
-						text: acf.__( 'Validation successful' ),
-						timeout: 1000,
+			acf.addAction( 'prepare', function () {
+				wp.blockEditor || ( wp.blockEditor = wp.editor );
+				const e = acf.get( 'blockTypes' );
+				e &&
+					e.forEach( ( e ) => {
+						parseInt( e.acf_block_version ) <= 2 && S( e );
 					} );
-					validator.set( 'notice', null );
-				}
-
-				this.unlockBlockForSaving();
-			}
-			acf.doAction( 'blocks/validation/post_apply', errors );
-		}
-	}
-
-	/**
-	 * BlockForm Class.
-	 *
-	 * A react componenet to handle the block form.
-	 *
-	 * @date	19/2/19
-	 * @since	ACF 5.7.12
-	 *
-	 * @param	string id the block id.
-	 * @return	void
-	 */
-	class BlockForm extends DynamicHTML {
-		setup( props ) {
-			this.id = `BlockForm-${ props.clientId }`;
-			super.setup( props );
-		}
-
-		fetch( validate_only = false, data = false ) {
-			// Extract props.
-			const { context, clientId, name } = this.props;
-			let { attributes } = this.props;
-
-			let query = { form: true };
-			if ( validate_only ) {
-				query = { validate: true };
-				attributes.data = data;
-			}
-
-			const hash = createBlockAttributesHash( attributes, context );
-
-			acf.debug( 'BlockForm fetch', attributes, query );
-
-			// Try preloaded data first.
-			const preloaded = this.maybePreload( hash, clientId, true );
-
-			if ( preloaded ) {
-				this.setHtml(
-					acf.applyFilters(
-						'blocks/form/render',
-						preloaded.html,
-						true
-					)
+			} );
+		} )( jQuery );
+		const r = ( e ) => {
+				wp.data.dispatch( 'core/editor' ) &&
+					wp.data
+						.dispatch( 'core/editor' )
+						.lockPostSaving( 'acf/block/' + e );
+			},
+			o = ( e ) => {
+				wp.data.dispatch( 'core/editor' ) &&
+					wp.data
+						.dispatch( 'core/editor' )
+						.unlockPostSaving( 'acf/block/' + e );
+			},
+			i = ( e ) =>
+				!! wp.data.dispatch( 'core/editor' ) &&
+				wp.data
+					.select( 'core/editor' )
+					.isPostSavingLocked( `acf/block/${ e }` ),
+			a = ( e ) =>
+				Object.keys( e )
+					.sort()
+					.reduce( ( t, n ) => ( ( t[ n ] = e[ n ] ), t ), {} ),
+			s = n( 503 ),
+			l = ( e, t ) => {
+				const n = { ...e };
+				return (
+					delete n.hasAcfError,
+					( n._acf_context = a( t ) ),
+					s( JSON.stringify( a( n ) ) )
 				);
-				if ( preloaded.validation )
-					this.setValidationErrors( preloaded.validation.errors );
-				return;
-			}
-
-			if ( ! blockSupportsValidation( name ) ) {
-				query.validate = false;
-			}
-
-			// Request AJAX and update HTML on complete.
-			fetchBlock( {
-				attributes,
-				context,
-				clientId,
-				query,
-			} ).done( ( { data } ) => {
-				acf.debug( 'fetch block form promise' );
-
-				if ( ! data ) {
-					this.setHtml(
-						`<div class="acf-block-fields acf-fields acf-empty-block-fields">${ acf.__(
-							'Error loading block form'
-						) }</div>`
-					);
-					return;
+			},
+			{ InnerBlocks: c } = wp.blockEditor,
+			d =
+				wp.blockEditor.__experimentalUseInnerBlocksProps ||
+				wp.blockEditor.useInnerBlocksProps,
+			{ createRef: u, createElement: p, useEffect: f } = wp.element,
+			h = ( e, t, n, r, o, i ) =>
+				m(
+					i(
+						( e = ( e = '<div>' + e + '</div>' ).replace(
+							/<InnerBlocks([^>]+)?\/>/,
+							'<InnerBlocks$1></InnerBlocks>'
+						) )
+					)[ 0 ],
+					0,
+					t,
+					n,
+					r,
+					o
+				).props.children;
+		function m( t, n = 0, r, o, i, a ) {
+			const s = ( function ( e ) {
+				switch ( e ) {
+					case 'innerblocks':
+						return 'ACFInnerBlocks';
+					case 'script':
+						return k;
+					case '#comment':
+						return null;
+					default:
+						e = b( e );
 				}
-
-				if ( data.form ) {
-					this.setHtml(
-						acf.applyFilters(
-							'blocks/form/render',
-							data.form.replaceAll( data.clientId, clientId ),
-							false
+				return e;
+			} )( t.nodeName.toLowerCase() );
+			if ( ! s ) return null;
+			const l = {};
+			if (
+				( 1 === n && 'ACFInnerBlocks' !== s && ( l.ref = u() ),
+				acf
+					.arrayArgs( t.attributes )
+					.map( v )
+					.forEach( ( { name: e, value: t } ) => {
+						l[ e ] = t;
+					} ),
+				t.hasAttribute( 'data-acf-inline-fields' ) &&
+					( ( l.style = { ...y( t ), pointerEvents: 'all' } ),
+					( l.role = 'button' ),
+					( l.tabIndex = 0 ),
+					( l.onFocus = ( e ) => {
+						e.stopPropagation(),
+							r(
+								t.attributes.getNamedItem(
+									'data-acf-inline-fields-uid'
+								).value
+							);
+					} ),
+					( l.onMouseDown = ( e ) => e.stopPropagation() ),
+					( l.onClick = ( e ) => {
+						e.stopPropagation();
+						const n = e.target.closest( 'a' );
+						n &&
+							'A' === n.tagName &&
+							( e.preventDefault(),
+							acf.debug(
+								`Navigation prevented for ${ n.href }`
+							) ),
+							e.target.hasAttribute(
+								'data-acf-inline-contenteditable'
+							) ||
+								r(
+									t.attributes.getNamedItem(
+										'data-acf-inline-fields-uid'
+									).value
+								);
+					} ),
+					( l.onKeyDown = ( e ) => {
+						if ( 'Tab' === e.key && e.shiftKey ) {
+							e.preventDefault();
+							const n = document
+								.querySelector( '.acf-inline-editing-toolbar' )
+								.querySelector( 'button' );
+							n &&
+								( n.focus(),
+								r(
+									t.attributes.getNamedItem(
+										'data-acf-inline-fields-uid'
+									).value
+								) );
+						}
+						if ( 'Enter' === e.key ) {
+							e.stopPropagation();
+							const n = e.target.closest( 'a' );
+							n &&
+								'A' === n.tagName &&
+								( e.preventDefault(),
+								acf.debug(
+									`Navigation prevented for ${ n.href }`
+								) ),
+								r(
+									t.attributes.getNamedItem(
+										'data-acf-inline-fields-uid'
+									).value
+								);
+						}
+					} ) ),
+				t.hasAttribute( 'data-acf-inline-contenteditable' ) )
+			) {
+				const e = t.attributes.getNamedItem(
+					'data-acf-inline-contenteditable-field-slug'
+				).value;
+				( a
+					? a.filter(
+							( t ) =>
+								t.name === e &&
+								( 'text' === t.type || 'textarea' === t.type )
+					  )
+					: []
+				).length > 0
+					? ( ( l.contentEditable = ! 0 ),
+					  ( l.suppressContentEditableWarning = ! 0 ),
+					  ( l.role = 'input' ),
+					  ( l.tabIndex = 0 ),
+					  ( l.onFocus = ( e ) => {
+							const n = e.target.closest( 'a' );
+							n &&
+								'A' === n.tagName &&
+								( e.preventDefault(),
+								acf.debug(
+									`Navigation prevented for ${ n.href }`
+								) ),
+								e.stopPropagation(),
+								i(
+									t.attributes.getNamedItem(
+										'data-acf-inline-contenteditable-field-slug'
+									).value
+								),
+								t.hasAttribute( 'data-acf-inline-fields' )
+									? r(
+											t.attributes.getNamedItem(
+												'data-acf-inline-fields-uid'
+											).value
+									  )
+									: r( null );
+					  } ),
+					  ( l.onPaste = ( e ) => {
+							e.preventDefault();
+							const t = e.clipboardData.getData( 'text/plain' );
+							e.currentTarget.textContent =
+								e.currentTarget.textContent + t;
+					  } ) )
+					: ( delete l[
+							'data-acf-inline-contenteditable-field-slug'
+					  ],
+					  delete l[ 'data-acf-inline-contenteditable' ] );
+			}
+			if (
+				( t.hasAttribute( 'data-acf-inline-fields' ) ||
+					t.hasAttribute( 'data-acf-inline-contenteditable' ) ||
+					( l.onClick = ( e ) => {
+						e.target === e.currentTarget && r( null );
+					} ),
+				'ACFInnerBlocks' === s )
+			)
+				return ( 0, e.jsx )( g, { ...l } );
+			const c = [ s, l ];
+			return (
+				acf.arrayArgs( t.childNodes ).forEach( ( e ) => {
+					if ( e instanceof Text ) {
+						const t = e.textContent;
+						t && c.push( t );
+					} else c.push( m( e, n + 1, r, o, i, a ) );
+				} ),
+				p.apply( this, c )
+			);
+		}
+		function b( e ) {
+			return acf.isget( acf, 'jsxNameReplacements', e ) || e;
+		}
+		function g( t ) {
+			const { className: n = 'acf-innerblocks-container' } = t,
+				r = d( { className: n }, t );
+			return ( 0, e.jsx )( 'div', { ...r, children: r.children } );
+		}
+		function k( { children: e } ) {
+			return (
+				f( () => {
+					const t = ( function () {
+							const e = document.querySelector(
+								'[name="editor-canvas"]'
+							);
+							return e
+								? e.contentDocument || e.contentWindow.document
+								: document;
+						} )(),
+						n = t.createElement( 'script' );
+					return (
+						( n.textContent = e ),
+						t.body.appendChild( n ),
+						() => {
+							n.remove();
+						}
+					);
+				}, [ e ] ),
+				null
+			);
+		}
+		function v( e ) {
+			let t = e.name,
+				n = e.value,
+				r = acf.applyFilters( 'acf_blocks_parse_node_attr', ! 1, e );
+			if ( r ) return r;
+			switch ( t ) {
+				case 'class':
+					t = 'className';
+					break;
+				case 'style':
+					const e = {};
+					n.split( ';' ).forEach( ( t ) => {
+						const n = t.indexOf( ':' );
+						if ( n > 0 ) {
+							let r = t.substr( 0, n ).trim();
+							const o = t.substr( n + 1 ).trim();
+							'-' !== r.charAt( 0 ) &&
+								( r = acf.strCamelCase( r ) ),
+								( e[ r ] = o );
+						}
+					} ),
+						( n = e );
+					break;
+				default:
+					if ( 0 === t.indexOf( 'data-' ) ) break;
+					t = b( t );
+					const r = n.charAt( 0 );
+					( '[' !== r && '{' !== r ) || ( n = JSON.parse( n ) ),
+						( 'true' !== n && 'false' !== n ) ||
+							( n = 'true' === n );
+			}
+			return { name: t, value: n };
+		}
+		function y( e ) {
+			const t = JSON.parse( JSON.stringify( e.style ) ),
+				n = {},
+				r = Object.keys( t );
+			for ( let e = 0; e < r.length; e++ ) {
+				const o = r[ e ];
+				if ( Number.isInteger( parseInt( o ) ) ) continue;
+				const i = t[ r[ e ] ],
+					a = o.replace( /-([a-z])/g, ( e ) => e[ 1 ].toUpperCase() );
+				i && ( n[ a ] = i );
+			}
+			return n;
+		}
+		const { useState: x, useEffect: w } = wp.element,
+			{ subscribe: E, select: _ } = wp.data;
+		function C() {
+			return (
+				'edit-post/block' ===
+				_( 'core/interface' ).getActiveComplementaryArea( 'core' )
+			);
+		}
+		const { useEffect: j } = wp.element,
+			I = ( {
+				inspectorBlockFormRef: t,
+				setCurrentBlockFormContainer: n,
+			} ) => (
+				j( () => {
+					n( t.current );
+				}, [] ),
+				( 0, e.jsx )( 'div', { ref: t } )
+			),
+			{ useState: S, useEffect: A, useRef: T } = wp.element,
+			B = ( {
+				$: t,
+				clientId: n,
+				blockFormHtml: i,
+				onMount: a,
+				onChange: s,
+				validationErrors: l,
+				showValidationErrors: c,
+				acfFormRef: d,
+				userHasInteractedWithForm: u,
+				attributes: p,
+				hideFieldsInSidebar: f,
+			} ) => {
+				const [ h, m ] = S( ! 1 ),
+					[ b, g ] = S( i ),
+					[ k, v ] = S( ! 1 ),
+					y = T( null ),
+					[ x, w ] = S( ! 1 );
+				return (
+					A( () => {
+						a();
+					}, [] ),
+					A( () => {
+						k && ( u || x ) && ( s( k ), v( ! 1 ) );
+					}, [ k, u, v, s ] ),
+					A( () => {
+						! b && i && g( i );
+					}, [ i ] ),
+					A( () => {
+						if ( ! d?.current ) return;
+						const e = acf.getBlockFormValidator(
+							t( d.current ).find( '.acf-block-fields' )
+						);
+						if (
+							( e.clearErrors(),
+							e.set( 'notice', null ),
+							acf.doAction( 'blocks/validation/pre_apply', l ),
+							l )
 						)
-					);
-				}
-
-				if ( data.validation )
-					this.setValidationErrors( data.validation.errors );
-
-				if ( this.isNotNewlyAdded() ) {
-					acf.debug(
-						"Block has already shown it's invalid. The form needs to show validation errors"
-					);
-					this.validate();
-				}
-			} );
-		}
-
-		validate( loadState = true ) {
-			if ( loadState ) {
-				this.loadState();
-			}
-
-			acf.debug(
-				'BlockForm calling validate with state',
-				Object.assign( {}, this )
-			);
-			super.displayValidation( this.state.$el );
-		}
-
-		shouldComponentUpdate( nextProps, nextState ) {
-			if (
-				blockSupportsValidation( this.props.name ) &&
-				this.state.$el &&
-				this.isNotNewlyAdded() &&
-				! this.hasShownValidation()
-			) {
-				this.validate( false ); // Shouldn't update state in shouldComponentUpdate.
-			}
-
-			return super.shouldComponentUpdate( nextProps, nextState );
-		}
-
-		componentWillUnmount() {
-			super.componentWillUnmount();
-
-			//TODO: either delete this, or clear validations here (if that's a sensible idea)
-
-			acf.debug( 'BlockForm Component did unmount' );
-		}
-
-		componentDidRemount() {
-			super.componentDidRemount();
-
-			acf.debug( 'BlockForm component did remount' );
-
-			const { $el } = this.state;
-
-			if (
-				blockSupportsValidation( this.props.name ) &&
-				this.isNotNewlyAdded()
-			) {
-				acf.debug(
-					"Block has already shown it's invalid. The form needs to show validation errors"
+							c &&
+								( r( n ),
+								e.$el.find( '.acf-notice' ).remove(),
+								e.addErrors( l ),
+								e.showErrors( 'after' ) );
+						else {
+							if ( e.$el.find( '.acf-notice' ).length > 0 && c ) {
+								e.$el.find( '.acf-notice' ).remove(),
+									e.addErrors( [
+										{
+											message: acf.__(
+												'Validation successful'
+											),
+										},
+									] ),
+									e.showErrors( 'after' ),
+									e.get( 'notice' ).update( {
+										type: 'success',
+										text: acf.__( 'Validation successful' ),
+										timeout: 1e3,
+									} ),
+									e.set( 'notice', null ),
+									setTimeout( () => {
+										e.$el.find( '.acf-notice' ).remove();
+									}, 1001 );
+								const i = wp.data.dispatch( 'core/notices' );
+								function a( e ) {
+									return new Promise( function ( t ) {
+										return (
+											e.forEach( ( e ) => {
+												if (
+													( e.innerBlocks.length >
+														0 &&
+														a( e.innerBlocks ).then(
+															( e ) => {
+																if ( e )
+																	return t(
+																		! 0
+																	);
+															}
+														),
+													e.attributes.hasAcfError &&
+														e.clientId !== n )
+												)
+													return t( ! 0 );
+											} ),
+											t( ! 1 )
+										);
+									} );
+								}
+								a(
+									wp.data
+										.select( 'core/block-editor' )
+										.getBlocks()
+								).then( ( e ) => {
+									e
+										? i.createErrorNotice(
+												acf.__(
+													'An ACF Block on this page requires attention before you can save.'
+												),
+												{
+													id: 'acf-blocks-validation',
+													isDismissible: ! 0,
+												}
+										  )
+										: i.removeNotice(
+												'acf-blocks-validation'
+										  );
+								} );
+							}
+							o( n );
+						}
+						acf.doAction( 'blocks/validation/post_apply', l );
+					}, [ l, n, c ] ),
+					A( () => {
+						if ( ! d?.current || ! b ) return;
+						acf.debug( 'Remounting ACF Form' );
+						const e = d.current,
+							n = t( e );
+						let r = ! 0;
+						acf.doAction( 'remount', n ), h || ( s( n ), m( ! 0 ) );
+						const o = () => {
+								s( n );
+							},
+							i = () => {
+								if ( ! r ) return;
+								const t =
+										e.querySelectorAll( 'input, textarea' ),
+									i = e.querySelectorAll( 'select' );
+								t.forEach( ( e ) => {
+									e.removeEventListener( 'input', o ),
+										e.addEventListener( 'input', o );
+								} ),
+									i.forEach( ( e ) => {
+										e.removeEventListener( 'change', o ),
+											e.addEventListener( 'change', o );
+									} ),
+									clearTimeout( y.current ),
+									( y.current = setTimeout( () => {
+										r && v( n );
+									}, 300 ) );
+							},
+							a = new MutationObserver( i ),
+							l = new MutationObserver( () => {
+								r && ( w( ! 0 ), i() );
+							} ),
+							c = {
+								attributes: ! 0,
+								childList: ! 0,
+								subtree: ! 0,
+								characterData: ! 0,
+							};
+						return (
+							a.observe( e, c ),
+							[ ...e.querySelectorAll( 'iframe' ) ].forEach(
+								( e ) => {
+									if ( e && e.contentDocument ) {
+										const t = e.contentDocument.body;
+										t && l.observe( t, c );
+									}
+								}
+							),
+							e
+								.querySelectorAll( 'input, textarea' )
+								.forEach( ( e ) => {
+									e.addEventListener( 'input', o );
+								} ),
+							e.querySelectorAll( 'select' ).forEach( ( e ) => {
+								e.addEventListener( 'change', o );
+							} ),
+							() => {
+								( r = ! 1 ),
+									a.disconnect(),
+									l.disconnect(),
+									clearTimeout( y.current ),
+									e &&
+										( e
+											.querySelectorAll(
+												'input, textarea'
+											)
+											.forEach( ( e ) => {
+												e.removeEventListener(
+													'input',
+													o
+												);
+											} ),
+										e
+											.querySelectorAll( 'select' )
+											.forEach( ( e ) => {
+												e.removeEventListener(
+													'change',
+													o
+												);
+											} ) );
+							}
+						);
+					}, [ d, p, b ] ),
+					( 0, e.jsx )( 'div', {
+						ref: d,
+						className: 'acf-block-component acf-block-panel',
+						style: { display: f ? 'none' : null },
+						dangerouslySetInnerHTML: {
+							__html: acf.applyFilters(
+								'blocks/form/render',
+								b,
+								! 0
+							),
+						},
+					} )
 				);
-				this.validate();
+			};
+		var F = n( 540 );
+		const O = ( 0, F.createContext )( null ),
+			N = { didCatch: ! 1, error: null };
+		class R extends F.Component {
+			constructor( e ) {
+				super( e ),
+					( this.resetErrorBoundary =
+						this.resetErrorBoundary.bind( this ) ),
+					( this.state = N );
 			}
-
-			// Make sure our on append events are registered.
-			if ( $el.data( 'acf-events-added' ) !== true ) {
-				this.componentDidAppend();
+			static getDerivedStateFromError( e ) {
+				return { didCatch: ! 0, error: e };
 			}
-		}
-
-		componentDidAppend() {
-			super.componentDidAppend();
-
-			acf.debug( 'BlockForm component did append' );
-
-			// Extract props.
-			const { attributes, setAttributes, clientId, name } = this.props;
-			const thisBlockForm = this;
-			const { $el } = this.state;
-
-			// Callback for updating block data and validation status if we're in an edit only mode.
-			function serializeData( silent = false ) {
-				const data = acf.serialize( $el, `acf-block_${ clientId }` );
-
-				if ( silent ) {
-					attributes.data = data;
-				} else {
-					setAttributes( {
-						data,
-					} );
-				}
-
-				if (
-					blockSupportsValidation( name ) &&
-					! silent &&
-					thisBlockForm.getMode() === 'edit'
-				) {
-					acf.debug(
-						'No block preview currently available. Need to trigger a validation only fetch.'
-					);
-					thisBlockForm.fetch( true, data );
-				}
-			}
-
-			// Add events.
-			let timeout = false;
-			$el.on( 'change keyup', () => {
-				clearTimeout( timeout );
-				timeout = setTimeout( serializeData, 300 );
-			} );
-
-			// Log initialization for remount check on the persistent element.
-			$el.data( 'acf-events-added', true );
-
-			// Ensure newly added block is saved with data.
-			// Do it silently to avoid triggering a preview render.
-			if ( ! attributes.data ) {
-				serializeData( true );
-			}
-		}
-	}
-
-	/**
-	 * BlockPreview Class.
-	 *
-	 * A react componenet to handle the block preview.
-	 *
-	 * @date	19/2/19
-	 * @since	ACF 5.7.12
-	 *
-	 * @param	string id the block id.
-	 * @return	void
-	 */
-	class BlockPreview extends DynamicHTML {
-		setup( props ) {
-			const blockType = getBlockType( props.name );
-			const contextPostId = acf.isget( this.props, 'context', 'postId' );
-
-			this.id = `BlockPreview-${ props.clientId }`;
-
-			super.setup( props );
-
-			// Apply the contextPostId to the ID if set to stop query loop ID duplication.
-			if ( contextPostId ) {
-				this.id = `BlockPreview-${ props.clientId }-${ contextPostId }`;
-			}
-
-			if ( blockType.supports.jsx ) {
-				this.renderMethod = 'jsx';
-			}
-		}
-
-		fetch( args = {} ) {
-			const {
-				attributes = this.props.attributes,
-				clientId = this.props.clientId,
-				context = this.props.context,
-				delay = 0,
-			} = args;
-
-			const { name } = this.props;
-
-			// Remember attributes used to fetch HTML.
-			this.setState( {
-				prevAttributes: attributes,
-				prevContext: context,
-			} );
-
-			const hash = createBlockAttributesHash( attributes, context );
-
-			// Try preloaded data first.
-			let preloaded = this.maybePreload( hash, clientId, false );
-
-			if ( preloaded ) {
-				if ( getBlockVersion( name ) == 1 ) {
-					preloaded.html =
-						'<div class="acf-block-preview">' +
-						preloaded.html +
-						'</div>';
-				}
-				this.setHtml(
-					acf.applyFilters(
-						'blocks/preview/render',
-						preloaded.html,
-						true
+			resetErrorBoundary() {
+				const { error: e } = this.state;
+				if ( null !== e ) {
+					for (
+						var t,
+							n,
+							r = arguments.length,
+							o = new Array( r ),
+							i = 0;
+						i < r;
+						i++
 					)
-				);
-				if ( preloaded.validation )
-					this.setValidationErrors( preloaded.validation.errors );
-				return;
+						o[ i ] = arguments[ i ];
+					null === ( t = ( n = this.props ).onReset ) ||
+						void 0 === t ||
+						t.call( n, { args: o, reason: 'imperative-api' } ),
+						this.setState( N );
+				}
 			}
-
-			let query = { preview: true };
-
-			if ( ! blockSupportsValidation( name ) ) {
-				query.validate = false;
+			componentDidCatch( e, t ) {
+				var n, r;
+				null === ( n = ( r = this.props ).onError ) ||
+					void 0 === n ||
+					n.call( r, e, t );
 			}
-
-			// Request AJAX and update HTML on complete.
-			fetchBlock( {
-				attributes,
-				context,
-				clientId,
-				query,
-				delay,
-			} ).done( ( { data } ) => {
-				if ( ! data ) {
-					this.setHtml(
-						`<div class="acf-block-fields acf-fields acf-empty-block-fields">${ acf.__(
-							'Error previewing block'
-						) }</div>`
-					);
-					return;
+			componentDidUpdate( e, t ) {
+				const { didCatch: n } = this.state,
+					{ resetKeys: r } = this.props;
+				var o, i;
+				n &&
+					null !== t.error &&
+					( function () {
+						let e =
+								arguments.length > 0 &&
+								void 0 !== arguments[ 0 ]
+									? arguments[ 0 ]
+									: [],
+							t =
+								arguments.length > 1 &&
+								void 0 !== arguments[ 1 ]
+									? arguments[ 1 ]
+									: [];
+						return (
+							e.length !== t.length ||
+							e.some( ( e, n ) => ! Object.is( e, t[ n ] ) )
+						);
+					} )( e.resetKeys, r ) &&
+					( null === ( o = ( i = this.props ).onReset ) ||
+						void 0 === o ||
+						o.call( i, {
+							next: r,
+							prev: e.resetKeys,
+							reason: 'keys',
+						} ),
+					this.setState( N ) );
+			}
+			render() {
+				const {
+						children: e,
+						fallbackRender: t,
+						FallbackComponent: n,
+						fallback: r,
+					} = this.props,
+					{ didCatch: o, error: i } = this.state;
+				let a = e;
+				if ( o ) {
+					const e = {
+						error: i,
+						resetErrorBoundary: this.resetErrorBoundary,
+					};
+					if ( 'function' == typeof t ) a = t( e );
+					else if ( n ) a = ( 0, F.createElement )( n, e );
+					else {
+						if ( void 0 === r ) throw i;
+						a = r;
+					}
 				}
-
-				let replaceHtml = data.preview.replaceAll(
-					data.clientId,
-					clientId
+				return ( 0, F.createElement )(
+					O.Provider,
+					{
+						value: {
+							didCatch: o,
+							error: i,
+							resetErrorBoundary: this.resetErrorBoundary,
+						},
+					},
+					a
 				);
-				if ( getBlockVersion( name ) == 1 ) {
-					replaceHtml =
-						'<div class="acf-block-preview">' +
-						replaceHtml +
-						'</div>';
-				}
-				acf.debug( 'fetch block render promise' );
-				this.setHtml(
-					acf.applyFilters(
-						'blocks/preview/render',
-						replaceHtml,
-						false
-					)
-				);
-				if ( data.validation ) {
-					this.setValidationErrors( data.validation.errors );
-				}
-				if ( this.isNotNewlyAdded() ) {
-					this.validate();
-				}
-			} );
-		}
-
-		validate() {
-			// Check we've got a block form for this instance.
-			const client = acf.blockInstances[ this.props.clientId ] || {};
-			const blockFormState = client.BlockForm || false;
-			if ( blockFormState ) {
-				super.displayValidation( blockFormState.$el );
 			}
 		}
-
-		componentDidAppend() {
-			super.componentDidAppend();
-			this.renderBlockPreviewEvent();
-		}
-
-		shouldComponentUpdate( nextProps, nextState ) {
-			const nextAttributes = nextProps.attributes;
-			const thisAttributes = this.props.attributes;
-
-			// Update preview if block data has changed.
-			if (
-				! compareObjects( nextAttributes, thisAttributes ) ||
-				! compareObjects( nextProps.context, this.props.context )
-			) {
-				let delay = 0;
-
-				// Delay fetch when editing className or anchor to simulate consistent logic to custom fields.
-				if ( nextAttributes.className !== thisAttributes.className ) {
-					delay = 300;
-				}
-				if ( nextAttributes.anchor !== thisAttributes.anchor ) {
-					delay = 300;
-				}
-
-				acf.debug(
-					'Triggering fetch from block preview shouldComponentUpdate'
+		const { Placeholder: P, Button: M, Icon: H } = wp.components,
+			L = ( 0, e.jsx )( 'svg', {
+				xmlns: 'http://www.w3.org/2000/svg',
+				viewBox: '0 0 24 24',
+				width: '24',
+				height: '24',
+				'aria-hidden': 'true',
+				focusable: 'false',
+				children: ( 0, e.jsx )( 'path', {
+					d: 'M19 8h-1V6h-5v2h-2V6H6v2H5c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-8c0-1.1-.9-2-2-2zm.5 10c0 .3-.2.5-.5.5H5c-.3 0-.5-.2-.5-.5v-8c0-.3.2-.5.5-.5h14c.3 0 .5.2.5.5v8z',
+				} ),
+			} ),
+			D = ( { setBlockFormModalOpen: t, blockLabel: n, error: r } ) => {
+				let o = null;
+				return (
+					r &&
+						( acf.debug( 'Block preview error:', r ),
+						( o = acf.__( 'Error previewing block v3' ) ) ),
+					( 0, e.jsx )( P, {
+						icon: ( 0, e.jsx )( H, { icon: L } ),
+						label: n,
+						instructions: o,
+						children: ( 0, e.jsx )( M, {
+							variant: 'primary',
+							onClick: () => {
+								t( ! 0 );
+							},
+							children: acf.__( 'Edit Block' ),
+						} ),
+					} )
 				);
-
-				this.fetch( {
-					attributes: nextAttributes,
-					context: nextProps.context,
-					delay,
+			},
+			$ = ( {
+				children: t,
+				blockPreviewHtml: n,
+				blockProps: r,
+				blockType: o,
+				setBlockFormModalOpen: i,
+			} ) =>
+				( 0, e.jsx )(
+					'div',
+					{
+						...r,
+						children: ( 0, e.jsx )( R, {
+							fallbackRender: ( { error: t } ) =>
+								( 0, e.jsx )( D, {
+									blockLabel:
+										o?.title || acf.__( 'ACF Block' ),
+									setBlockFormModalOpen: i,
+									error: t,
+								} ),
+							children: t,
+						} ),
+					},
+					n
+				),
+			{ useEffect: q, useRef: V } = wp.element,
+			{ Popover: U } = wp.components,
+			z = ( {
+				children: t,
+				className: n,
+				anchor: r,
+				placement: o,
+				onClose: i,
+				focusOnMount: a,
+				variant: s,
+				animate: l = ! 1,
+				gutenbergIframeOrDocument: c,
+				hidePrimaryBlockToolbar: d = ! 1,
+			} ) => {
+				const u = V();
+				return (
+					q( () => {
+						const e = ( e ) => {
+								'Escape' === e.key && i( e );
+							},
+							t = ( e ) => {
+								! r ||
+									e?.key ||
+									u?.current?.contains( e.target ) ||
+									e.target === r ||
+									( i( e ) &&
+										( c.removeEventListener(
+											'mousedown',
+											t
+										),
+										document.removeEventListener(
+											'mousedown',
+											t
+										) ) );
+							};
+						return (
+							setTimeout( () => {
+								document.addEventListener( 'keydown', e ),
+									c.addEventListener( 'mousedown', t ),
+									document.addEventListener( 'mousedown', t );
+							} ),
+							() => {
+								document.removeEventListener( 'keydown', e ),
+									c.removeEventListener( 'mousedown', t ),
+									document.removeEventListener(
+										'mousedown',
+										t
+									);
+							}
+						);
+					}, [] ),
+					( 0, e.jsx )( e.Fragment, {
+						children: ( 0, e.jsxs )( U, {
+							ref: u,
+							style: {
+								position: 'absolute',
+								top: 200,
+								zIndex: 59899,
+							},
+							className: n,
+							anchor: r,
+							focusOnMount: a,
+							placement: o,
+							variant: s,
+							animate: l,
+							children: [
+								d &&
+									( 0, e.jsx )( 'style', {
+										children:
+											'\n\t\t\t\t\t.components-popover.block-editor-block-popover.block-editor-block-list__block-popover{\n\t\t\t\t\t\tdisplay: none!important;\n\t\t\t\t\t}\n\t\t\t\t',
+									} ),
+								t,
+							],
+						} ),
+					} )
+				);
+			},
+			{ useState: W, useRef: J } = wp.element,
+			{ ToolbarGroup: X, ToolbarButton: Y, Modal: G } = wp.components,
+			{ BlockControls: K } = wp.blockEditor,
+			Q = ( {
+				blockToolbarFields: t,
+				blockFieldInfo: n,
+				setCurrentBlockFormContainer: r,
+				gutenbergIframeOrDocument: o,
+				setBlockFormModalOpen: i,
+				blockFormModalOpen: a,
+			} ) => {
+				const [ s, l ] = W( null ),
+					[ c, d ] = W(),
+					[ u, p ] = W( ! 0 ),
+					f = J();
+				function h( e ) {
+					if ( ! e ) return '';
+					if ( ! n ) return '';
+					const t = n.find( ( t ) => t.name === e );
+					return t?.type.replace( '_', '-' );
+				}
+				function m( e ) {
+					return e && n ? n.find( ( t ) => t.name === e ) : '';
+				}
+				function b( e ) {
+					if ( ! e ) return '';
+					if ( ! n ) return '';
+					const t = n.find( ( t ) => t.name === e );
+					return t ? t.label : '';
+				}
+				return ( 0, e.jsxs )( K, {
+					children: [
+						( 0, e.jsx )( X, {
+							children: ( 0, e.jsx )( Y, {
+								className:
+									'components-icon-button components-toolbar__control',
+								label: acf.__( 'Edit Block' ),
+								icon: 'edit',
+								onClick: () => {
+									i( ! 0 );
+								},
+								isPressed: a,
+							} ),
+						} ),
+						t.length > 0 &&
+							( 0, e.jsxs )( X, {
+								children: [
+									( function () {
+										let t = `[data-name="${ s }"]{ display: block!important; }`;
+										return ( 0, e.jsx )( 'style', {
+											children: t,
+										} );
+									} )(),
+									t &&
+										t.map( ( t ) => {
+											let n = '',
+												r = null,
+												o = null;
+											return (
+												'object' == typeof t
+													? ( ( n = t.fieldName
+															? t.fieldName
+															: index ),
+													  ( r = t.fieldIcon
+															? window.atob(
+																	t.fieldIcon
+															  )
+															: null ),
+													  ( o = t.fieldLabel
+															? t.fieldLabel
+															: n ) )
+													: ( n = t ),
+												( 0, e.jsx )(
+													Y,
+													{
+														icon: r
+															? ( 0, e.jsx )(
+																	'i',
+																	{
+																		dangerouslySetInnerHTML:
+																			{
+																				__html: r,
+																			},
+																	}
+															  )
+															: ( 0, e.jsx )(
+																	'i',
+																	{
+																		className: `field-type-icon field-type-icon-${ h(
+																			n
+																		) }`,
+																	}
+															  ),
+														label: o || b( n ),
+														isPressed: n === s,
+														ref: n === s ? d : null,
+														onMouseDown: () => {
+															s === n
+																? l( null )
+																: ( l( null ),
+																  setTimeout(
+																		() => {
+																			const e =
+																				m(
+																					n
+																				);
+																			'flexible_content' ===
+																				e.type ||
+																			'repeater' ===
+																				e.type
+																				? p(
+																						! 1
+																				  )
+																				: p(
+																						! 0
+																				  ),
+																				l(
+																					n
+																				);
+																		}
+																  ) );
+														},
+													},
+													n
+												)
+											);
+										} ),
+									s &&
+										c &&
+										u &&
+										( 0, e.jsx )(
+											z,
+											{
+												focusOnMount: ! 1,
+												className:
+													'acf-inline-fields-popover',
+												anchor: c,
+												animate: ! 0,
+												onClose: ( e ) =>
+													! (
+														( 'Escape' !== e.key &&
+															( e?.target.closest(
+																'.media-modal'
+															) ||
+																e?.target.closest(
+																	'.acf-tooltip'
+																) ||
+																( e?.target &&
+																	f?.current &&
+																	f?.current.contains(
+																		e.target
+																	) ) ||
+																( c?.current &&
+																	c?.current.contains(
+																		e?.target
+																	) ) ) ) ||
+														( l( null ), 0 )
+													),
+												variant: 'unstyled',
+												gutenbergIframeOrDocument: o,
+												children: ( 0, e.jsx )( 'div', {
+													ref: f,
+													children: ( 0, e.jsx )(
+														'div',
+														{
+															className:
+																'acf-inline-fields-popover-inner',
+															style: {
+																minWidth:
+																	'300px',
+															},
+															ref: r,
+														}
+													),
+												} ),
+											},
+											c
+										),
+									s &&
+										c &&
+										! u &&
+										( 0, e.jsx )( G, {
+											className: 'acf-block-form-modal',
+											isFullScreen: ! 0,
+											title: m( s ).label,
+											onRequestClose: () => {
+												l( null );
+											},
+											children: ( 0, e.jsx )( 'div', {
+												ref: f,
+												children: ( 0, e.jsx )( 'div', {
+													className:
+														'acf-inline-fields-popover-inner',
+													style: {
+														minWidth: '300px',
+													},
+													ref: r,
+												} ),
+											} ),
+										} ),
+								],
+							} ),
+					],
 				} );
-			}
-			return super.shouldComponentUpdate( nextProps, nextState );
-		}
-
-		renderBlockPreviewEvent() {
-			// Extract props.
-			const { attributes, name } = this.props;
-			const { $el, ref } = this.state;
-			var blockElement;
-
-			// Generate action friendly type.
-			const type = attributes.name.replace( 'acf/', '' );
-
-			if ( ref && ref.current ) {
-				// We've got a react ref from a JSX container. Use the parent as the blockElement
-				blockElement = $( ref.current ).parent();
-			} else if ( getBlockVersion( name ) == 1 ) {
-				blockElement = $el;
-			} else {
-				blockElement = $el.parents( '.acf-block-preview' );
-			}
-
-			// Do action.
-			acf.doAction( 'render_block_preview', blockElement, attributes );
-			acf.doAction(
-				`render_block_preview/type=${ type }`,
-				blockElement,
-				attributes
-			);
-		}
-
-		componentDidRemount() {
-			super.componentDidRemount();
-
-			acf.debug(
-				'Checking if fetch is required in BlockPreview componentDidRemount',
-				Object.assign( {}, this.state.prevAttributes ),
-				Object.assign( {}, this.props.attributes ),
-				Object.assign( {}, this.state.prevContext ),
-				Object.assign( {}, this.props.context )
-			);
-
-			// Update preview if data has changed since last render (changing from "edit" to "preview").
-			if (
-				! compareObjects(
-					this.state.prevAttributes,
-					this.props.attributes
-				) ||
-				! compareObjects( this.state.prevContext, this.props.context )
-			) {
-				acf.debug(
-					'Triggering block preview fetch from componentDidRemount'
+			},
+			{
+				useState: Z,
+				useEffect: ee,
+				useRef: te,
+				useMemo: ne,
+			} = wp.element,
+			{
+				Toolbar: re,
+				ToolbarGroup: oe,
+				ToolbarButton: ie,
+				Modal: ae,
+			} = wp.components,
+			se = ( {
+				blockIcon: t,
+				blockFieldInfo: n,
+				setInlineEditingToolbarHasFocus: r,
+				currentContentEditableElement: o,
+				currentInlineEditingElement: i,
+				currentInlineEditingElementUid: a,
+				gutenbergIframeOrDocument: s,
+				setCurrentBlockFormContainer: l,
+				contentEditableChangeInProgress: c,
+			} ) => {
+				const [ d, u ] = Z( null ),
+					[ p, f ] = Z(),
+					[ h, m ] = Z(),
+					[ b, g ] = Z( ! 0 ),
+					k = te(),
+					v = i ? i.getAttribute( 'data-acf-inline-fields' ) : null;
+				let y = [];
+				try {
+					y = JSON.parse( v );
+				} catch ( e ) {
+					acf.debug(
+						'Inline fields were not a properly formatted JSON array',
+						v
+					);
+				}
+				function x( e ) {
+					if ( ! e ) return '';
+					if ( ! n ) return '';
+					const t = n.find( ( t ) => t.name === e );
+					return t?.type.replace( '_', '-' );
+				}
+				function w( e ) {
+					if ( ! e ) return '';
+					if ( ! n ) return '';
+					const t = n.find( ( t ) => t.name === e );
+					return t ? t.label : '';
+				}
+				ee( () => {
+					u( null );
+				}, [ c ] );
+				const E = ne(
+						() =>
+							( function () {
+								let n =
+									o && ! i
+										? o.getAttribute(
+												'data-acf-toolbar-icon'
+										  )
+										: null;
+								if (
+									( ! n &&
+										i &&
+										( n = i
+											? i.getAttribute(
+													'data-acf-toolbar-icon'
+											  )
+											: null ),
+									n &&
+										( n = ( 0, e.jsx )( 'i', {
+											dangerouslySetInnerHTML: {
+												__html: n,
+											},
+										} ) ),
+									! n && o && ! i )
+								) {
+									const t = o.getAttribute(
+										'data-acf-inline-contenteditable-field-slug'
+									);
+									n = ( 0, e.jsx )( 'i', {
+										className: `field-type-icon field-type-icon-${ x(
+											t
+										) }`,
+									} );
+								}
+								return (
+									n ||
+										( n = React.isValidElement( t )
+											? t
+											: ( 0, e.jsx )( 'span', {
+													className: `dashicon dashicons dashicons-${ t }`,
+											  } ) ),
+									n
+								);
+							} )(),
+						[ n, o, i ]
+					),
+					_ = ne(
+						() =>
+							( function () {
+								let e;
+								if ( o && ! i ) {
+									const t = o.getAttribute(
+										'data-acf-toolbar-title'
+									);
+									if ( t ) return t;
+									e = o.getAttribute(
+										'data-acf-inline-contenteditable-field-slug'
+									);
+								} else if ( i ) {
+									const t = i.getAttribute(
+										'data-acf-toolbar-title'
+									);
+									if ( t ) return t;
+									if ( y.length > 1 )
+										return {
+											A: 'Link',
+											DIV: 'Division',
+											P: 'Paragraph',
+											SPAN: 'Span',
+											INPUT: 'Input',
+											BUTTON: 'Button',
+											IMG: 'Image',
+											UL: 'Unordered List',
+											OL: 'Ordered List',
+											LI: 'List Item',
+											H1: 'Heading 1',
+											H2: 'Heading 2',
+											H3: 'Heading 3',
+											H4: 'Heading 4',
+											H5: 'Heading 5',
+											H6: 'Heading 6',
+											TABLE: 'Table',
+											TR: 'Table Row',
+											TD: 'Table Cell',
+											TH: 'Table Header',
+											FORM: 'Form',
+											TEXTAREA: 'Text Area',
+											SELECT: 'Select',
+											OPTION: 'Option',
+										}[ i.tagName ];
+									e =
+										'object' == typeof y[ 0 ]
+											? y[ 0 ].fieldName
+											: y[ 0 ];
+								}
+								return w( e );
+							} )(),
+						[ n, o, i ]
+					);
+				return ( 0, e.jsxs )( e.Fragment, {
+					children: [
+						d &&
+							h &&
+							b &&
+							a &&
+							( 0, e.jsx )(
+								z,
+								{
+									focusOnMount: ! 1,
+									className: 'acf-inline-fields-popover',
+									anchor: h,
+									onClose: ( e ) =>
+										'Escape' === e.key
+											? ( u( null ), ! 0 )
+											: ! (
+													( e?.target &&
+														k?.current &&
+														k?.current.contains(
+															e.target
+														) ) ||
+													( h?.current &&
+														h?.current.contains(
+															e?.target
+														) )
+											  ) && void 0,
+									variant: i ? 'toolbar' : 'unstyled',
+									gutenbergIframeOrDocument: s,
+									hidePrimaryBlockToolbar: ! 0,
+									animate: ! 0,
+									children: ( 0, e.jsx )( 'div', {
+										ref: k,
+										onClick: () => {
+											r( ! 0 );
+										},
+										children: ( 0, e.jsx )( 'div', {
+											className:
+												'acf-inline-fields-popover-inner',
+											style: {
+												minWidth: p?.popoverMinWidth
+													? p?.popoverMinWidth
+													: '300px',
+											},
+											ref: l,
+										} ),
+									} ),
+								},
+								d || null
+							),
+						d &&
+							h &&
+							! b &&
+							a &&
+							( 0, e.jsx )( ae, {
+								className: 'acf-block-form-modal',
+								isFullScreen: ! 0,
+								title: ( ( C = d ),
+								C && n ? n.find( ( e ) => e.name === C ) : '' )
+									.label,
+								onRequestClose: () => {
+									u( null );
+								},
+								children: ( 0, e.jsx )( 'div', {
+									ref: k,
+									onClick: () => {
+										r( ! 0 );
+									},
+									children: ( 0, e.jsx )( 'div', {
+										className:
+											'acf-inline-fields-popover-inner',
+										style: {
+											minWidth: p?.popoverMinWidth
+												? p?.popoverMinWidth
+												: '300px',
+										},
+										ref: l,
+									} ),
+								} ),
+							} ),
+						( 0, e.jsx )( re, {
+							orientation: 'horizontal',
+							className:
+								'components-accessible-toolbar block-editor-block-contextual-toolbar',
+							style: { width: 'max-content' },
+							children: ( 0, e.jsxs )( 'div', {
+								className: 'block-editor-block-toolbar',
+								children: [
+									( 0, e.jsx )( oe, {
+										style: { alignItems: 'center' },
+										children: ( 0, e.jsxs )( 'div', {
+											className:
+												'acf-blocks-toolbar-icon components-toolbar-group block-editor-block-toolbar__block-controls',
+											label: _,
+											children: [
+												E,
+												( 0, e.jsx )( 'span', {
+													children: _,
+												} ),
+											],
+										} ),
+									} ),
+									( 0, e.jsx )( oe, {
+										children: ( function () {
+											if ( ! y || 0 === y.length )
+												return '';
+											let t = [];
+											return (
+												( t = y.map( ( t, n ) => {
+													let o = '',
+														i = null,
+														a = null;
+													return (
+														'object' == typeof t
+															? ( ( o =
+																	t.fieldName
+																		? t.fieldName
+																		: n ),
+															  ( i = t.fieldIcon
+																	? ( 0,
+																	  e.jsx )(
+																			'i',
+																			{
+																				dangerouslySetInnerHTML:
+																					{
+																						__html: window.atob(
+																							t.fieldIcon
+																						),
+																					},
+																			}
+																	  )
+																	: null ),
+															  ( a = t.fieldLabel
+																	? t.fieldLabel
+																	: o ) )
+															: ( o = t ),
+														! i &&
+															t?.useExpandedEditor &&
+															( i = 'edit' ),
+														( 0, e.jsx )(
+															ie,
+															{
+																disabled: c,
+																className:
+																	'acf-toolbar-button',
+																icon:
+																	i ||
+																	( 0,
+																	e.jsx )(
+																		'i',
+																		{
+																			className: `field-type-icon field-type-icon-${ x(
+																				o
+																			) }`,
+																		}
+																	),
+																label:
+																	a || w( o ),
+																isPressed:
+																	o === d,
+																ref:
+																	o === d
+																		? m
+																		: null,
+																onClick: () => {
+																	r( ! 0 ),
+																		d === o
+																			? u(
+																					null
+																			  )
+																			: ( g(
+																					! t?.useExpandedEditor
+																			  ),
+																			  u(
+																					o
+																			  ),
+																			  f(
+																					t
+																			  ) );
+																},
+															},
+															o
+														)
+													);
+												} ) ),
+												t
+											);
+										} )(),
+									} ),
+								],
+							} ),
+						} ),
+						( function () {
+							let t = `[data-name="${ d }"]{ display: block!important; }`;
+							return ( 0, e.jsx )( 'style', { children: t } );
+						} )(),
+					],
+				} );
+				var C;
+			},
+			{
+				useState: le,
+				useEffect: ce,
+				useRef: de,
+				createPortal: ue,
+				useMemo: pe,
+			} = wp.element,
+			{
+				InspectorControls: fe,
+				useBlockProps: he,
+				useBlockEditContext: me,
+			} = wp.blockEditor,
+			{
+				ToolbarGroup: be,
+				ToolbarButton: ge,
+				Placeholder: ke,
+				Spinner: ve,
+				Modal: ye,
+				Button: xe,
+				PanelBody: we,
+			} = wp.components,
+			Ee = ( t ) => {
+				const {
+						attributes: n,
+						setAttributes: i,
+						context: a,
+						isSelected: s,
+						$: c,
+						blockType: d,
+					} = t,
+					u = d.validate,
+					{ clientId: p } = me(),
+					[ f, h ] = le( null ),
+					[ m, b ] = le( '' ),
+					[ g, k ] = le( '' ),
+					v = pe( () => ue( l( n, a ), p, s ), [] ),
+					[ y, _ ] = le( () =>
+						v?.html
+							? acf.applyFilters(
+									'blocks/preview/render',
+									v.html,
+									! 0
+							  )
+							: 'acf-block-preview-loading'
+					),
+					[ j, I ] = le( () => {
+						var e;
+						return null !== ( e = v?.validation?.errors ) &&
+							void 0 !== e
+							? e
+							: null;
+					} ),
+					[ S, A ] = le( v?.fields ? v.fields : null ),
+					[ T, B ] = le( null ),
+					[ F, O ] = le( ! 1 ),
+					[ N, R ] = le(),
+					[ P, M ] = le( ! 1 ),
+					[ H, L ] = le( ! 1 ),
+					D = de( null ),
+					$ = de( null ),
+					[ q, V ] = le( [] ),
+					[ U, z ] = le( null ),
+					[ W, J ] = le( null ),
+					[ X, Y ] = le( null ),
+					[ G, K ] = le( ! 1 ),
+					[ Q, Z ] = le(
+						( function () {
+							const e = document.querySelector(
+								'[name="editor-canvas"]'
+							);
+							return e
+								? e.contentDocument || e.contentWindow.document
+								: document;
+						} )()
+					),
+					[ ee, te ] = le(),
+					[ ne, re ] = le( '' ),
+					oe = de( null ),
+					ie = ( function () {
+						const [ e, t ] = x( () => C() );
+						return (
+							w( () => {
+								const e = E( () => {
+									t( C() );
+								} );
+								return () => e();
+							}, [] ),
+							e
+						);
+					} )();
+				ce( () => {
+					s || ( J( null ), z( null ), Y( null ), g && _( g ) );
+				}, [ s ] ),
+					ce( () => {
+						if ( Q ) {
+							let e = Q.getElementById( 'acf-dynamic-styles' );
+							e ||
+								( ( e = document.createElement( 'style' ) ),
+								( e.id = 'acf-dynamic-styles' ),
+								Q.head.appendChild( e ) ),
+								te( e );
+						}
+					}, [ Q ] );
+				const ae = pe( () => {
+					const { hasAcfError: e, ...t } = n;
+					return t;
+				}, [ n ] );
+				function se( e, t ) {
+					if ( ! D?.current || ! t ) return;
+					const n = D.current.querySelector( `[data-name=${ t }]` );
+					if ( ! n ) return;
+					const r = n.attributes.getNamedItem( 'data-key' )?.value;
+					if ( ! r ) return;
+					const o = D.current.querySelector(
+						`[name="acf-block_${ p }[${ r }]"`
+					);
+					if ( ! o ) return;
+					e && L( ! 0 ), K( ! 1 ), ( o.value = e );
+					const i = c( D?.current ),
+						a = acf.serialize( i, `acf-block_${ p }` );
+					a ? h( JSON.stringify( a ) ) : L( ! 1 );
+				}
+				function ue( e, t, n ) {
+					if ( n ) return ! 1;
+					if (
+						( acf.debug( 'Preload check', e, t ),
+						( ( e ) => {
+							const t = wp.data
+								.select( 'core/block-editor' )
+								.getBlockParents( e );
+							return wp.data
+								.select( 'core/block-editor' )
+								.getBlocksByClientId( t )
+								.filter( ( e ) => 'core/query' === e.name )
+								.length;
+						} )( t ) )
+					)
+						return ! 1;
+					const r = acf.get( 'preloadedBlocks' );
+					return r && r[ e ]
+						? ( ( r[ e ].html = r[ e ].html.replaceAll( e, t ) ),
+						  r[ e ]?.validation &&
+								r[ e ]?.validation.errors &&
+								( r[ e ].validation.errors = r[
+									e
+								]?.validation.errors.map(
+									( n ) => (
+										( n.input = n.input.replaceAll(
+											e,
+											t
+										) ),
+										n
+									)
+								) ),
+						  acf.debug( 'Preload successful', r[ e ] ),
+						  r[ e ] )
+						: ( acf.debug( 'Preload failed: not preloaded.' ),
+						  ! 1 );
+				}
+				function fe( {
+					theAttributes: e,
+					theClientId: t,
+					theContext: n,
+					isSelected: i,
+				} ) {
+					if ( ! e ) return;
+					N && N.abort();
+					const s = ue( l( e, a ), t, i );
+					if ( s )
+						return (
+							X ||
+								( s.html
+									? _(
+											acf.applyFilters(
+												'blocks/preview/render',
+												s.html,
+												! 0
+											)
+									  )
+									: _(
+											acf.applyFilters(
+												'blocks/preview/render',
+												'acf-block-preview-no-html',
+												! 0
+											)
+									  ),
+								s?.blockToolbarFields &&
+									V( s?.blockToolbarFields ),
+								s?.fields && A( s.fields ) ),
+							void ( s?.validation &&
+							! s.validation.valid &&
+							s.validation.errors
+								? I( s.validation.errors )
+								: I( null ) )
+						);
+					const d = { preview: ! 0, form: ! 0, validate: ! 0 };
+					m || ( d.validate = ! 1 ), u || ( d.validate = ! 1 );
+					const p = { ...e };
+					r( 'acf-fetching-block' );
+					const f = c
+						.ajax( {
+							url: acf.get( 'ajaxurl' ),
+							dataType: 'json',
+							type: 'post',
+							cache: ! 1,
+							data: acf.prepareForAjax( {
+								action: 'acf/ajax/fetch-block',
+								block: JSON.stringify( p ),
+								clientId: t,
+								context: JSON.stringify( n ),
+								query: d,
+							} ),
+						} )
+						.done( ( e ) => {
+							L( ! 1 ),
+								o( 'acf-fetching-block' ),
+								A( e.data.fields ),
+								b( e.data.form );
+							const t = acf.applyFilters(
+								'blocks/preview/render',
+								e.data.preview
+									? e.data.preview
+									: 'acf-block-preview-no-html',
+								! 1
+							);
+							k( t ),
+								e.data?.validation &&
+								! e.data.validation.valid &&
+								e.data.validation.errors
+									? I( e.data.validation.errors )
+									: I( null ),
+								e.data?.blockToolbarFields &&
+									V( e.data?.blockToolbarFields ),
+								M( ! 0 );
+						} )
+						.fail( function () {
+							M( ! 0 ), L( ! 1 ), o( 'acf-fetching-block' );
+						} );
+					R( f );
+				}
+				return (
+					ce( () => {
+						function e() {
+							O( ! 0 ),
+								window.removeEventListener( 'click', e ),
+								window.removeEventListener( 'keydown', e );
+						}
+						return (
+							window.addEventListener( 'click', e ),
+							window.addEventListener( 'keydown', e ),
+							() => {
+								window.removeEventListener( 'click', e ),
+									window.removeEventListener( 'keydown', e );
+							}
+						);
+					}, [] ),
+					ce( () => {
+						i( j ? { hasAcfError: ! 0 } : { hasAcfError: ! 1 } );
+					}, [ j, i ] ),
+					ce( () => {
+						const e = ( e ) => {
+							p === e.detail.acfBlockWithValidationErrors &&
+								( r( p ), B( ! 0 ), J( null ) );
+						};
+						return (
+							document.addEventListener(
+								'acf/block/has-error',
+								e
+							),
+							() => {
+								document.removeEventListener(
+									'acf/block/has-error',
+									e
+								),
+									o( p );
+							}
+						);
+					}, [] ),
+					ce(
+						() => (
+							clearTimeout( oe.current ),
+							r( 'acf-fetching-block' ),
+							( oe.current = setTimeout( () => {
+								! ( function () {
+									const e = JSON.parse( f );
+									if ( ! e )
+										return (
+											fe( {
+												theAttributes: ae,
+												theClientId: p,
+												theContext: a,
+												isSelected: s,
+											} ),
+											void o( 'acf-fetching-block' )
+										);
+									if ( f === JSON.stringify( ae.data ) )
+										return (
+											fe( {
+												theAttributes: ae,
+												theClientId: p,
+												theContext: a,
+												isSelected: s,
+											} ),
+											void o( 'acf-fetching-block' )
+										);
+									const t = { ...n, data: { ...e } };
+									i( t );
+								} )();
+							}, 200 ) ),
+							() => {
+								clearTimeout( oe.current ),
+									o( 'acf-fetching-block' );
+							}
+						),
+						[ f, ae ]
+					),
+					ce( () => {
+						if ( $.current && y ) {
+							const e = n.name.replace( 'acf/', '' ),
+								t = c( $.current );
+							if (
+								( acf.doAction( 'render_block_preview', t, n ),
+								acf.doAction(
+									`render_block_preview/type=${ e }`,
+									t,
+									n
+								),
+								W )
+							) {
+								const e = $?.current.querySelector(
+									`[data-acf-inline-fields-uid="${ W }"]`
+								);
+								z( e );
+							}
+						}
+					}, [ y ] ),
+					ce( () => {
+						if ( ( X && ! G ) || ! g ) return;
+						const e = document.querySelector(
+							'.acf-inline-editing-toolbar'
+						);
+						e &&
+							e.style &&
+							e.style.cssText &&
+							re(
+								e.style.cssText.replaceAll( ';', '!important;' )
+							),
+							setTimeout( () => {
+								_( g ),
+									setTimeout( () => {
+										re( null );
+									}, 0 );
+							}, 0 );
+					}, [ g ] ),
+					ce( () => {
+						const e = new MutationObserver( ( e ) => {
+							for ( const t of e )
+								if ( 'characterData' === t.type ) {
+									let e = t.target.parentNode;
+									const n = e?.closest( '[data-block]' ),
+										r = n?.getAttribute( 'data-block' );
+									if ( ! e || ! n || r !== p ) return;
+									if (
+										( e &&
+											! e.hasAttribute(
+												'data-acf-inline-contenteditable'
+											) &&
+											( e = e.closest(
+												'[data-acf-inline-contenteditable]'
+											) ),
+										e &&
+											e.hasAttribute(
+												'data-acf-inline-contenteditable'
+											) )
+									) {
+										const t = e.attributes.getNamedItem(
+											'data-acf-inline-contenteditable-field-slug'
+										).value;
+										let n = e.innerHTML.trim();
+										n || ( n = '' ), se( n, t );
+									}
+								} else {
+									const e = t.target.closest(
+											'[data-acf-inline-contenteditable]'
+										),
+										n = e?.closest( '[data-block]' );
+									if (
+										! e ||
+										! n ||
+										n.getAttribute( 'data-block' ) !== p
+									)
+										return;
+									if ( e ) {
+										const t = e.attributes.getNamedItem(
+											'data-acf-inline-contenteditable-field-slug'
+										).value;
+										let n = e.innerHTML.trim();
+										( ! n ||
+											( 0 ===
+												e.textContent.trim().length &&
+												1 === e.children.length &&
+												e.firstElementChild &&
+												'BR' ===
+													e.firstElementChild
+														.nodeName ) ) &&
+											( ( e.innerHTML = '' ),
+											( n = '' ) ),
+											se( n, t );
+									}
+								}
+						} );
+						return (
+							e.observe( Q, {
+								attributes: ! 0,
+								childList: ! 0,
+								subtree: ! 0,
+								characterData: ! 0,
+								attributeFilter: [
+									'data-acf-inline-contenteditable',
+								],
+							} ),
+							() => {
+								e.disconnect();
+							}
+						);
+					}, [ y ] ),
+					( 0, e.jsx )( _e, {
+						...t,
+						validationErrors: j,
+						showValidationErrors: T,
+						theSerializedAcfData: f,
+						setTheSerializedAcfData: h,
+						acfFormRef: D,
+						blockFormHtml: m,
+						blockPreviewHtml: y,
+						blockFetcher: fe,
+						userHasInteractedWithForm: F,
+						setUserHasInteractedWithForm: O,
+						previewRef: $,
+						setInlineEditingToolbarHasFocus: K,
+						currentContentEditableElement: X,
+						setCurrentContentEditableElement: Y,
+						currentInlineEditingElement: U,
+						setCurrentInlineEditingElement: z,
+						currentInlineEditingElementUid: W,
+						onNewInlineEditingElementSelected: function ( e ) {
+							setTimeout( () => {
+								J( e );
+								const t = $?.current.querySelector(
+									`[data-acf-inline-fields-uid="${ e }"]`
+								);
+								z( t ),
+									t &&
+										t.scrollIntoView( {
+											behavior: 'smooth',
+											block: 'nearest',
+										} );
+							}, 1 );
+						},
+						onContentEditableChange: se,
+						onNewContentEditableElementSelected: function ( e ) {
+							if ( e ) {
+								const t = $?.current.querySelector(
+									`[data-acf-inline-contenteditable-field-slug="${ e }"]`
+								);
+								Y( t );
+							} else Y( null );
+						},
+						gutenbergIframeOrDocument: Q,
+						acfDynamicStylesElement: ee,
+						blockFieldInfo: S,
+						blockEditorInspectorSidebarOpen: ie,
+						blockToolbarFields: q,
+						hasFetchedOnce: P,
+						contentEditableChangeInProgress: H,
+						freezeInlineToolbarDuringReRender: ne,
+					} )
 				);
-				this.fetch();
+			};
+		function _e( t ) {
+			const {
+					$: n,
+					isSelected: r,
+					blockType: o,
+					attributes: a,
+					context: s,
+					validationErrors: l,
+					showValidationErrors: c,
+					theSerializedAcfData: d,
+					setTheSerializedAcfData: u,
+					acfFormRef: p,
+					blockFormHtml: f,
+					blockPreviewHtml: m,
+					blockFetcher: b,
+					userHasInteractedWithForm: g,
+					previewRef: k,
+					setInlineEditingToolbarHasFocus: v,
+					currentContentEditableElement: y,
+					setCurrentContentEditableElement: x,
+					currentInlineEditingElement: w,
+					currentInlineEditingElementUid: E,
+					setCurrentInlineEditingElement: _,
+					onNewInlineEditingElementSelected: C,
+					onContentEditableChange: j,
+					onNewContentEditableElementSelected: S,
+					gutenbergIframeOrDocument: A,
+					acfDynamicStylesElement: T,
+					blockFieldInfo: F,
+					blockEditorInspectorSidebarOpen: O,
+					blockToolbarFields: N,
+					hasFetchedOnce: R,
+					contentEditableChangeInProgress: P,
+					freezeInlineToolbarDuringReRender: M,
+				} = t,
+				{ clientId: H } = me(),
+				L = de(),
+				[ q, V ] = le( ! 1 ),
+				U = de(),
+				[ W, J ] = le( ! 1 ),
+				[ X, Y ] = le(),
+				[ G, K ] = le();
+			ce( () => {
+				let e = document.getElementById( 'invisible-acf-form-element' );
+				e ||
+					( ( e = document.createElement( 'div' ) ),
+					( e.id = 'invisible-acf-form-element' ),
+					( e.style.display = 'none' ),
+					document.body.appendChild( e ) ),
+					K( e );
+			}, [ O ] ),
+				ce( () => {
+					Y( W && U?.current ? U.current : O ? L.current : G );
+				}, [ W, U ] ),
+				ce( () => {
+					O ? W || Y( L.current ) : Y( G );
+				}, [ O, G ] ),
+				ce( () => {
+					r && L?.current && L.current
+						? V( ! 0 )
+						: r &&
+						  ! L?.current &&
+						  setTimeout( () => {
+								V( ! 0 );
+						  }, 1 );
+				}, [ r, L, L.current ] ),
+				ce( () => {
+					r && l && c && o?.hide_fields_in_sidebar && J( ! 0 );
+				}, [ r, c, l, o ] );
+			let Z = 'acf-block-component acf-block-body';
+			( Z += ' acf-block-preview' ),
+				l && c && ( Z += ' acf-block-has-validation-error' );
+			const ee = { ...he( { className: Z, ref: k } ) };
+			let te = O && L?.current ? L.current : G;
+			X && ( te = X );
+			let ne = null;
+			return (
+				w && y && ( ne = w ),
+				w && ! y && ( ne = w ),
+				! w && y && ( ne = y ),
+				ne?.isConnected || ( ne = null ),
+				( 0, e.jsxs )( e.Fragment, {
+					children: [
+						( 0, e.jsx )( Q, {
+							blockToolbarFields: N,
+							blockFieldInfo: F,
+							setCurrentBlockFormContainer: Y,
+							gutenbergIframeOrDocument: A,
+							setBlockFormModalOpen: J,
+							blockFormModalOpen: W,
+							invisibleBlockFormContainer: G,
+						} ),
+						( 0, e.jsxs )( fe, {
+							children: [
+								( 0, e.jsx )( we, {
+									children: ( 0, e.jsx )( xe, {
+										icon: 'edit',
+										className:
+											'acf-blocks-open-expanded-editor-btn',
+										variant: 'secondary',
+										onClick: () => {
+											J( ! 0 );
+										},
+										children: acf.__(
+											'Open Expanded Editor'
+										),
+									} ),
+								} ),
+								( 0, e.jsx )( I, {
+									inspectorBlockFormRef: L,
+									setCurrentBlockFormContainer: Y,
+								} ),
+							],
+						} ),
+						te &&
+							q &&
+							ue(
+								( 0, e.jsxs )( e.Fragment, {
+									children: [
+										( 0, e.jsx )( B, {
+											$: n,
+											clientId: H,
+											blockFormHtml: f,
+											onMount: () => {
+												R ||
+													b( {
+														theAttributes: a,
+														theClientId: H,
+														theContext: s,
+														isSelected: r,
+													} );
+											},
+											onChange: function ( e ) {
+												const t = acf.serialize(
+													e,
+													`acf-block_${ H }`
+												);
+												t && u( JSON.stringify( t ) );
+											},
+											validationErrors: l,
+											showValidationErrors: c,
+											acfFormRef: p,
+											blockFormPortalElement: te,
+											theSerializedAcfData: d,
+											userHasInteractedWithForm: g,
+											attributes: a,
+											hideFieldsInSidebar:
+												( o?.auto_inline_editing &&
+													void 0 ===
+														o?.hide_fields_in_sidebar &&
+													L.current === X ) ||
+												( o?.hide_fields_in_sidebar &&
+													L.current === X ),
+										} ),
+										M &&
+											( 0, e.jsx )( 'style', {
+												children: `.acf-inline-editing-toolbar{${ M }}`,
+											} ),
+									],
+								} ),
+								te
+							),
+						( 0, e.jsxs )( e.Fragment, {
+							children: [
+								T &&
+									E &&
+									ue(
+										( 0, e.jsx )( e.Fragment, {
+											children: `\n\t\t\t\t[data-acf-inline-fields-uid="${ E }"]{\n\t\t\t\t\toutline: 2px solid var( --wp-admin-theme-color );\n\t\t\t\t\toutline-offset: 2px;\n\t\t\t\t}\n\t\t\t`,
+										} ),
+										T
+									),
+								W &&
+									( 0, e.jsx )( ye, {
+										className: 'acf-block-form-modal',
+										isFullScreen: ! 0,
+										title: o.title,
+										onRequestClose: () => {
+											i( 'acf-fetching-block' ) ||
+												J( ! 1 );
+										},
+										isDismissible: ! 1,
+										headerActions: [
+											( 0, e.jsx )(
+												xe,
+												{
+													variant: 'primary',
+													disabled:
+														i(
+															'acf-fetching-block'
+														),
+													onClick: () => {
+														Y( null ), J( ! 1 );
+													},
+													children: acf.__( 'Done' ),
+												},
+												'done'
+											),
+										],
+										children: ( 0, e.jsx )( 'div', {
+											className:
+												'acf-modal-block-form-container',
+											ref: U,
+										} ),
+									} ),
+							],
+						} ),
+						( 0, e.jsxs )( e.Fragment, {
+							children: [
+								ne &&
+									( 0, e.jsx )(
+										z,
+										{
+											focusOnMount: ( () => {
+												const e =
+													document.activeElement;
+												return (
+													e && e.isContentEditable,
+													! 1
+												);
+											} )(),
+											variant: 'unstyled',
+											anchor: ne,
+											className:
+												'acf-inline-editing-toolbar block-editor-block-list__block-popover',
+											placement: 'top-start',
+											onClose: ( e ) => {
+												if (
+													'Escape' !== e.key &&
+													e.target.closest(
+														'.acf-toolbar-button'
+													)
+												)
+													return ! 1;
+												if ( 'Escape' === e.key )
+													return (
+														! document.querySelector(
+															'.acf-inline-fields-popover-inner'
+														) &&
+														! y &&
+														( w && w.focus(),
+														x( null ),
+														_( null ),
+														! 0 )
+													);
+												if (
+													e.target.getAttribute(
+														'data-acf-inline-contenteditable'
+													)
+												)
+													return ! 1;
+												const t = e.target.closest(
+														'.acf-inline-fields-popover-inner'
+													),
+													n = e.target.closest(
+														'.components-modal__content'
+													);
+												return (
+													t ||
+														n ||
+														( x( null ),
+														_( null ) ),
+													! 0
+												);
+											},
+											gutenbergIframeOrDocument: A,
+											hidePrimaryBlockToolbar: ! 0,
+											children: ( 0, e.jsx )(
+												se,
+												{
+													blockIcon: o.icon,
+													blockFieldInfo: F,
+													acfFormRef: p,
+													setInlineEditingToolbarHasFocus:
+														v,
+													currentContentEditableElement:
+														y,
+													currentInlineEditingElement:
+														w,
+													currentInlineEditingElementUid:
+														E,
+													gutenbergIframeOrDocument:
+														A,
+													setCurrentBlockFormContainer:
+														Y,
+													contentEditableChangeInProgress:
+														P,
+												},
+												E
+											),
+										},
+										y
+									),
+								( 0, e.jsxs )( $, {
+									blockPreviewHtml: m,
+									blockProps: ee,
+									blockType: o,
+									setBlockFormModalOpen: J,
+									children: [
+										'acf-block-preview-no-html' === m
+											? ( 0, e.jsx )( D, {
+													setBlockFormModalOpen: J,
+													blockLabel: o.title,
+											  } )
+											: null,
+										'acf-block-preview-loading' === m &&
+											( 0, e.jsx )( ke, {
+												children: ( 0, e.jsx )(
+													ve,
+													{}
+												),
+											} ),
+										'acf-block-preview-loading' !== m &&
+											'acf-block-preview-no-html' !== m &&
+											m &&
+											h( m, C, j, S, F, n ),
+									],
+								} ),
+							],
+						} ),
+					],
+				} )
+			);
+		}
+		const Ce = ( e, t, n ) => ( ( e[ t ] = { type: n } ), e ),
+			je = ( e ) => {
+				const t = acf.get( 'rtl' ) ? 'right' : 'left';
+				return [ 'left', 'center', 'right' ].includes( e ) ? e : t;
+			},
+			{ Fragment: Ie, Component: Se } = wp.element,
+			{ BlockControls: Ae, AlignmentToolbar: Te } = wp.blockEditor,
+			Be = ( t, n ) => {
+				const r = je;
+				return (
+					( n.alignText = r( n.alignText ) ),
+					class extends Se {
+						render() {
+							const { attributes: n, setAttributes: o } =
+									this.props,
+								{ alignText: i } = n;
+							return ( 0, e.jsxs )( Ie, {
+								children: [
+									( 0, e.jsx )( Ae, {
+										group: 'block',
+										children: ( 0, e.jsx )( Te, {
+											value: r( i ),
+											onChange: function ( e ) {
+												o( { alignText: r( e ) } );
+											},
+										} ),
+									} ),
+									( 0, e.jsx )( t, { ...this.props } ),
+								],
+							} );
+						}
+					}
+				);
+			},
+			Fe = ( e ) =>
+				[ 'top', 'center', 'bottom' ].includes( e ) ? e : 'top',
+			Oe = ( e ) => {
+				if ( e ) {
+					const [ t, n ] = e.split( ' ' );
+					return `${ Fe( t ) } ${ je( n ) }`;
+				}
+				return 'center center';
+			},
+			{ Fragment: Ne, Component: Re } = wp.element,
+			{ BlockControls: Pe, BlockVerticalAlignmentToolbar: Me } =
+				wp.blockEditor,
+			He =
+				wp.blockEditor.__experimentalBlockAlignmentMatrixToolbar ||
+				wp.blockEditor.BlockAlignmentMatrixToolbar,
+			Le =
+				wp.blockEditor.__experimentalBlockAlignmentMatrixControl ||
+				wp.blockEditor.BlockAlignmentMatrixControl,
+			De = ( t, n ) => {
+				let r, o;
+				return (
+					'matrix' ===
+					( n.supports.align_content || n.supports.alignContent )
+						? ( ( r = Le || He ), ( o = Oe ) )
+						: ( ( r = Me ), ( o = Fe ) ),
+					void 0 === r
+						? t
+						: ( ( n.alignContent = o( n.alignContent ) ),
+						  class extends Re {
+								render() {
+									const { attributes: n, setAttributes: i } =
+											this.props,
+										{ alignContent: a } = n;
+									return ( 0, e.jsxs )( Ne, {
+										children: [
+											( 0, e.jsx )( Pe, {
+												group: 'block',
+												children: ( 0, e.jsx )( r, {
+													label: acf.__(
+														'Change content alignment'
+													),
+													value: o( a ),
+													onChange: function ( e ) {
+														i( {
+															alignContent:
+																o( e ),
+														} );
+													},
+												} ),
+											} ),
+											( 0, e.jsx )( t, {
+												...this.props,
+											} ),
+										],
+									} );
+								}
+						  } )
+				);
+			},
+			{ Fragment: $e, Component: qe } = wp.element,
+			{ BlockControls: Ve } = wp.blockEditor,
+			Ue =
+				wp.blockEditor.__experimentalBlockFullHeightAligmentControl ||
+				wp.blockEditor.__experimentalBlockFullHeightAlignmentControl ||
+				wp.blockEditor.BlockFullHeightAlignmentControl,
+			ze = ( t ) =>
+				Ue
+					? class extends qe {
+							render() {
+								const { attributes: n, setAttributes: r } =
+										this.props,
+									{ fullHeight: o } = n;
+								return ( 0, e.jsxs )( $e, {
+									children: [
+										( 0, e.jsx )( Ve, {
+											group: 'block',
+											children: ( 0, e.jsx )( Ue, {
+												isActive: o,
+												onToggle: function ( e ) {
+													r( { fullHeight: e } );
+												},
+											} ),
+										} ),
+										( 0, e.jsx )( t, { ...this.props } ),
+									],
+								} );
+							}
+					  }
+					: t;
+		( ( t, n ) => {
+			const { InnerBlocks: r } = wp.blockEditor,
+				{ Component: o } = wp.element,
+				{ createHigherOrderComponent: i } = wp.compose,
+				a = {};
+			function s( n ) {
+				const o = n.post_types || [];
+				if ( o.length ) {
+					o.push( 'wp_block' );
+					const e = acf.get( 'postType' );
+					if ( ! o.includes( e ) ) return ! 1;
+				}
+				if (
+					'string' == typeof n.icon &&
+					'<svg' === n.icon.substr( 0, 4 )
+				) {
+					const t = n.icon;
+					n.icon = ( 0, e.jsx )( 'div', {
+						dangerouslySetInnerHTML: { __html: t },
+					} );
+				}
+				n.icon || delete n.icon,
+					wp.blocks
+						.getCategories()
+						.filter( ( { slug: e } ) => e === n.category )
+						.pop() || ( n.category = 'common' ),
+					( n = acf.parseArgs( n, {
+						title: '',
+						name: '',
+						category: '',
+						api_version: 2,
+						acf_block_version: 3,
+					} ) );
+				for ( const e in n.attributes )
+					'default' in n.attributes[ e ] &&
+						0 === n.attributes[ e ].default.length &&
+						delete n.attributes[ e ].default;
+				n.supports.anchor &&
+					( n.attributes.anchor = { type: 'string' } ),
+					( n.attributes.hasAcfError = {
+						type: 'boolean',
+						default: ! 1,
+					} );
+				let i = Ee;
+				( n.supports.alignText || n.supports.align_text ) &&
+					( ( n.attributes = Ce(
+						n.attributes,
+						'align_text',
+						'string'
+					) ),
+					( i = Be( i, n ) ) ),
+					( n.supports.alignContent || n.supports.align_content ) &&
+						( ( n.attributes = Ce(
+							n.attributes,
+							'align_content',
+							'string'
+						) ),
+						( i = De( i, n ) ) ),
+					( n.supports.fullHeight || n.supports.full_height ) &&
+						( ( n.attributes = Ce(
+							n.attributes,
+							'full_height',
+							'boolean'
+						) ),
+						( i = ze( i ) ) ),
+					( n.edit = function ( r ) {
+						return ( 0, e.jsx )( i, { ...r, blockType: n, $: t } );
+					} ),
+					( n.save = () => ( 0, e.jsx )( r.Content, {} ) ),
+					( a[ n.name ] = n );
+				const s = wp.blocks.registerBlockType( n.name, n );
+				return (
+					s.attributes.anchor &&
+						( s.attributes.anchor = { type: 'string' } ),
+					s
+				);
 			}
-
-			// Fire the block preview event so blocks can reinit JS elements.
-			// React reusing DOM elements covers any potential race condition from the above fetch.
-			this.renderBlockPreviewEvent();
-		}
-	}
-
-	/**
-	 * Initializes ACF Blocks logic and registration.
-	 *
-	 * @since ACF 5.9.0
-	 */
-	function initialize() {
-		// Add support for WordPress versions before 5.2.
-		if ( ! wp.blockEditor ) {
-			wp.blockEditor = wp.editor;
-		}
-
-		// Register block types.
-		const blockTypes = acf.get( 'blockTypes' );
-		if ( blockTypes ) {
-			// Only register blocks with version <= 2 (v3+ blocks are registered separately).
-			blockTypes.forEach( ( blockType ) => {
-				parseInt( blockType.acf_block_version ) <= 2 &&
-					registerBlockType( blockType );
+			acf.addAction( 'prepare', function () {
+				wp.blockEditor || ( wp.blockEditor = wp.editor );
+				const e = acf.get( 'blockTypes' );
+				e &&
+					e.forEach( ( e ) => {
+						parseInt( e.acf_block_version ) >= 3 && s( e );
+					} );
 			} );
-		}
-	}
-
-	// Run the initialize callback during the "prepare" action.
-	// This ensures that all localized data is available and that blocks are registered before the WP editor has been instantiated.
-	acf.addAction( 'prepare', initialize );
-
-	/**
-	 * Returns a valid vertical alignment.
-	 *
-	 * @date	07/08/2020
-	 * @since	ACF 5.9.0
-	 *
-	 * @param	string align A vertical alignment.
-	 * @return	string
-	 */
-	function validateVerticalAlignment( align ) {
-		const ALIGNMENTS = [ 'top', 'center', 'bottom' ];
-		const DEFAULT = 'top';
-		return ALIGNMENTS.includes( align ) ? align : DEFAULT;
-	}
-
-	/**
-	 * Returns a valid horizontal alignment.
-	 *
-	 * @date	07/08/2020
-	 * @since	ACF 5.9.0
-	 *
-	 * @param	string align A horizontal alignment.
-	 * @return	string
-	 */
-	function validateHorizontalAlignment( align ) {
-		const ALIGNMENTS = [ 'left', 'center', 'right' ];
-		const DEFAULT = acf.get( 'rtl' ) ? 'right' : 'left';
-		return ALIGNMENTS.includes( align ) ? align : DEFAULT;
-	}
-
-	/**
-	 * Returns a valid matrix alignment.
-	 *
-	 * Written for "upgrade-path" compatibility from vertical alignment to matrix alignment.
-	 *
-	 * @date	07/08/2020
-	 * @since	ACF 5.9.0
-	 *
-	 * @param	string align A matrix alignment.
-	 * @return	string
-	 */
-	function validateMatrixAlignment( align ) {
-		const DEFAULT = 'center center';
-		if ( align ) {
-			const [ y, x ] = align.split( ' ' );
-			return `${ validateVerticalAlignment(
-				y
-			) } ${ validateHorizontalAlignment( x ) }`;
-		}
-		return DEFAULT;
-	}
-
-	/**
-	 * A higher order component adding alignContent editing functionality.
-	 *
-	 * @date	08/07/2020
-	 * @since	ACF 5.9.0
-	 *
-	 * @param	component OriginalBlockEdit The original BlockEdit component.
-	 * @param	object blockType The block type settings.
-	 * @return	component
-	 */
-	function withAlignContentComponent( OriginalBlockEdit, blockType ) {
-		// Determine alignment vars
-		let type =
-			blockType.supports.align_content || blockType.supports.alignContent;
-		let AlignmentComponent;
-		let validateAlignment;
-		switch ( type ) {
-			case 'matrix':
-				AlignmentComponent =
-					BlockAlignmentMatrixControl || BlockAlignmentMatrixToolbar;
-				validateAlignment = validateMatrixAlignment;
-				break;
-			default:
-				AlignmentComponent = BlockVerticalAlignmentToolbar;
-				validateAlignment = validateVerticalAlignment;
-				break;
-		}
-
-		// Ensure alignment component exists.
-		if ( AlignmentComponent === undefined ) {
-			console.warn(
-				`The "${ type }" alignment component was not found.`
+			const l = i(
+				( t ) =>
+					class extends o {
+						constructor( e ) {
+							super( e );
+							const { name: t, attributes: r } = this.props,
+								o = ( function ( e ) {
+									return a[ e ] || ! 1;
+								} )( t );
+							if ( ! o ) return;
+							Object.keys( r ).forEach( ( e ) => {
+								'' === r[ e ] && delete r[ e ];
+							} );
+							const i = {
+								full_height: 'fullHeight',
+								align_content: 'alignContent',
+								align_text: 'alignText',
+							};
+							Object.keys( i ).forEach( ( e ) => {
+								r[ e ] !== n
+									? ( r[ i[ e ] ] = r[ e ] )
+									: r[ i[ e ] ] === n &&
+									  o[ e ] !== n &&
+									  ( r[ i[ e ] ] = o[ e ] ),
+									delete o[ e ],
+									delete r[ e ];
+							} );
+							for ( let e in o.attributes )
+								r[ e ] === n &&
+									o[ e ] !== n &&
+									( r[ e ] = o[ e ] );
+						}
+						render() {
+							return ( 0, e.jsx )( t, { ...this.props } );
+						}
+					},
+				'withDefaultAttributes'
 			);
-			return OriginalBlockEdit;
-		}
-
-		// Ensure correct block attribute data is sent in intial preview AJAX request.
-		blockType.alignContent = validateAlignment( blockType.alignContent );
-
-		// Return wrapped component.
-		return class WrappedBlockEdit extends Component {
-			render() {
-				const { attributes, setAttributes } = this.props;
-				const { alignContent } = attributes;
-				function onChangeAlignContent( alignContent ) {
-					setAttributes( {
-						alignContent: validateAlignment( alignContent ),
-					} );
-				}
-				return (
-					<Fragment>
-						<BlockControls group="block">
-							<AlignmentComponent
-								label={ acf.__( 'Change content alignment' ) }
-								value={ validateAlignment( alignContent ) }
-								onChange={ onChangeAlignContent }
-							/>
-						</BlockControls>
-						<OriginalBlockEdit { ...this.props } />
-					</Fragment>
-				);
-			}
-		};
-	}
-
-	/**
-	 * A higher order component adding alignText editing functionality.
-	 *
-	 * @date	08/07/2020
-	 * @since	ACF 5.9.0
-	 *
-	 * @param	component OriginalBlockEdit The original BlockEdit component.
-	 * @param	object blockType The block type settings.
-	 * @return	component
-	 */
-	function withAlignTextComponent( OriginalBlockEdit, blockType ) {
-		const validateAlignment = validateHorizontalAlignment;
-
-		// Ensure correct block attribute data is sent in intial preview AJAX request.
-		blockType.alignText = validateAlignment( blockType.alignText );
-
-		// Return wrapped component.
-		return class WrappedBlockEdit extends Component {
-			render() {
-				const { attributes, setAttributes } = this.props;
-				const { alignText } = attributes;
-
-				function onChangeAlignText( alignText ) {
-					setAttributes( {
-						alignText: validateAlignment( alignText ),
-					} );
-				}
-
-				return (
-					<Fragment>
-						<BlockControls group="block">
-							<AlignmentToolbar
-								value={ validateAlignment( alignText ) }
-								onChange={ onChangeAlignText }
-							/>
-						</BlockControls>
-						<OriginalBlockEdit { ...this.props } />
-					</Fragment>
-				);
-			}
-		};
-	}
-
-	/**
-	 * A higher order component adding full height support.
-	 *
-	 * @date	19/07/2021
-	 * @since	ACF 5.10.0
-	 *
-	 * @param	component OriginalBlockEdit The original BlockEdit component.
-	 * @param	object blockType The block type settings.
-	 * @return	component
-	 */
-	function withFullHeightComponent( OriginalBlockEdit, blockType ) {
-		if ( ! BlockFullHeightAlignmentControl ) return OriginalBlockEdit;
-
-		// Return wrapped component.
-		return class WrappedBlockEdit extends Component {
-			render() {
-				const { attributes, setAttributes } = this.props;
-				const { fullHeight } = attributes;
-
-				function onToggleFullHeight( fullHeight ) {
-					setAttributes( {
-						fullHeight,
-					} );
-				}
-
-				return (
-					<Fragment>
-						<BlockControls group="block">
-							<BlockFullHeightAlignmentControl
-								isActive={ fullHeight }
-								onToggle={ onToggleFullHeight }
-							/>
-						</BlockControls>
-						<OriginalBlockEdit { ...this.props } />
-					</Fragment>
-				);
-			}
-		};
-	}
-
-	/**
-	 * Appends a backwards compatibility attribute for conversion.
-	 *
-	 * @since	ACF 6.0
-	 *
-	 * @param	object attributes The block type attributes.
-	 * @return	object
-	 */
-	function addBackCompatAttribute( attributes, new_attribute, type ) {
-		attributes[ new_attribute ] = {
-			type: type,
-		};
-		return attributes;
-	}
-
-	/**
-	 * Create a block hash from attributes
-	 *
-	 * @since ACF 6.0
-	 *
-	 * @param object attributes The block type attributes.
-	 * @param object context The current block context object.
-	 * @return string
-	 */
-	function createBlockAttributesHash( attributes, context ) {
-		attributes[ '_acf_context' ] = sortObjectByKey( context );
-		return md5( JSON.stringify( sortObjectByKey( attributes ) ) );
-	}
-
-	/**
-	 * Key sort an object
-	 *
-	 * @since ACF 6.3.1
-	 *
-	 * @param object toSort The object to be sorted
-	 * @return object
-	 */
-	function sortObjectByKey( toSort ) {
-		return Object.keys( toSort )
-			.sort()
-			.reduce( ( acc, currValue ) => {
-				acc[ currValue ] = toSort[ currValue ];
-				return acc;
-			}, {} );
-	}
-} )( jQuery );
+			wp.hooks.addFilter(
+				'editor.BlockListBlock',
+				'acf/with-default-attributes',
+				l
+			);
+		} )( jQuery );
+	} )();
+} )();

--- a/assets/src/js/pro/_acf-blocks.js
+++ b/assets/src/js/pro/_acf-blocks.js
@@ -611,6 +611,33 @@ const md5 = require( 'md5' );
 	}
 
 	/**
+	 * A react Component for inline scripts.
+	 *
+	 * This Component uses a combination of React references and jQuery to append the
+	 * inline <script> HTML each time the component is rendered.
+	 *
+	 * @date	29/05/2020
+	 * @since	ACF 5.9.0
+	 *
+	 * @param	type Var Description.
+	 * @return	type Description.
+	 */
+	class Script extends Component {
+		render() {
+			return <div ref={ ( el ) => ( this.el = el ) } />;
+		}
+		setHTML( html ) {
+			$( this.el ).html( `<script>${ html }</script>` );
+		}
+		componentDidUpdate() {
+			this.setHTML( this.props.children );
+		}
+		componentDidMount() {
+			this.setHTML( this.props.children );
+		}
+	}
+
+	/**
 	 * Converts the given name into a React friendly name or component.
 	 *
 	 * @date	19/05/2020
@@ -1006,33 +1033,6 @@ const md5 = require( 'md5' );
 					dangerouslySetInnerHTML={ { __html: this.props.children } }
 				/>
 			);
-		}
-	}
-
-	/**
-	 * A react Component for inline scripts.
-	 *
-	 * This Component uses a combination of React references and jQuery to append the
-	 * inline <script> HTML each time the component is rendered.
-	 *
-	 * @date	29/05/2020
-	 * @since	ACF 5.9.0
-	 *
-	 * @param	type Var Description.
-	 * @return	type Description.
-	 */
-	class Script extends Component {
-		render() {
-			return <div ref={ ( el ) => ( this.el = el ) } />;
-		}
-		setHTML( html ) {
-			$( this.el ).html( `<script>${ html }</script>` );
-		}
-		componentDidUpdate() {
-			this.setHTML( this.props.children );
-		}
-		componentDidMount() {
-			this.setHTML( this.props.children );
 		}
 	}
 

--- a/assets/src/js/pro/blocks-v3/6.7.0.2.js
+++ b/assets/src/js/pro/blocks-v3/6.7.0.2.js
@@ -1,0 +1,5163 @@
+( () => {
+	var e = {
+			20: ( e, t, n ) => {
+				'use strict';
+				var r = n( 540 ),
+					o = Symbol.for( 'react.element' ),
+					i = Symbol.for( 'react.fragment' ),
+					a = Object.prototype.hasOwnProperty,
+					s =
+						r.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+							.ReactCurrentOwner,
+					l = { key: ! 0, ref: ! 0, __self: ! 0, __source: ! 0 };
+				function c( e, t, n ) {
+					var r,
+						i = {},
+						c = null,
+						d = null;
+					for ( r in ( void 0 !== n && ( c = '' + n ),
+					void 0 !== t.key && ( c = '' + t.key ),
+					void 0 !== t.ref && ( d = t.ref ),
+					t ) )
+						a.call( t, r ) &&
+							! l.hasOwnProperty( r ) &&
+							( i[ r ] = t[ r ] );
+					if ( e && e.defaultProps )
+						for ( r in ( t = e.defaultProps ) )
+							void 0 === i[ r ] && ( i[ r ] = t[ r ] );
+					return {
+						$$typeof: o,
+						type: e,
+						key: c,
+						ref: d,
+						props: i,
+						_owner: s.current,
+					};
+				}
+				( t.Fragment = i ), ( t.jsx = c ), ( t.jsxs = c );
+			},
+			138: () => {
+				jQuery,
+					( acf.jsxNameReplacements = {
+						'accent-height': 'accentHeight',
+						accentheight: 'accentHeight',
+						'accept-charset': 'acceptCharset',
+						acceptcharset: 'acceptCharset',
+						accesskey: 'accessKey',
+						'alignment-baseline': 'alignmentBaseline',
+						alignmentbaseline: 'alignmentBaseline',
+						allowedblocks: 'allowedBlocks',
+						allowfullscreen: 'allowFullScreen',
+						allowreorder: 'allowReorder',
+						'arabic-form': 'arabicForm',
+						arabicform: 'arabicForm',
+						attributename: 'attributeName',
+						attributetype: 'attributeType',
+						autocapitalize: 'autoCapitalize',
+						autocomplete: 'autoComplete',
+						autocorrect: 'autoCorrect',
+						autofocus: 'autoFocus',
+						autoplay: 'autoPlay',
+						autoreverse: 'autoReverse',
+						autosave: 'autoSave',
+						basefrequency: 'baseFrequency',
+						'baseline-shift': 'baselineShift',
+						baselineshift: 'baselineShift',
+						baseprofile: 'baseProfile',
+						calcmode: 'calcMode',
+						'cap-height': 'capHeight',
+						capheight: 'capHeight',
+						cellpadding: 'cellPadding',
+						cellspacing: 'cellSpacing',
+						charset: 'charSet',
+						class: 'className',
+						classid: 'classID',
+						classname: 'className',
+						'clip-path': 'clipPath',
+						'clip-rule': 'clipRule',
+						clippath: 'clipPath',
+						clippathunits: 'clipPathUnits',
+						cliprule: 'clipRule',
+						'color-interpolation': 'colorInterpolation',
+						'color-interpolation-filters':
+							'colorInterpolationFilters',
+						'color-profile': 'colorProfile',
+						'color-rendering': 'colorRendering',
+						colorinterpolation: 'colorInterpolation',
+						colorinterpolationfilters: 'colorInterpolationFilters',
+						colorprofile: 'colorProfile',
+						colorrendering: 'colorRendering',
+						colspan: 'colSpan',
+						contenteditable: 'contentEditable',
+						contentscripttype: 'contentScriptType',
+						contentstyletype: 'contentStyleType',
+						contextmenu: 'contextMenu',
+						controlslist: 'controlsList',
+						crossorigin: 'crossOrigin',
+						dangerouslysetinnerhtml: 'dangerouslySetInnerHTML',
+						datetime: 'dateTime',
+						defaultchecked: 'defaultChecked',
+						defaultvalue: 'defaultValue',
+						diffuseconstant: 'diffuseConstant',
+						disablepictureinpicture: 'disablePictureInPicture',
+						disableremoteplayback: 'disableRemotePlayback',
+						'dominant-baseline': 'dominantBaseline',
+						dominantbaseline: 'dominantBaseline',
+						edgemode: 'edgeMode',
+						'enable-background': 'enableBackground',
+						enablebackground: 'enableBackground',
+						enctype: 'encType',
+						enterkeyhint: 'enterKeyHint',
+						externalresourcesrequired: 'externalResourcesRequired',
+						'fill-opacity': 'fillOpacity',
+						'fill-rule': 'fillRule',
+						fillopacity: 'fillOpacity',
+						fillrule: 'fillRule',
+						filterres: 'filterRes',
+						filterunits: 'filterUnits',
+						'flood-color': 'floodColor',
+						'flood-opacity': 'floodOpacity',
+						floodcolor: 'floodColor',
+						floodopacity: 'floodOpacity',
+						'font-family': 'fontFamily',
+						'font-size': 'fontSize',
+						'font-size-adjust': 'fontSizeAdjust',
+						'font-stretch': 'fontStretch',
+						'font-style': 'fontStyle',
+						'font-variant': 'fontVariant',
+						'font-weight': 'fontWeight',
+						fontfamily: 'fontFamily',
+						fontsize: 'fontSize',
+						fontsizeadjust: 'fontSizeAdjust',
+						fontstretch: 'fontStretch',
+						fontstyle: 'fontStyle',
+						fontvariant: 'fontVariant',
+						fontweight: 'fontWeight',
+						for: 'htmlFor',
+						foreignobject: 'foreignObject',
+						formaction: 'formAction',
+						formenctype: 'formEncType',
+						formmethod: 'formMethod',
+						formnovalidate: 'formNoValidate',
+						formtarget: 'formTarget',
+						frameborder: 'frameBorder',
+						'glyph-name': 'glyphName',
+						'glyph-orientation-horizontal':
+							'glyphOrientationHorizontal',
+						'glyph-orientation-vertical':
+							'glyphOrientationVertical',
+						glyphname: 'glyphName',
+						glyphorientationhorizontal:
+							'glyphOrientationHorizontal',
+						glyphorientationvertical: 'glyphOrientationVertical',
+						glyphref: 'glyphRef',
+						gradienttransform: 'gradientTransform',
+						gradientunits: 'gradientUnits',
+						'horiz-adv-x': 'horizAdvX',
+						'horiz-origin-x': 'horizOriginX',
+						horizadvx: 'horizAdvX',
+						horizoriginx: 'horizOriginX',
+						hreflang: 'hrefLang',
+						htmlfor: 'htmlFor',
+						'http-equiv': 'httpEquiv',
+						httpequiv: 'httpEquiv',
+						'image-rendering': 'imageRendering',
+						imagerendering: 'imageRendering',
+						innerhtml: 'innerHTML',
+						inputmode: 'inputMode',
+						itemid: 'itemID',
+						itemprop: 'itemProp',
+						itemref: 'itemRef',
+						itemscope: 'itemScope',
+						itemtype: 'itemType',
+						kernelmatrix: 'kernelMatrix',
+						kernelunitlength: 'kernelUnitLength',
+						keyparams: 'keyParams',
+						keypoints: 'keyPoints',
+						keysplines: 'keySplines',
+						keytimes: 'keyTimes',
+						keytype: 'keyType',
+						lengthadjust: 'lengthAdjust',
+						'letter-spacing': 'letterSpacing',
+						letterspacing: 'letterSpacing',
+						'lighting-color': 'lightingColor',
+						lightingcolor: 'lightingColor',
+						limitingconeangle: 'limitingConeAngle',
+						marginheight: 'marginHeight',
+						marginwidth: 'marginWidth',
+						'marker-end': 'markerEnd',
+						'marker-mid': 'markerMid',
+						'marker-start': 'markerStart',
+						markerend: 'markerEnd',
+						markerheight: 'markerHeight',
+						markermid: 'markerMid',
+						markerstart: 'markerStart',
+						markerunits: 'markerUnits',
+						markerwidth: 'markerWidth',
+						maskcontentunits: 'maskContentUnits',
+						maskunits: 'maskUnits',
+						maxlength: 'maxLength',
+						mediagroup: 'mediaGroup',
+						minlength: 'minLength',
+						nomodule: 'noModule',
+						novalidate: 'noValidate',
+						numoctaves: 'numOctaves',
+						'overline-position': 'overlinePosition',
+						'overline-thickness': 'overlineThickness',
+						overlineposition: 'overlinePosition',
+						overlinethickness: 'overlineThickness',
+						'paint-order': 'paintOrder',
+						paintorder: 'paintOrder',
+						'panose-1': 'panose1',
+						pathlength: 'pathLength',
+						patterncontentunits: 'patternContentUnits',
+						patterntransform: 'patternTransform',
+						patternunits: 'patternUnits',
+						playsinline: 'playsInline',
+						'pointer-events': 'pointerEvents',
+						pointerevents: 'pointerEvents',
+						pointsatx: 'pointsAtX',
+						pointsaty: 'pointsAtY',
+						pointsatz: 'pointsAtZ',
+						preservealpha: 'preserveAlpha',
+						preserveaspectratio: 'preserveAspectRatio',
+						primitiveunits: 'primitiveUnits',
+						radiogroup: 'radioGroup',
+						readonly: 'readOnly',
+						referrerpolicy: 'referrerPolicy',
+						refx: 'refX',
+						refy: 'refY',
+						'rendering-intent': 'renderingIntent',
+						renderingintent: 'renderingIntent',
+						repeatcount: 'repeatCount',
+						repeatdur: 'repeatDur',
+						requiredextensions: 'requiredExtensions',
+						requiredfeatures: 'requiredFeatures',
+						rowspan: 'rowSpan',
+						'shape-rendering': 'shapeRendering',
+						shaperendering: 'shapeRendering',
+						specularconstant: 'specularConstant',
+						specularexponent: 'specularExponent',
+						spellcheck: 'spellCheck',
+						spreadmethod: 'spreadMethod',
+						srcdoc: 'srcDoc',
+						srclang: 'srcLang',
+						srcset: 'srcSet',
+						startoffset: 'startOffset',
+						stddeviation: 'stdDeviation',
+						stitchtiles: 'stitchTiles',
+						'stop-color': 'stopColor',
+						'stop-opacity': 'stopOpacity',
+						stopcolor: 'stopColor',
+						stopopacity: 'stopOpacity',
+						'strikethrough-position': 'strikethroughPosition',
+						'strikethrough-thickness': 'strikethroughThickness',
+						strikethroughposition: 'strikethroughPosition',
+						strikethroughthickness: 'strikethroughThickness',
+						'stroke-dasharray': 'strokeDasharray',
+						'stroke-dashoffset': 'strokeDashoffset',
+						'stroke-linecap': 'strokeLinecap',
+						'stroke-linejoin': 'strokeLinejoin',
+						'stroke-miterlimit': 'strokeMiterlimit',
+						'stroke-opacity': 'strokeOpacity',
+						'stroke-width': 'strokeWidth',
+						strokedasharray: 'strokeDasharray',
+						strokedashoffset: 'strokeDashoffset',
+						strokelinecap: 'strokeLinecap',
+						strokelinejoin: 'strokeLinejoin',
+						strokemiterlimit: 'strokeMiterlimit',
+						strokeopacity: 'strokeOpacity',
+						strokewidth: 'strokeWidth',
+						suppresscontenteditablewarning:
+							'suppressContentEditableWarning',
+						suppresshydrationwarning: 'suppressHydrationWarning',
+						surfacescale: 'surfaceScale',
+						systemlanguage: 'systemLanguage',
+						tabindex: 'tabIndex',
+						tablevalues: 'tableValues',
+						targetx: 'targetX',
+						targety: 'targetY',
+						templatelock: 'templateLock',
+						'text-anchor': 'textAnchor',
+						'text-decoration': 'textDecoration',
+						'text-rendering': 'textRendering',
+						textanchor: 'textAnchor',
+						textdecoration: 'textDecoration',
+						textlength: 'textLength',
+						textrendering: 'textRendering',
+						'underline-position': 'underlinePosition',
+						'underline-thickness': 'underlineThickness',
+						underlineposition: 'underlinePosition',
+						underlinethickness: 'underlineThickness',
+						'unicode-bidi': 'unicodeBidi',
+						'unicode-range': 'unicodeRange',
+						unicodebidi: 'unicodeBidi',
+						unicoderange: 'unicodeRange',
+						'units-per-em': 'unitsPerEm',
+						unitsperem: 'unitsPerEm',
+						usemap: 'useMap',
+						'v-alphabetic': 'vAlphabetic',
+						'v-hanging': 'vHanging',
+						'v-ideographic': 'vIdeographic',
+						'v-mathematical': 'vMathematical',
+						valphabetic: 'vAlphabetic',
+						'vector-effect': 'vectorEffect',
+						vectoreffect: 'vectorEffect',
+						'vert-adv-y': 'vertAdvY',
+						'vert-origin-x': 'vertOriginX',
+						'vert-origin-y': 'vertOriginY',
+						vertadvy: 'vertAdvY',
+						vertoriginx: 'vertOriginX',
+						vertoriginy: 'vertOriginY',
+						vhanging: 'vHanging',
+						videographic: 'vIdeographic',
+						viewbox: 'viewBox',
+						viewtarget: 'viewTarget',
+						vmathematical: 'vMathematical',
+						'word-spacing': 'wordSpacing',
+						wordspacing: 'wordSpacing',
+						'writing-mode': 'writingMode',
+						writingmode: 'writingMode',
+						'x-height': 'xHeight',
+						xchannelselector: 'xChannelSelector',
+						xheight: 'xHeight',
+						'xlink:actuate': 'xlinkActuate',
+						'xlink:arcrole': 'xlinkArcrole',
+						'xlink:href': 'xlinkHref',
+						'xlink:role': 'xlinkRole',
+						'xlink:show': 'xlinkShow',
+						'xlink:title': 'xlinkTitle',
+						'xlink:type': 'xlinkType',
+						xlinkactuate: 'xlinkActuate',
+						xlinkarcrole: 'xlinkArcrole',
+						xlinkhref: 'xlinkHref',
+						xlinkrole: 'xlinkRole',
+						xlinkshow: 'xlinkShow',
+						xlinktitle: 'xlinkTitle',
+						xlinktype: 'xlinkType',
+						'xml:base': 'xmlBase',
+						'xml:lang': 'xmlLang',
+						'xml:space': 'xmlSpace',
+						xmlbase: 'xmlBase',
+						xmllang: 'xmlLang',
+						'xmlns:xlink': 'xmlnsXlink',
+						xmlnsxlink: 'xmlnsXlink',
+						xmlspace: 'xmlSpace',
+						ychannelselector: 'yChannelSelector',
+						zoomandpan: 'zoomAndPan',
+					} );
+			},
+			151: ( e ) => {
+				var t = {
+					utf8: {
+						stringToBytes: function ( e ) {
+							return t.bin.stringToBytes(
+								unescape( encodeURIComponent( e ) )
+							);
+						},
+						bytesToString: function ( e ) {
+							return decodeURIComponent(
+								escape( t.bin.bytesToString( e ) )
+							);
+						},
+					},
+					bin: {
+						stringToBytes: function ( e ) {
+							for ( var t = [], n = 0; n < e.length; n++ )
+								t.push( 255 & e.charCodeAt( n ) );
+							return t;
+						},
+						bytesToString: function ( e ) {
+							for ( var t = [], n = 0; n < e.length; n++ )
+								t.push( String.fromCharCode( e[ n ] ) );
+							return t.join( '' );
+						},
+					},
+				};
+				e.exports = t;
+			},
+			206: ( e ) => {
+				function t( e ) {
+					return (
+						!! e.constructor &&
+						'function' == typeof e.constructor.isBuffer &&
+						e.constructor.isBuffer( e )
+					);
+				}
+				e.exports = function ( e ) {
+					return (
+						null != e &&
+						( t( e ) ||
+							( function ( e ) {
+								return (
+									'function' == typeof e.readFloatLE &&
+									'function' == typeof e.slice &&
+									t( e.slice( 0, 0 ) )
+								);
+							} )( e ) ||
+							!! e._isBuffer )
+					);
+				};
+			},
+			287: ( e, t ) => {
+				'use strict';
+				var n = Symbol.for( 'react.element' ),
+					r = Symbol.for( 'react.portal' ),
+					o = Symbol.for( 'react.fragment' ),
+					i = Symbol.for( 'react.strict_mode' ),
+					a = Symbol.for( 'react.profiler' ),
+					s = Symbol.for( 'react.provider' ),
+					l = Symbol.for( 'react.context' ),
+					c = Symbol.for( 'react.forward_ref' ),
+					d = Symbol.for( 'react.suspense' ),
+					u = Symbol.for( 'react.memo' ),
+					p = Symbol.for( 'react.lazy' ),
+					f = Symbol.iterator,
+					h = {
+						isMounted: function () {
+							return ! 1;
+						},
+						enqueueForceUpdate: function () {},
+						enqueueReplaceState: function () {},
+						enqueueSetState: function () {},
+					},
+					m = Object.assign,
+					b = {};
+				function g( e, t, n ) {
+					( this.props = e ),
+						( this.context = t ),
+						( this.refs = b ),
+						( this.updater = n || h );
+				}
+				function k() {}
+				function v( e, t, n ) {
+					( this.props = e ),
+						( this.context = t ),
+						( this.refs = b ),
+						( this.updater = n || h );
+				}
+				( g.prototype.isReactComponent = {} ),
+					( g.prototype.setState = function ( e, t ) {
+						if (
+							'object' != typeof e &&
+							'function' != typeof e &&
+							null != e
+						)
+							throw Error(
+								'setState(...): takes an object of state variables to update or a function which returns an object of state variables.'
+							);
+						this.updater.enqueueSetState( this, e, t, 'setState' );
+					} ),
+					( g.prototype.forceUpdate = function ( e ) {
+						this.updater.enqueueForceUpdate(
+							this,
+							e,
+							'forceUpdate'
+						);
+					} ),
+					( k.prototype = g.prototype );
+				var y = ( v.prototype = new k() );
+				( y.constructor = v ),
+					m( y, g.prototype ),
+					( y.isPureReactComponent = ! 0 );
+				var x = Array.isArray,
+					w = Object.prototype.hasOwnProperty,
+					E = { current: null },
+					_ = { key: ! 0, ref: ! 0, __self: ! 0, __source: ! 0 };
+				function C( e, t, r ) {
+					var o,
+						i = {},
+						a = null,
+						s = null;
+					if ( null != t )
+						for ( o in ( void 0 !== t.ref && ( s = t.ref ),
+						void 0 !== t.key && ( a = '' + t.key ),
+						t ) )
+							w.call( t, o ) &&
+								! _.hasOwnProperty( o ) &&
+								( i[ o ] = t[ o ] );
+					var l = arguments.length - 2;
+					if ( 1 === l ) i.children = r;
+					else if ( 1 < l ) {
+						for ( var c = Array( l ), d = 0; d < l; d++ )
+							c[ d ] = arguments[ d + 2 ];
+						i.children = c;
+					}
+					if ( e && e.defaultProps )
+						for ( o in ( l = e.defaultProps ) )
+							void 0 === i[ o ] && ( i[ o ] = l[ o ] );
+					return {
+						$$typeof: n,
+						type: e,
+						key: a,
+						ref: s,
+						props: i,
+						_owner: E.current,
+					};
+				}
+				function j( e ) {
+					return (
+						'object' == typeof e && null !== e && e.$$typeof === n
+					);
+				}
+				var I = /\/+/g;
+				function S( e, t ) {
+					return 'object' == typeof e && null !== e && null != e.key
+						? ( function ( e ) {
+								var t = { '=': '=0', ':': '=2' };
+								return (
+									'$' +
+									e.replace( /[=:]/g, function ( e ) {
+										return t[ e ];
+									} )
+								);
+						  } )( '' + e.key )
+						: t.toString( 36 );
+				}
+				function A( e, t, o, i, a ) {
+					var s = typeof e;
+					( 'undefined' !== s && 'boolean' !== s ) || ( e = null );
+					var l = ! 1;
+					if ( null === e ) l = ! 0;
+					else
+						switch ( s ) {
+							case 'string':
+							case 'number':
+								l = ! 0;
+								break;
+							case 'object':
+								switch ( e.$$typeof ) {
+									case n:
+									case r:
+										l = ! 0;
+								}
+						}
+					if ( l )
+						return (
+							( a = a( ( l = e ) ) ),
+							( e = '' === i ? '.' + S( l, 0 ) : i ),
+							x( a )
+								? ( ( o = '' ),
+								  null != e &&
+										( o = e.replace( I, '$&/' ) + '/' ),
+								  A( a, t, o, '', function ( e ) {
+										return e;
+								  } ) )
+								: null != a &&
+								  ( j( a ) &&
+										( a = ( function ( e, t ) {
+											return {
+												$$typeof: n,
+												type: e.type,
+												key: t,
+												ref: e.ref,
+												props: e.props,
+												_owner: e._owner,
+											};
+										} )(
+											a,
+											o +
+												( ! a.key ||
+												( l && l.key === a.key )
+													? ''
+													: ( '' + a.key ).replace(
+															I,
+															'$&/'
+													  ) + '/' ) +
+												e
+										) ),
+								  t.push( a ) ),
+							1
+						);
+					if (
+						( ( l = 0 ), ( i = '' === i ? '.' : i + ':' ), x( e ) )
+					)
+						for ( var c = 0; c < e.length; c++ ) {
+							var d = i + S( ( s = e[ c ] ), c );
+							l += A( s, t, o, d, a );
+						}
+					else if (
+						( ( d = ( function ( e ) {
+							return null === e || 'object' != typeof e
+								? null
+								: 'function' ==
+								  typeof ( e =
+										( f && e[ f ] ) || e[ '@@iterator' ] )
+								? e
+								: null;
+						} )( e ) ),
+						'function' == typeof d )
+					)
+						for (
+							e = d.call( e ), c = 0;
+							! ( s = e.next() ).done;
+
+						)
+							l += A(
+								( s = s.value ),
+								t,
+								o,
+								( d = i + S( s, c++ ) ),
+								a
+							);
+					else if ( 'object' === s )
+						throw (
+							( ( t = String( e ) ),
+							Error(
+								'Objects are not valid as a React child (found: ' +
+									( '[object Object]' === t
+										? 'object with keys {' +
+										  Object.keys( e ).join( ', ' ) +
+										  '}'
+										: t ) +
+									'). If you meant to render a collection of children, use an array instead.'
+							) )
+						);
+					return l;
+				}
+				function T( e, t, n ) {
+					if ( null == e ) return e;
+					var r = [],
+						o = 0;
+					return (
+						A( e, r, '', '', function ( e ) {
+							return t.call( n, e, o++ );
+						} ),
+						r
+					);
+				}
+				function B( e ) {
+					if ( -1 === e._status ) {
+						var t = e._result;
+						( t = t() ).then(
+							function ( t ) {
+								( 0 !== e._status && -1 !== e._status ) ||
+									( ( e._status = 1 ), ( e._result = t ) );
+							},
+							function ( t ) {
+								( 0 !== e._status && -1 !== e._status ) ||
+									( ( e._status = 2 ), ( e._result = t ) );
+							}
+						),
+							-1 === e._status &&
+								( ( e._status = 0 ), ( e._result = t ) );
+					}
+					if ( 1 === e._status ) return e._result.default;
+					throw e._result;
+				}
+				var F = { current: null },
+					O = { transition: null },
+					N = {
+						ReactCurrentDispatcher: F,
+						ReactCurrentBatchConfig: O,
+						ReactCurrentOwner: E,
+					};
+				function R() {
+					throw Error(
+						'act(...) is not supported in production builds of React.'
+					);
+				}
+				( t.Children = {
+					map: T,
+					forEach: function ( e, t, n ) {
+						T(
+							e,
+							function () {
+								t.apply( this, arguments );
+							},
+							n
+						);
+					},
+					count: function ( e ) {
+						var t = 0;
+						return (
+							T( e, function () {
+								t++;
+							} ),
+							t
+						);
+					},
+					toArray: function ( e ) {
+						return (
+							T( e, function ( e ) {
+								return e;
+							} ) || []
+						);
+					},
+					only: function ( e ) {
+						if ( ! j( e ) )
+							throw Error(
+								'React.Children.only expected to receive a single React element child.'
+							);
+						return e;
+					},
+				} ),
+					( t.Component = g ),
+					( t.Fragment = o ),
+					( t.Profiler = a ),
+					( t.PureComponent = v ),
+					( t.StrictMode = i ),
+					( t.Suspense = d ),
+					( t.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED =
+						N ),
+					( t.act = R ),
+					( t.cloneElement = function ( e, t, r ) {
+						if ( null == e )
+							throw Error(
+								'React.cloneElement(...): The argument must be a React element, but you passed ' +
+									e +
+									'.'
+							);
+						var o = m( {}, e.props ),
+							i = e.key,
+							a = e.ref,
+							s = e._owner;
+						if ( null != t ) {
+							if (
+								( void 0 !== t.ref &&
+									( ( a = t.ref ), ( s = E.current ) ),
+								void 0 !== t.key && ( i = '' + t.key ),
+								e.type && e.type.defaultProps )
+							)
+								var l = e.type.defaultProps;
+							for ( c in t )
+								w.call( t, c ) &&
+									! _.hasOwnProperty( c ) &&
+									( o[ c ] =
+										void 0 === t[ c ] && void 0 !== l
+											? l[ c ]
+											: t[ c ] );
+						}
+						var c = arguments.length - 2;
+						if ( 1 === c ) o.children = r;
+						else if ( 1 < c ) {
+							l = Array( c );
+							for ( var d = 0; d < c; d++ )
+								l[ d ] = arguments[ d + 2 ];
+							o.children = l;
+						}
+						return {
+							$$typeof: n,
+							type: e.type,
+							key: i,
+							ref: a,
+							props: o,
+							_owner: s,
+						};
+					} ),
+					( t.createContext = function ( e ) {
+						return (
+							( ( e = {
+								$$typeof: l,
+								_currentValue: e,
+								_currentValue2: e,
+								_threadCount: 0,
+								Provider: null,
+								Consumer: null,
+								_defaultValue: null,
+								_globalName: null,
+							} ).Provider = { $$typeof: s, _context: e } ),
+							( e.Consumer = e )
+						);
+					} ),
+					( t.createElement = C ),
+					( t.createFactory = function ( e ) {
+						var t = C.bind( null, e );
+						return ( t.type = e ), t;
+					} ),
+					( t.createRef = function () {
+						return { current: null };
+					} ),
+					( t.forwardRef = function ( e ) {
+						return { $$typeof: c, render: e };
+					} ),
+					( t.isValidElement = j ),
+					( t.lazy = function ( e ) {
+						return {
+							$$typeof: p,
+							_payload: { _status: -1, _result: e },
+							_init: B,
+						};
+					} ),
+					( t.memo = function ( e, t ) {
+						return {
+							$$typeof: u,
+							type: e,
+							compare: void 0 === t ? null : t,
+						};
+					} ),
+					( t.startTransition = function ( e ) {
+						var t = O.transition;
+						O.transition = {};
+						try {
+							e();
+						} finally {
+							O.transition = t;
+						}
+					} ),
+					( t.unstable_act = R ),
+					( t.useCallback = function ( e, t ) {
+						return F.current.useCallback( e, t );
+					} ),
+					( t.useContext = function ( e ) {
+						return F.current.useContext( e );
+					} ),
+					( t.useDebugValue = function () {} ),
+					( t.useDeferredValue = function ( e ) {
+						return F.current.useDeferredValue( e );
+					} ),
+					( t.useEffect = function ( e, t ) {
+						return F.current.useEffect( e, t );
+					} ),
+					( t.useId = function () {
+						return F.current.useId();
+					} ),
+					( t.useImperativeHandle = function ( e, t, n ) {
+						return F.current.useImperativeHandle( e, t, n );
+					} ),
+					( t.useInsertionEffect = function ( e, t ) {
+						return F.current.useInsertionEffect( e, t );
+					} ),
+					( t.useLayoutEffect = function ( e, t ) {
+						return F.current.useLayoutEffect( e, t );
+					} ),
+					( t.useMemo = function ( e, t ) {
+						return F.current.useMemo( e, t );
+					} ),
+					( t.useReducer = function ( e, t, n ) {
+						return F.current.useReducer( e, t, n );
+					} ),
+					( t.useRef = function ( e ) {
+						return F.current.useRef( e );
+					} ),
+					( t.useState = function ( e ) {
+						return F.current.useState( e );
+					} ),
+					( t.useSyncExternalStore = function ( e, t, n ) {
+						return F.current.useSyncExternalStore( e, t, n );
+					} ),
+					( t.useTransition = function () {
+						return F.current.useTransition();
+					} ),
+					( t.version = '18.3.1' );
+			},
+			503: ( e, t, n ) => {
+				var r, o, i, a, s;
+				( r = n( 939 ) ),
+					( o = n( 151 ).utf8 ),
+					( i = n( 206 ) ),
+					( a = n( 151 ).bin ),
+					( ( s = function ( e, t ) {
+						e.constructor == String
+							? ( e =
+									t && 'binary' === t.encoding
+										? a.stringToBytes( e )
+										: o.stringToBytes( e ) )
+							: i( e )
+							? ( e = Array.prototype.slice.call( e, 0 ) )
+							: Array.isArray( e ) ||
+							  e.constructor === Uint8Array ||
+							  ( e = e.toString() );
+						for (
+							var n = r.bytesToWords( e ),
+								l = 8 * e.length,
+								c = 1732584193,
+								d = -271733879,
+								u = -1732584194,
+								p = 271733878,
+								f = 0;
+							f < n.length;
+							f++
+						)
+							n[ f ] =
+								( 16711935 &
+									( ( n[ f ] << 8 ) | ( n[ f ] >>> 24 ) ) ) |
+								( 4278255360 &
+									( ( n[ f ] << 24 ) | ( n[ f ] >>> 8 ) ) );
+						( n[ l >>> 5 ] |= 128 << l % 32 ),
+							( n[ 14 + ( ( ( l + 64 ) >>> 9 ) << 4 ) ] = l );
+						var h = s._ff,
+							m = s._gg,
+							b = s._hh,
+							g = s._ii;
+						for ( f = 0; f < n.length; f += 16 ) {
+							var k = c,
+								v = d,
+								y = u,
+								x = p;
+							( c = h( c, d, u, p, n[ f + 0 ], 7, -680876936 ) ),
+								( p = h(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 1 ],
+									12,
+									-389564586
+								) ),
+								( u = h(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 2 ],
+									17,
+									606105819
+								) ),
+								( d = h(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 3 ],
+									22,
+									-1044525330
+								) ),
+								( c = h(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 4 ],
+									7,
+									-176418897
+								) ),
+								( p = h(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 5 ],
+									12,
+									1200080426
+								) ),
+								( u = h(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 6 ],
+									17,
+									-1473231341
+								) ),
+								( d = h(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 7 ],
+									22,
+									-45705983
+								) ),
+								( c = h(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 8 ],
+									7,
+									1770035416
+								) ),
+								( p = h(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 9 ],
+									12,
+									-1958414417
+								) ),
+								( u = h(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 10 ],
+									17,
+									-42063
+								) ),
+								( d = h(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 11 ],
+									22,
+									-1990404162
+								) ),
+								( c = h(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 12 ],
+									7,
+									1804603682
+								) ),
+								( p = h(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 13 ],
+									12,
+									-40341101
+								) ),
+								( u = h(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 14 ],
+									17,
+									-1502002290
+								) ),
+								( c = m(
+									c,
+									( d = h(
+										d,
+										u,
+										p,
+										c,
+										n[ f + 15 ],
+										22,
+										1236535329
+									) ),
+									u,
+									p,
+									n[ f + 1 ],
+									5,
+									-165796510
+								) ),
+								( p = m(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 6 ],
+									9,
+									-1069501632
+								) ),
+								( u = m(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 11 ],
+									14,
+									643717713
+								) ),
+								( d = m(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 0 ],
+									20,
+									-373897302
+								) ),
+								( c = m(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 5 ],
+									5,
+									-701558691
+								) ),
+								( p = m(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 10 ],
+									9,
+									38016083
+								) ),
+								( u = m(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 15 ],
+									14,
+									-660478335
+								) ),
+								( d = m(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 4 ],
+									20,
+									-405537848
+								) ),
+								( c = m(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 9 ],
+									5,
+									568446438
+								) ),
+								( p = m(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 14 ],
+									9,
+									-1019803690
+								) ),
+								( u = m(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 3 ],
+									14,
+									-187363961
+								) ),
+								( d = m(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 8 ],
+									20,
+									1163531501
+								) ),
+								( c = m(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 13 ],
+									5,
+									-1444681467
+								) ),
+								( p = m(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 2 ],
+									9,
+									-51403784
+								) ),
+								( u = m(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 7 ],
+									14,
+									1735328473
+								) ),
+								( c = b(
+									c,
+									( d = m(
+										d,
+										u,
+										p,
+										c,
+										n[ f + 12 ],
+										20,
+										-1926607734
+									) ),
+									u,
+									p,
+									n[ f + 5 ],
+									4,
+									-378558
+								) ),
+								( p = b(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 8 ],
+									11,
+									-2022574463
+								) ),
+								( u = b(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 11 ],
+									16,
+									1839030562
+								) ),
+								( d = b(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 14 ],
+									23,
+									-35309556
+								) ),
+								( c = b(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 1 ],
+									4,
+									-1530992060
+								) ),
+								( p = b(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 4 ],
+									11,
+									1272893353
+								) ),
+								( u = b(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 7 ],
+									16,
+									-155497632
+								) ),
+								( d = b(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 10 ],
+									23,
+									-1094730640
+								) ),
+								( c = b(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 13 ],
+									4,
+									681279174
+								) ),
+								( p = b(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 0 ],
+									11,
+									-358537222
+								) ),
+								( u = b(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 3 ],
+									16,
+									-722521979
+								) ),
+								( d = b(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 6 ],
+									23,
+									76029189
+								) ),
+								( c = b(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 9 ],
+									4,
+									-640364487
+								) ),
+								( p = b(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 12 ],
+									11,
+									-421815835
+								) ),
+								( u = b(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 15 ],
+									16,
+									530742520
+								) ),
+								( c = g(
+									c,
+									( d = b(
+										d,
+										u,
+										p,
+										c,
+										n[ f + 2 ],
+										23,
+										-995338651
+									) ),
+									u,
+									p,
+									n[ f + 0 ],
+									6,
+									-198630844
+								) ),
+								( p = g(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 7 ],
+									10,
+									1126891415
+								) ),
+								( u = g(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 14 ],
+									15,
+									-1416354905
+								) ),
+								( d = g(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 5 ],
+									21,
+									-57434055
+								) ),
+								( c = g(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 12 ],
+									6,
+									1700485571
+								) ),
+								( p = g(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 3 ],
+									10,
+									-1894986606
+								) ),
+								( u = g(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 10 ],
+									15,
+									-1051523
+								) ),
+								( d = g(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 1 ],
+									21,
+									-2054922799
+								) ),
+								( c = g(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 8 ],
+									6,
+									1873313359
+								) ),
+								( p = g(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 15 ],
+									10,
+									-30611744
+								) ),
+								( u = g(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 6 ],
+									15,
+									-1560198380
+								) ),
+								( d = g(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 13 ],
+									21,
+									1309151649
+								) ),
+								( c = g(
+									c,
+									d,
+									u,
+									p,
+									n[ f + 4 ],
+									6,
+									-145523070
+								) ),
+								( p = g(
+									p,
+									c,
+									d,
+									u,
+									n[ f + 11 ],
+									10,
+									-1120210379
+								) ),
+								( u = g(
+									u,
+									p,
+									c,
+									d,
+									n[ f + 2 ],
+									15,
+									718787259
+								) ),
+								( d = g(
+									d,
+									u,
+									p,
+									c,
+									n[ f + 9 ],
+									21,
+									-343485551
+								) ),
+								( c = ( c + k ) >>> 0 ),
+								( d = ( d + v ) >>> 0 ),
+								( u = ( u + y ) >>> 0 ),
+								( p = ( p + x ) >>> 0 );
+						}
+						return r.endian( [ c, d, u, p ] );
+					} )._ff = function ( e, t, n, r, o, i, a ) {
+						var s =
+							e + ( ( t & n ) | ( ~t & r ) ) + ( o >>> 0 ) + a;
+						return ( ( s << i ) | ( s >>> ( 32 - i ) ) ) + t;
+					} ),
+					( s._gg = function ( e, t, n, r, o, i, a ) {
+						var s =
+							e + ( ( t & r ) | ( n & ~r ) ) + ( o >>> 0 ) + a;
+						return ( ( s << i ) | ( s >>> ( 32 - i ) ) ) + t;
+					} ),
+					( s._hh = function ( e, t, n, r, o, i, a ) {
+						var s = e + ( t ^ n ^ r ) + ( o >>> 0 ) + a;
+						return ( ( s << i ) | ( s >>> ( 32 - i ) ) ) + t;
+					} ),
+					( s._ii = function ( e, t, n, r, o, i, a ) {
+						var s = e + ( n ^ ( t | ~r ) ) + ( o >>> 0 ) + a;
+						return ( ( s << i ) | ( s >>> ( 32 - i ) ) ) + t;
+					} ),
+					( s._blocksize = 16 ),
+					( s._digestsize = 16 ),
+					( e.exports = function ( e, t ) {
+						if ( null == e )
+							throw new Error( 'Illegal argument ' + e );
+						var n = r.wordsToBytes( s( e, t ) );
+						return t && t.asBytes
+							? n
+							: t && t.asString
+							? a.bytesToString( n )
+							: r.bytesToHex( n );
+					} );
+			},
+			540: ( e, t, n ) => {
+				'use strict';
+				e.exports = n( 287 );
+			},
+			848: ( e, t, n ) => {
+				'use strict';
+				e.exports = n( 20 );
+			},
+			939: ( e ) => {
+				var t, n;
+				( t =
+					'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/' ),
+					( n = {
+						rotl: function ( e, t ) {
+							return ( e << t ) | ( e >>> ( 32 - t ) );
+						},
+						rotr: function ( e, t ) {
+							return ( e << ( 32 - t ) ) | ( e >>> t );
+						},
+						endian: function ( e ) {
+							if ( e.constructor == Number )
+								return (
+									( 16711935 & n.rotl( e, 8 ) ) |
+									( 4278255360 & n.rotl( e, 24 ) )
+								);
+							for ( var t = 0; t < e.length; t++ )
+								e[ t ] = n.endian( e[ t ] );
+							return e;
+						},
+						randomBytes: function ( e ) {
+							for ( var t = []; e > 0; e-- )
+								t.push( Math.floor( 256 * Math.random() ) );
+							return t;
+						},
+						bytesToWords: function ( e ) {
+							for (
+								var t = [], n = 0, r = 0;
+								n < e.length;
+								n++, r += 8
+							)
+								t[ r >>> 5 ] |= e[ n ] << ( 24 - ( r % 32 ) );
+							return t;
+						},
+						wordsToBytes: function ( e ) {
+							for ( var t = [], n = 0; n < 32 * e.length; n += 8 )
+								t.push(
+									( e[ n >>> 5 ] >>> ( 24 - ( n % 32 ) ) ) &
+										255
+								);
+							return t;
+						},
+						bytesToHex: function ( e ) {
+							for ( var t = [], n = 0; n < e.length; n++ )
+								t.push( ( e[ n ] >>> 4 ).toString( 16 ) ),
+									t.push( ( 15 & e[ n ] ).toString( 16 ) );
+							return t.join( '' );
+						},
+						hexToBytes: function ( e ) {
+							for ( var t = [], n = 0; n < e.length; n += 2 )
+								t.push( parseInt( e.substr( n, 2 ), 16 ) );
+							return t;
+						},
+						bytesToBase64: function ( e ) {
+							for ( var n = [], r = 0; r < e.length; r += 3 )
+								for (
+									var o =
+											( e[ r ] << 16 ) |
+											( e[ r + 1 ] << 8 ) |
+											e[ r + 2 ],
+										i = 0;
+									i < 4;
+									i++
+								)
+									8 * r + 6 * i <= 8 * e.length
+										? n.push(
+												t.charAt(
+													( o >>>
+														( 6 * ( 3 - i ) ) ) &
+														63
+												)
+										  )
+										: n.push( '=' );
+							return n.join( '' );
+						},
+						base64ToBytes: function ( e ) {
+							e = e.replace( /[^A-Z0-9+\/]/gi, '' );
+							for (
+								var n = [], r = 0, o = 0;
+								r < e.length;
+								o = ++r % 4
+							)
+								0 != o &&
+									n.push(
+										( ( t.indexOf( e.charAt( r - 1 ) ) &
+											( Math.pow( 2, -2 * o + 8 ) -
+												1 ) ) <<
+											( 2 * o ) ) |
+											( t.indexOf( e.charAt( r ) ) >>>
+												( 6 - 2 * o ) )
+									);
+							return n;
+						},
+					} ),
+					( e.exports = n );
+			},
+		},
+		t = {};
+	function n( r ) {
+		var o = t[ r ];
+		if ( void 0 !== o ) return o.exports;
+		var i = ( t[ r ] = { exports: {} } );
+		return e[ r ]( i, i.exports, n ), i.exports;
+	}
+	( () => {
+		'use strict';
+		n( 138 );
+		var e = n( 848 );
+		const t = n( 503 );
+		( ( n, r ) => {
+			const {
+					BlockControls: o,
+					InspectorControls: i,
+					InnerBlocks: a,
+					useBlockProps: s,
+					AlignmentToolbar: l,
+					BlockVerticalAlignmentToolbar: c,
+				} = wp.blockEditor,
+				{
+					ToolbarGroup: d,
+					ToolbarButton: u,
+					Placeholder: p,
+					Spinner: f,
+				} = wp.components,
+				{ Fragment: h } = wp.element,
+				{ Component: m } = React,
+				{ useSelect: b } = wp.data,
+				{ createHigherOrderComponent: g } = wp.compose,
+				k =
+					wp.blockEditor.__experimentalBlockAlignmentMatrixToolbar ||
+					wp.blockEditor.BlockAlignmentMatrixToolbar,
+				v =
+					wp.blockEditor.__experimentalBlockAlignmentMatrixControl ||
+					wp.blockEditor.BlockAlignmentMatrixControl,
+				y =
+					wp.blockEditor
+						.__experimentalBlockFullHeightAligmentControl ||
+					wp.blockEditor
+						.__experimentalBlockFullHeightAlignmentControl ||
+					wp.blockEditor.BlockFullHeightAlignmentControl,
+				x =
+					wp.blockEditor.__experimentalUseInnerBlocksProps ||
+					wp.blockEditor.useInnerBlocksProps,
+				w = {};
+			function E( e ) {
+				return w[ e ] || ! 1;
+			}
+			function _( e ) {
+				return E( e ).acf_block_version || 1;
+			}
+			function C( e ) {
+				return E( e ).validate;
+			}
+			function j( e ) {
+				const t = wp.data
+					.select( 'core/block-editor' )
+					.getBlockParents( e );
+				return wp.data
+					.select( 'core/block-editor' )
+					.getBlocksByClientId( t )
+					.filter( ( e ) => 'core/query' === e.name ).length;
+			}
+			function I() {
+				return (
+					document.querySelectorAll( 'iframe[name="editor-canvas"]' )
+						.length > 0
+				);
+			}
+			function S( t ) {
+				const n = t.post_types || [];
+				if ( n.length ) {
+					n.push( 'wp_block' );
+					const e = acf.get( 'postType' );
+					if ( ! n.includes( e ) ) return ! 1;
+				}
+				if (
+					'string' == typeof t.icon &&
+					'<svg' === t.icon.substr( 0, 4 )
+				) {
+					const n = t.icon;
+					t.icon = ( 0, e.jsx )( $, { children: n } );
+				}
+				t.icon || delete t.icon,
+					wp.blocks
+						.getCategories()
+						.filter( ( { slug: e } ) => e === t.category )
+						.pop() || ( t.category = 'common' ),
+					( t = acf.parseArgs( t, {
+						title: '',
+						name: '',
+						category: '',
+						api_version: 2,
+						acf_block_version: 1,
+					} ) );
+				for ( const e in t.attributes )
+					'default' in t.attributes[ e ] &&
+						0 === t.attributes[ e ].default.length &&
+						delete t.attributes[ e ].default;
+				t.supports.anchor &&
+					( t.attributes.anchor = { type: 'string' } );
+				let i = L,
+					a = H;
+				var s;
+				( t.supports.alignText || t.supports.align_text ) &&
+					( ( t.attributes = Y(
+						t.attributes,
+						'align_text',
+						'string'
+					) ),
+					( i = ( function ( t, n ) {
+						const r = J;
+						return (
+							( n.alignText = r( n.alignText ) ),
+							class extends m {
+								render() {
+									const { attributes: n, setAttributes: i } =
+											this.props,
+										{ alignText: a } = n;
+									return ( 0, e.jsxs )( h, {
+										children: [
+											( 0, e.jsx )( o, {
+												group: 'block',
+												children: ( 0, e.jsx )( l, {
+													value: r( a ),
+													onChange: function ( e ) {
+														i( {
+															alignText: r( e ),
+														} );
+													},
+												} ),
+											} ),
+											( 0, e.jsx )( t, {
+												...this.props,
+											} ),
+										],
+									} );
+								}
+							}
+						);
+					} )( i, t ) ) ),
+					( t.supports.alignContent || t.supports.align_content ) &&
+						( ( t.attributes = Y(
+							t.attributes,
+							'align_content',
+							'string'
+						) ),
+						( i = ( function ( t, n ) {
+							let i,
+								a,
+								s =
+									n.supports.align_content ||
+									n.supports.alignContent;
+							return (
+								'matrix' === s
+									? ( ( i = v || k ), ( a = X ) )
+									: ( ( i = c ), ( a = W ) ),
+								i === r
+									? ( console.warn(
+											`The "${ s }" alignment component was not found.`
+									  ),
+									  t )
+									: ( ( n.alignContent = a(
+											n.alignContent
+									  ) ),
+									  class extends m {
+											render() {
+												const {
+														attributes: n,
+														setAttributes: r,
+													} = this.props,
+													{ alignContent: s } = n;
+												return ( 0, e.jsxs )( h, {
+													children: [
+														( 0, e.jsx )( o, {
+															group: 'block',
+															children: ( 0,
+															e.jsx )( i, {
+																label: acf.__(
+																	'Change content alignment'
+																),
+																value: a( s ),
+																onChange:
+																	function (
+																		e
+																	) {
+																		r( {
+																			alignContent:
+																				a(
+																					e
+																				),
+																		} );
+																	},
+															} ),
+														} ),
+														( 0, e.jsx )( t, {
+															...this.props,
+														} ),
+													],
+												} );
+											}
+									  } )
+							);
+						} )( i, t ) ) ),
+					( t.supports.fullHeight || t.supports.full_height ) &&
+						( ( t.attributes = Y(
+							t.attributes,
+							'full_height',
+							'boolean'
+						) ),
+						( s = i ),
+						t.blockType,
+						( i = y
+							? class extends m {
+									render() {
+										const {
+												attributes: t,
+												setAttributes: n,
+											} = this.props,
+											{ fullHeight: r } = t;
+										return ( 0, e.jsxs )( h, {
+											children: [
+												( 0, e.jsx )( o, {
+													group: 'block',
+													children: ( 0, e.jsx )( y, {
+														isActive: r,
+														onToggle: function (
+															e
+														) {
+															n( {
+																fullHeight: e,
+															} );
+														},
+													} ),
+												} ),
+												( 0, e.jsx )( s, {
+													...this.props,
+												} ),
+											],
+										} );
+									}
+							  }
+							: s ) ),
+					( t.edit = ( t ) => (
+						wp.element.useEffect(
+							() => () => {
+								wp.data.dispatch( 'core/editor' ) &&
+									wp.data
+										.dispatch( 'core/editor' )
+										.unlockPostSaving(
+											'acf/block/' + t.clientId
+										);
+							},
+							[]
+						),
+						( 0, e.jsx )( i, { ...t } )
+					) ),
+					( t.save = () => ( 0, e.jsx )( a, {} ) ),
+					( w[ t.name ] = t );
+				const d = wp.blocks.registerBlockType( t.name, t );
+				return (
+					d.attributes.anchor &&
+						( d.attributes.anchor = { type: 'string' } ),
+					d
+				);
+			}
+			acf.blockInstances = {};
+			const A = {},
+				T = {};
+			function B( e ) {
+				const {
+						attributes: r = {},
+						context: o = {},
+						query: i = {},
+						clientId: a = null,
+						delay: s = 0,
+					} = e,
+					l = t( JSON.stringify( { ...r, ...o, ...i } ) ),
+					c = A[ l ] || {
+						query: {},
+						timeout: ! 1,
+						promise: n.Deferred(),
+						started: ! 1,
+					};
+				return (
+					( c.query = { ...c.query, ...i } ),
+					c.started ||
+						( clearTimeout( c.timeout ),
+						( c.timeout = setTimeout( () => {
+							( c.started = ! 0 ),
+								T[ l ]
+									? ( ( A[ l ] = null ),
+									  c.promise.resolve.apply(
+											T[ l ][ 0 ],
+											T[ l ][ 1 ]
+									  ) )
+									: n
+											.ajax( {
+												url: acf.get( 'ajaxurl' ),
+												dataType: 'json',
+												type: 'post',
+												cache: ! 1,
+												data: acf.prepareForAjax( {
+													action: 'acf/ajax/fetch-block',
+													block: JSON.stringify( r ),
+													clientId: a,
+													context:
+														JSON.stringify( o ),
+													query: c.query,
+												} ),
+											} )
+											.always( () => {
+												A[ l ] = null;
+											} )
+											.done( function () {
+												( T[ l ] = [
+													this,
+													arguments,
+												] ),
+													c.promise.resolve.apply(
+														this,
+														arguments
+													);
+											} )
+											.fail( function () {
+												c.promise.reject.apply(
+													this,
+													arguments
+												);
+											} );
+						}, s ) ),
+						( A[ l ] = c ) ),
+					c.promise
+				);
+			}
+			function F( e, t ) {
+				return JSON.stringify( e ) === JSON.stringify( t );
+			}
+			function O( t, n, r = 0 ) {
+				const o = ( function ( e, t ) {
+					switch ( e ) {
+						case 'innerblocks':
+							return t < 2 ? a : 'ACFInnerBlocks';
+						case 'script':
+							return q;
+						case '#comment':
+							return null;
+						default:
+							e = N( e );
+					}
+					return e;
+				} )( t.nodeName.toLowerCase(), n );
+				if ( ! o ) return null;
+				const i = {};
+				if (
+					( 1 === r &&
+						'ACFInnerBlocks' !== o &&
+						( i.ref = React.createRef() ),
+					acf
+						.arrayArgs( t.attributes )
+						.map( P )
+						.forEach( ( { name: e, value: t } ) => {
+							i[ e ] = t;
+						} ),
+					'ACFInnerBlocks' === o )
+				)
+					return ( 0, e.jsx )( R, { ...i } );
+				const s = [ o, i ];
+				return (
+					acf.arrayArgs( t.childNodes ).forEach( ( e ) => {
+						if ( e instanceof Text ) {
+							const t = e.textContent;
+							t && s.push( t );
+						} else s.push( O( e, n, r + 1 ) );
+					} ),
+					React.createElement.apply( this, s )
+				);
+			}
+			function N( e ) {
+				return acf.isget( acf, 'jsxNameReplacements', e ) || e;
+			}
+			function R( t ) {
+				const { className: n = 'acf-innerblocks-container' } = t,
+					r = x( { className: n }, t );
+				return ( 0, e.jsx )( 'div', { ...r, children: r.children } );
+			}
+			function P( e ) {
+				let t = e.name,
+					n = e.value,
+					r = acf.applyFilters(
+						'acf_blocks_parse_node_attr',
+						! 1,
+						e
+					);
+				if ( r ) return r;
+				switch ( t ) {
+					case 'class':
+						t = 'className';
+						break;
+					case 'style':
+						const e = {};
+						n.split( ';' ).forEach( ( t ) => {
+							const n = t.indexOf( ':' );
+							if ( n > 0 ) {
+								let r = t.substr( 0, n ).trim();
+								const o = t.substr( n + 1 ).trim();
+								'-' !== r.charAt( 0 ) &&
+									( r = acf.strCamelCase( r ) ),
+									( e[ r ] = o );
+							}
+						} ),
+							( n = e );
+						break;
+					default:
+						if ( 0 === t.indexOf( 'data-' ) ) break;
+						t = N( t );
+						const r = n.charAt( 0 );
+						( '[' !== r && '{' !== r ) || ( n = JSON.parse( n ) ),
+							( 'true' !== n && 'false' !== n ) ||
+								( n = 'true' === n );
+				}
+				return { name: t, value: n };
+			}
+			acf.parseJSX = ( e, t ) => (
+				( e = ( e = '<div>' + e + '</div>' ).replace(
+					/<InnerBlocks([^>]+)?\/>/,
+					'<InnerBlocks$1></InnerBlocks>'
+				) ),
+				O( n( e )[ 0 ], t, 0 ).props.children
+			);
+			const M = g(
+				( t ) =>
+					class extends m {
+						constructor( e ) {
+							super( e );
+							const { name: t, attributes: n } = this.props,
+								o = E( t );
+							if ( ! o ) return;
+							Object.keys( n ).forEach( ( e ) => {
+								'' === n[ e ] && delete n[ e ];
+							} );
+							const i = {
+								full_height: 'fullHeight',
+								align_content: 'alignContent',
+								align_text: 'alignText',
+							};
+							Object.keys( i ).forEach( ( e ) => {
+								n[ e ] !== r
+									? ( n[ i[ e ] ] = n[ e ] )
+									: n[ i[ e ] ] === r &&
+									  o[ e ] !== r &&
+									  ( n[ i[ e ] ] = o[ e ] ),
+									delete o[ e ],
+									delete n[ e ];
+							} );
+							for ( let e in o.attributes )
+								n[ e ] === r &&
+									o[ e ] !== r &&
+									( n[ e ] = o[ e ] );
+						}
+						render() {
+							return ( 0, e.jsx )( t, { ...this.props } );
+						}
+					},
+				'withDefaultAttributes'
+			);
+			function H() {
+				return ( 0, e.jsx )( a.Content, {} );
+			}
+			wp.hooks.addFilter(
+				'editor.BlockListBlock',
+				'acf/with-default-attributes',
+				M
+			);
+			class L extends m {
+				constructor( e ) {
+					super( e ), this.setup();
+				}
+				setup() {
+					const { name: e, attributes: t, clientId: n } = this.props,
+						r = E( e );
+					function o( e ) {
+						e.includes( t.mode ) || ( t.mode = e[ 0 ] );
+					}
+					if ( j( n ) || I() ) o( [ 'preview' ] );
+					else
+						switch ( r.mode ) {
+							case 'edit':
+								o( [ 'edit', 'preview' ] );
+								break;
+							case 'preview':
+								o( [ 'preview', 'edit' ] );
+								break;
+							default:
+								o( [ 'auto' ] );
+						}
+				}
+				render() {
+					const {
+							name: t,
+							attributes: n,
+							setAttributes: r,
+							clientId: a,
+						} = this.props,
+						s = E( t ),
+						l = j( a ) || I();
+					let { mode: c } = n;
+					l && ( c = 'preview' );
+					let p = s.supports.mode;
+					( 'auto' === c || l ) && ( p = ! 1 );
+					const f =
+							'preview' === c
+								? acf.__( 'Switch to Edit' )
+								: acf.__( 'Switch to Preview' ),
+						m = 'preview' === c ? 'edit' : 'welcome-view-site';
+					return ( 0, e.jsxs )( h, {
+						children: [
+							( 0, e.jsx )( o, {
+								children:
+									p &&
+									( 0, e.jsx )( d, {
+										children: ( 0, e.jsx )( u, {
+											className:
+												'components-icon-button components-toolbar__control',
+											label: f,
+											icon: m,
+											onClick: function () {
+												r( {
+													mode:
+														'preview' === c
+															? 'edit'
+															: 'preview',
+												} );
+											},
+										} ),
+									} ),
+							} ),
+							( 0, e.jsx )( i, {
+								children:
+									'preview' === c &&
+									( 0, e.jsx )( 'div', {
+										className:
+											'acf-block-component acf-block-panel',
+										children: ( 0, e.jsx )( U, {
+											...this.props,
+										} ),
+									} ),
+							} ),
+							( 0, e.jsx )( D, { ...this.props } ),
+						],
+					} );
+				}
+			}
+			function D( t ) {
+				const {
+						attributes: n,
+						isSelected: r,
+						name: o,
+						clientId: i,
+					} = t,
+					{ mode: a } = n,
+					l = b( ( e ) => {
+						const t =
+							e( 'core/block-editor' ).getBlockRootClientId( i );
+						return e( 'core/block-editor' ).getBlockIndex( i, t );
+					} );
+				let c = ! 0,
+					d = 'acf-block-component acf-block-body';
+				return (
+					( ( 'auto' === a && ! r ) || 'preview' === a ) &&
+						( ( d += ' acf-block-preview' ), ( c = ! 1 ) ),
+					i in acf.blockInstances ||
+						( acf.blockInstances[ i ] = {
+							validation_errors: ! 1,
+							mode: a,
+						} ),
+					( acf.blockInstances[ i ].mode = a ),
+					r ||
+						( C( o ) &&
+							acf.blockInstances[ i ].validation_errors &&
+							( d += ' acf-block-has-validation-error' ),
+						( acf.blockInstances[ i ].has_been_deselected = ! 0 ) ),
+					_( o ) > 1
+						? ( 0, e.jsx )( 'div', {
+								...s( { className: d } ),
+								children: c
+									? ( 0, e.jsx )( U, { ...t, index: l } )
+									: ( 0, e.jsx )( z, { ...t, index: l } ),
+						  } )
+						: ( 0, e.jsx )( 'div', {
+								...s(),
+								children: ( 0, e.jsx )( 'div', {
+									className:
+										'acf-block-component acf-block-body',
+									children: c
+										? ( 0, e.jsx )( U, { ...t, index: l } )
+										: ( 0, e.jsx )( z, { ...t, index: l } ),
+								} ),
+						  } )
+				);
+			}
+			class $ extends m {
+				render() {
+					return ( 0, e.jsx )( 'div', {
+						dangerouslySetInnerHTML: {
+							__html: this.props.children,
+						},
+					} );
+				}
+			}
+			class q extends m {
+				render() {
+					return ( 0, e.jsx )( 'div', {
+						ref: ( e ) => ( this.el = e ),
+					} );
+				}
+				setHTML( e ) {
+					n( this.el ).html( `<script>${ e }<\/script>` );
+				}
+				componentDidUpdate() {
+					this.setHTML( this.props.children );
+				}
+				componentDidMount() {
+					this.setHTML( this.props.children );
+				}
+			}
+			class V extends m {
+				constructor( e ) {
+					super( e ),
+						( this.setRef = this.setRef.bind( this ) ),
+						( this.id = '' ),
+						( this.el = ! 1 ),
+						( this.subscribed = ! 0 ),
+						( this.renderMethod = 'jQuery' ),
+						( this.passedValidation = ! 1 ),
+						this.setup( e ),
+						this.loadState();
+				}
+				setup( e ) {
+					const t = this.constructor.name,
+						n = e.clientId;
+					n in acf.blockInstances ||
+						( acf.blockInstances[ n ] = {
+							validation_errors: ! 1,
+							mode: e.mode,
+						} ),
+						t in acf.blockInstances[ n ] ||
+							( acf.blockInstances[ n ][ t ] = {} );
+				}
+				fetch() {}
+				maybePreload( e, t, n ) {
+					if (
+						( acf.debug( 'Preload check', e, t, n ),
+						j( this.props.clientId ) )
+					)
+						return (
+							acf.debug(
+								'Preload failed: Block is in query loop.'
+							),
+							! 1
+						);
+					const r = acf.get( 'preloadedBlocks' );
+					if ( ! r || ! r[ e ] )
+						return (
+							acf.debug( 'Preload failed: Block not preloaded.' ),
+							! 1
+						);
+					const o = { ...r[ e ] };
+					return ( n && ! o.form ) || ( ! n && o.form )
+						? ( acf.debug(
+								'Preload failed: Correct state not preloaded.',
+								n ? 'form' : 'preview'
+						  ),
+						  ! 1 )
+						: ( ( o.html = o.html.replaceAll( e, t ) ),
+						  o.validation &&
+								o.validation.errors &&
+								( o.validation.errors = o.validation.errors.map(
+									( n ) => (
+										( n.input = n.input.replaceAll(
+											e,
+											t
+										) ),
+										n
+									)
+								) ),
+						  acf.debug( 'Preload successful', o ),
+						  o );
+				}
+				loadState() {
+					const e = acf.blockInstances[ this.props.clientId ] || {};
+					this.state = e[ this.constructor.name ] || {};
+				}
+				setState( e ) {
+					( acf.blockInstances[ this.props.clientId ][
+						this.constructor.name
+					] = {
+						...this.state,
+						...e,
+					} ),
+						( this.subscribed || acf.get( 'StrictMode' ) ) &&
+							super.setState( e ),
+						acf.debug(
+							'SetState',
+							Object.assign( {}, this ),
+							this.props.clientId,
+							this.constructor.name,
+							Object.assign(
+								{},
+								acf.blockInstances[ this.props.clientId ][
+									this.constructor.name
+								]
+							)
+						);
+				}
+				setHtml( e ) {
+					if ( ( e = e ? e.trim() : '' ) === this.state.html ) return;
+					const t = { html: e };
+					if ( 'jsx' === this.renderMethod ) {
+						if (
+							( ( t.jsx = acf.parseJSX(
+								e,
+								_( this.props.name )
+							) ),
+							t.jsx ||
+								( console.warn(
+									'Your ACF block template contains no valid HTML elements. Appending a empty div to prevent React JS errors.'
+								),
+								( t.html += '<div></div>' ),
+								( t.jsx = acf.parseJSX(
+									t.html,
+									_( this.props.name )
+								) ) ),
+							Array.isArray( t.jsx ) )
+						) {
+							let e = t.jsx.find( ( e ) =>
+								React.isValidElement( e )
+							);
+							t.ref = e.ref;
+						} else t.ref = t.jsx.ref;
+						t.$el = n( this.el );
+					} else t.$el = n( e );
+					this.setState( t );
+				}
+				setRef( e ) {
+					this.el = e;
+				}
+				render() {
+					return this.state.jsx
+						? _( this.props.name ) > 1
+							? ( this.setRef( this.state.jsx ), this.state.jsx )
+							: ( 0, e.jsx )( 'div', {
+									ref: this.setRef,
+									children: this.state.jsx,
+							  } )
+						: ( 0, e.jsx )( 'div', {
+								ref: this.setRef,
+								children: ( 0, e.jsx )( p, {
+									children: ( 0, e.jsx )( f, {} ),
+								} ),
+						  } );
+				}
+				shouldComponentUpdate( { index: e }, { html: t } ) {
+					return (
+						e !== this.props.index && this.componentWillMove(),
+						t !== this.state.html
+					);
+				}
+				display( e ) {
+					if ( 'jQuery' === this.renderMethod ) {
+						const t = this.state.$el,
+							r = t.parent(),
+							o = n( this.el );
+						( acf.get( 'StrictMode' ) &&
+							'append' !== e &&
+							! this.subscribed ) ||
+							o.html( t ),
+							r.length &&
+								r[ 0 ] !== o[ 0 ] &&
+								r.html( t.clone() );
+					}
+					switch (
+						( this.getValidationErrors() && this.isNotNewlyAdded()
+							? this.lockBlockForSaving()
+							: this.unlockBlockForSaving(),
+						e )
+					) {
+						case 'append':
+							this.componentDidAppend();
+							break;
+						case 'remount':
+							this.componentDidRemount();
+					}
+				}
+				validate() {}
+				componentDidMount() {
+					this.state.html === r
+						? this.fetch()
+						: this.display( 'remount' );
+				}
+				componentDidUpdate( e, t ) {
+					this.display( 'append' );
+				}
+				componentDidAppend() {
+					acf.doAction( 'append', this.state.$el );
+				}
+				componentWillUnmount() {
+					( acf.get( 'StrictMode' ) && ! this.subscribed ) ||
+						acf.doAction( 'unmount', this.state.$el ),
+						( this.subscribed = ! 1 );
+				}
+				componentDidRemount() {
+					( this.subscribed = ! 0 ),
+						setTimeout( () => {
+							acf.doAction( 'remount', this.state.$el );
+						} );
+				}
+				componentWillMove() {
+					acf.doAction( 'unmount', this.state.$el ),
+						setTimeout( () => {
+							acf.doAction( 'remount', this.state.$el );
+						} );
+				}
+				isNotNewlyAdded() {
+					return (
+						acf.blockInstances[ this.props.clientId ]
+							.has_been_deselected || ! 1
+					);
+				}
+				hasShownValidation() {
+					return (
+						acf.blockInstances[ this.props.clientId ]
+							.shown_validation || ! 1
+					);
+				}
+				setShownValidation() {
+					acf.blockInstances[ this.props.clientId ].shown_validation =
+						! 0;
+				}
+				setValidationErrors( e ) {
+					acf.blockInstances[
+						this.props.clientId
+					].validation_errors = e;
+				}
+				getValidationErrors() {
+					return acf.blockInstances[ this.props.clientId ]
+						.validation_errors;
+				}
+				getMode() {
+					return acf.blockInstances[ this.props.clientId ].mode;
+				}
+				lockBlockForSaving() {
+					wp.data.dispatch( 'core/editor' ) &&
+						wp.data
+							.dispatch( 'core/editor' )
+							.lockPostSaving(
+								'acf/block/' + this.props.clientId
+							);
+				}
+				unlockBlockForSaving() {
+					wp.data.dispatch( 'core/editor' ) &&
+						wp.data
+							.dispatch( 'core/editor' )
+							.unlockPostSaving(
+								'acf/block/' + this.props.clientId
+							);
+				}
+				displayValidation( e ) {
+					if ( ! C( this.props.name ) )
+						return void acf.debug(
+							'Block does not support validation'
+						);
+					if ( ! e || e.hasClass( 'acf-empty-block-fields' ) )
+						return void acf.debug(
+							'There is no edit form available to validate.'
+						);
+					const t = this.getValidationErrors();
+					acf.debug(
+						'Starting handle validation',
+						Object.assign( {}, this ),
+						Object.assign( {}, e ),
+						t
+					),
+						this.setShownValidation();
+					let n = acf.getBlockFormValidator( e );
+					n.clearErrors(),
+						acf.doAction( 'blocks/validation/pre_apply', t ),
+						t
+							? ( n.addErrors( t ),
+							  n.showErrors( 'after' ),
+							  this.lockBlockForSaving() )
+							: ( n.has( 'notice' ) &&
+									( n.get( 'notice' ).update( {
+										type: 'success',
+										text: acf.__( 'Validation successful' ),
+										timeout: 1e3,
+									} ),
+									n.set( 'notice', null ) ),
+							  this.unlockBlockForSaving() ),
+						acf.doAction( 'blocks/validation/post_apply', t );
+				}
+			}
+			class U extends V {
+				setup( e ) {
+					( this.id = `BlockForm-${ e.clientId }` ), super.setup( e );
+				}
+				fetch( e = ! 1, t = ! 1 ) {
+					const { context: n, clientId: r, name: o } = this.props;
+					let { attributes: i } = this.props,
+						a = { form: ! 0 };
+					e && ( ( a = { validate: ! 0 } ), ( i.data = t ) );
+					const s = G( i, n );
+					acf.debug( 'BlockForm fetch', i, a );
+					const l = this.maybePreload( s, r, ! 0 );
+					if ( l )
+						return (
+							this.setHtml(
+								acf.applyFilters(
+									'blocks/form/render',
+									l.html,
+									! 0
+								)
+							),
+							void (
+								l.validation &&
+								this.setValidationErrors( l.validation.errors )
+							)
+						);
+					C( o ) || ( a.validate = ! 1 ),
+						B( {
+							attributes: i,
+							context: n,
+							clientId: r,
+							query: a,
+						} ).done( ( { data: e } ) => {
+							acf.debug( 'fetch block form promise' ),
+								e
+									? ( e.form &&
+											this.setHtml(
+												acf.applyFilters(
+													'blocks/form/render',
+													e.form.replaceAll(
+														e.clientId,
+														r
+													),
+													! 1
+												)
+											),
+									  e.validation &&
+											this.setValidationErrors(
+												e.validation.errors
+											),
+									  this.isNotNewlyAdded() &&
+											( acf.debug(
+												"Block has already shown it's invalid. The form needs to show validation errors"
+											),
+											this.validate() ) )
+									: this.setHtml(
+											`<div class="acf-block-fields acf-fields acf-empty-block-fields">${ acf.__(
+												'Error loading block form'
+											) }</div>`
+									  );
+						} );
+				}
+				validate( e = ! 0 ) {
+					e && this.loadState(),
+						acf.debug(
+							'BlockForm calling validate with state',
+							Object.assign( {}, this )
+						),
+						super.displayValidation( this.state.$el );
+				}
+				shouldComponentUpdate( e, t ) {
+					return (
+						C( this.props.name ) &&
+							this.state.$el &&
+							this.isNotNewlyAdded() &&
+							! this.hasShownValidation() &&
+							this.validate( ! 1 ),
+						super.shouldComponentUpdate( e, t )
+					);
+				}
+				componentWillUnmount() {
+					super.componentWillUnmount(),
+						acf.debug( 'BlockForm Component did unmount' );
+				}
+				componentDidRemount() {
+					super.componentDidRemount(),
+						acf.debug( 'BlockForm component did remount' );
+					const { $el: e } = this.state;
+					C( this.props.name ) &&
+						this.isNotNewlyAdded() &&
+						( acf.debug(
+							"Block has already shown it's invalid. The form needs to show validation errors"
+						),
+						this.validate() ),
+						! 0 !== e.data( 'acf-events-added' ) &&
+							this.componentDidAppend();
+				}
+				componentDidAppend() {
+					super.componentDidAppend(),
+						acf.debug( 'BlockForm component did append' );
+					const {
+							attributes: e,
+							setAttributes: t,
+							clientId: n,
+							name: r,
+						} = this.props,
+						o = this,
+						{ $el: i } = this.state;
+					function a( a = ! 1 ) {
+						const s = acf.serialize( i, `acf-block_${ n }` );
+						a ? ( e.data = s ) : t( { data: s } ),
+							C( r ) &&
+								! a &&
+								'edit' === o.getMode() &&
+								( acf.debug(
+									'No block preview currently available. Need to trigger a validation only fetch.'
+								),
+								o.fetch( ! 0, s ) );
+					}
+					let s = ! 1;
+					i.on( 'change keyup', () => {
+						clearTimeout( s ), ( s = setTimeout( a, 300 ) );
+					} ),
+						i.data( 'acf-events-added', ! 0 ),
+						e.data || a( ! 0 );
+				}
+			}
+			class z extends V {
+				setup( e ) {
+					const t = E( e.name ),
+						n = acf.isget( this.props, 'context', 'postId' );
+					( this.id = `BlockPreview-${ e.clientId }` ),
+						super.setup( e ),
+						n &&
+							( this.id = `BlockPreview-${ e.clientId }-${ n }` ),
+						t.supports.jsx && ( this.renderMethod = 'jsx' );
+				}
+				fetch( e = {} ) {
+					const {
+							attributes: t = this.props.attributes,
+							clientId: n = this.props.clientId,
+							context: r = this.props.context,
+							delay: o = 0,
+						} = e,
+						{ name: i } = this.props;
+					this.setState( { prevAttributes: t, prevContext: r } );
+					const a = G( t, r );
+					let s = this.maybePreload( a, n, ! 1 );
+					if ( s )
+						return (
+							1 == _( i ) &&
+								( s.html =
+									'<div class="acf-block-preview">' +
+									s.html +
+									'</div>' ),
+							this.setHtml(
+								acf.applyFilters(
+									'blocks/preview/render',
+									s.html,
+									! 0
+								)
+							),
+							void (
+								s.validation &&
+								this.setValidationErrors( s.validation.errors )
+							)
+						);
+					let l = { preview: ! 0 };
+					C( i ) || ( l.validate = ! 1 ),
+						B( {
+							attributes: t,
+							context: r,
+							clientId: n,
+							query: l,
+							delay: o,
+						} ).done( ( { data: e } ) => {
+							if ( ! e )
+								return void this.setHtml(
+									`<div class="acf-block-fields acf-fields acf-empty-block-fields">${ acf.__(
+										'Error previewing block'
+									) }</div>`
+								);
+							let t = e.preview.replaceAll( e.clientId, n );
+							1 == _( i ) &&
+								( t =
+									'<div class="acf-block-preview">' +
+									t +
+									'</div>' ),
+								acf.debug( 'fetch block render promise' ),
+								this.setHtml(
+									acf.applyFilters(
+										'blocks/preview/render',
+										t,
+										! 1
+									)
+								),
+								e.validation &&
+									this.setValidationErrors(
+										e.validation.errors
+									),
+								this.isNotNewlyAdded() && this.validate();
+						} );
+				}
+				validate() {
+					const e =
+						( acf.blockInstances[ this.props.clientId ] || {} )
+							.BlockForm || ! 1;
+					e && super.displayValidation( e.$el );
+				}
+				componentDidAppend() {
+					super.componentDidAppend(), this.renderBlockPreviewEvent();
+				}
+				shouldComponentUpdate( e, t ) {
+					const n = e.attributes,
+						r = this.props.attributes;
+					if ( ! F( n, r ) || ! F( e.context, this.props.context ) ) {
+						let t = 0;
+						n.className !== r.className && ( t = 300 ),
+							n.anchor !== r.anchor && ( t = 300 ),
+							acf.debug(
+								'Triggering fetch from block preview shouldComponentUpdate'
+							),
+							this.fetch( {
+								attributes: n,
+								context: e.context,
+								delay: t,
+							} );
+					}
+					return super.shouldComponentUpdate( e, t );
+				}
+				renderBlockPreviewEvent() {
+					const { attributes: e, name: t } = this.props,
+						{ $el: r, ref: o } = this.state;
+					var i;
+					const a = e.name.replace( 'acf/', '' );
+					( i =
+						o && o.current
+							? n( o.current ).parent()
+							: 1 == _( t )
+							? r
+							: r.parents( '.acf-block-preview' ) ),
+						acf.doAction( 'render_block_preview', i, e ),
+						acf.doAction(
+							`render_block_preview/type=${ a }`,
+							i,
+							e
+						);
+				}
+				componentDidRemount() {
+					super.componentDidRemount(),
+						acf.debug(
+							'Checking if fetch is required in BlockPreview componentDidRemount',
+							Object.assign( {}, this.state.prevAttributes ),
+							Object.assign( {}, this.props.attributes ),
+							Object.assign( {}, this.state.prevContext ),
+							Object.assign( {}, this.props.context )
+						),
+						( F(
+							this.state.prevAttributes,
+							this.props.attributes
+						) &&
+							F( this.state.prevContext, this.props.context ) ) ||
+							( acf.debug(
+								'Triggering block preview fetch from componentDidRemount'
+							),
+							this.fetch() ),
+						this.renderBlockPreviewEvent();
+				}
+			}
+			function W( e ) {
+				return [ 'top', 'center', 'bottom' ].includes( e ) ? e : 'top';
+			}
+			function J( e ) {
+				const t = acf.get( 'rtl' ) ? 'right' : 'left';
+				return [ 'left', 'center', 'right' ].includes( e ) ? e : t;
+			}
+			function X( e ) {
+				if ( e ) {
+					const [ t, n ] = e.split( ' ' );
+					return `${ W( t ) } ${ J( n ) }`;
+				}
+				return 'center center';
+			}
+			function Y( e, t, n ) {
+				return ( e[ t ] = { type: n } ), e;
+			}
+			function G( e, n ) {
+				return (
+					( e._acf_context = K( n ) ), t( JSON.stringify( K( e ) ) )
+				);
+			}
+			function K( e ) {
+				return Object.keys( e )
+					.sort()
+					.reduce( ( t, n ) => ( ( t[ n ] = e[ n ] ), t ), {} );
+			}
+			acf.addAction( 'prepare', function () {
+				wp.blockEditor || ( wp.blockEditor = wp.editor );
+				const e = acf.get( 'blockTypes' );
+				e &&
+					e.forEach( ( e ) => {
+						parseInt( e.acf_block_version ) <= 2 && S( e );
+					} );
+			} );
+		} )( jQuery );
+		const r = ( e ) => {
+				wp.data.dispatch( 'core/editor' ) &&
+					wp.data
+						.dispatch( 'core/editor' )
+						.lockPostSaving( 'acf/block/' + e );
+			},
+			o = ( e ) => {
+				wp.data.dispatch( 'core/editor' ) &&
+					wp.data
+						.dispatch( 'core/editor' )
+						.unlockPostSaving( 'acf/block/' + e );
+			},
+			i = ( e ) =>
+				!! wp.data.dispatch( 'core/editor' ) &&
+				wp.data
+					.select( 'core/editor' )
+					.isPostSavingLocked( `acf/block/${ e }` ),
+			a = ( e ) =>
+				Object.keys( e )
+					.sort()
+					.reduce( ( t, n ) => ( ( t[ n ] = e[ n ] ), t ), {} ),
+			s = n( 503 ),
+			l = ( e, t ) => {
+				const n = { ...e };
+				return (
+					delete n.hasAcfError,
+					( n._acf_context = a( t ) ),
+					s( JSON.stringify( a( n ) ) )
+				);
+			},
+			{ InnerBlocks: c } = wp.blockEditor,
+			d =
+				wp.blockEditor.__experimentalUseInnerBlocksProps ||
+				wp.blockEditor.useInnerBlocksProps,
+			{ createRef: u, createElement: p, useEffect: f } = wp.element,
+			h = ( e, t, n, r, o, i ) =>
+				m(
+					i(
+						( e = ( e = '<div>' + e + '</div>' ).replace(
+							/<InnerBlocks([^>]+)?\/>/,
+							'<InnerBlocks$1></InnerBlocks>'
+						) )
+					)[ 0 ],
+					0,
+					t,
+					n,
+					r,
+					o
+				).props.children;
+		function m( t, n = 0, r, o, i, a ) {
+			const s = ( function ( e ) {
+				switch ( e ) {
+					case 'innerblocks':
+						return 'ACFInnerBlocks';
+					case 'script':
+						return k;
+					case '#comment':
+						return null;
+					default:
+						e = b( e );
+				}
+				return e;
+			} )( t.nodeName.toLowerCase() );
+			if ( ! s ) return null;
+			const l = {};
+			if (
+				( 1 === n && 'ACFInnerBlocks' !== s && ( l.ref = u() ),
+				acf
+					.arrayArgs( t.attributes )
+					.map( v )
+					.forEach( ( { name: e, value: t } ) => {
+						l[ e ] = t;
+					} ),
+				t.hasAttribute( 'data-acf-inline-fields' ) &&
+					( ( l.style = { ...y( t ), pointerEvents: 'all' } ),
+					( l.role = 'button' ),
+					( l.tabIndex = 0 ),
+					( l.onFocus = ( e ) => {
+						e.stopPropagation(),
+							r(
+								t.attributes.getNamedItem(
+									'data-acf-inline-fields-uid'
+								).value
+							);
+					} ),
+					( l.onMouseDown = ( e ) => e.stopPropagation() ),
+					( l.onClick = ( e ) => {
+						e.stopPropagation();
+						const n = e.target.closest( 'a' );
+						n &&
+							'A' === n.tagName &&
+							( e.preventDefault(),
+							acf.debug(
+								`Navigation prevented for ${ n.href }`
+							) ),
+							e.target.hasAttribute(
+								'data-acf-inline-contenteditable'
+							) ||
+								r(
+									t.attributes.getNamedItem(
+										'data-acf-inline-fields-uid'
+									).value
+								);
+					} ),
+					( l.onKeyDown = ( e ) => {
+						if ( 'Tab' === e.key && e.shiftKey ) {
+							e.preventDefault();
+							const n = document
+								.querySelector( '.acf-inline-editing-toolbar' )
+								.querySelector( 'button' );
+							n &&
+								( n.focus(),
+								r(
+									t.attributes.getNamedItem(
+										'data-acf-inline-fields-uid'
+									).value
+								) );
+						}
+						if ( 'Enter' === e.key ) {
+							e.stopPropagation();
+							const n = e.target.closest( 'a' );
+							n &&
+								'A' === n.tagName &&
+								( e.preventDefault(),
+								acf.debug(
+									`Navigation prevented for ${ n.href }`
+								) ),
+								r(
+									t.attributes.getNamedItem(
+										'data-acf-inline-fields-uid'
+									).value
+								);
+						}
+					} ) ),
+				t.hasAttribute( 'data-acf-inline-contenteditable' ) )
+			) {
+				const e = t.attributes.getNamedItem(
+					'data-acf-inline-contenteditable-field-slug'
+				).value;
+				( a
+					? a.filter(
+							( t ) =>
+								t.name === e &&
+								( 'text' === t.type || 'textarea' === t.type )
+					  )
+					: []
+				).length > 0
+					? ( ( l.contentEditable = ! 0 ),
+					  ( l.suppressContentEditableWarning = ! 0 ),
+					  ( l.role = 'input' ),
+					  ( l.tabIndex = 0 ),
+					  ( l.onFocus = ( e ) => {
+							const n = e.target.closest( 'a' );
+							n &&
+								'A' === n.tagName &&
+								( e.preventDefault(),
+								acf.debug(
+									`Navigation prevented for ${ n.href }`
+								) ),
+								e.stopPropagation(),
+								i(
+									t.attributes.getNamedItem(
+										'data-acf-inline-contenteditable-field-slug'
+									).value
+								),
+								t.hasAttribute( 'data-acf-inline-fields' )
+									? r(
+											t.attributes.getNamedItem(
+												'data-acf-inline-fields-uid'
+											).value
+									  )
+									: r( null );
+					  } ),
+					  ( l.onPaste = ( e ) => {
+							e.preventDefault();
+							const t = e.clipboardData.getData( 'text/plain' );
+							e.currentTarget.textContent =
+								e.currentTarget.textContent + t;
+					  } ) )
+					: ( delete l[
+							'data-acf-inline-contenteditable-field-slug'
+					  ],
+					  delete l[ 'data-acf-inline-contenteditable' ] );
+			}
+			if (
+				( t.hasAttribute( 'data-acf-inline-fields' ) ||
+					t.hasAttribute( 'data-acf-inline-contenteditable' ) ||
+					( l.onClick = ( e ) => {
+						e.target === e.currentTarget && r( null );
+					} ),
+				'ACFInnerBlocks' === s )
+			)
+				return ( 0, e.jsx )( g, { ...l } );
+			const c = [ s, l ];
+			return (
+				acf.arrayArgs( t.childNodes ).forEach( ( e ) => {
+					if ( e instanceof Text ) {
+						const t = e.textContent;
+						t && c.push( t );
+					} else c.push( m( e, n + 1, r, o, i, a ) );
+				} ),
+				p.apply( this, c )
+			);
+		}
+		function b( e ) {
+			return acf.isget( acf, 'jsxNameReplacements', e ) || e;
+		}
+		function g( t ) {
+			const { className: n = 'acf-innerblocks-container' } = t,
+				r = d( { className: n }, t );
+			return ( 0, e.jsx )( 'div', { ...r, children: r.children } );
+		}
+		function k( { children: e } ) {
+			return (
+				f( () => {
+					const t = ( function () {
+							const e = document.querySelector(
+								'[name="editor-canvas"]'
+							);
+							return e
+								? e.contentDocument || e.contentWindow.document
+								: document;
+						} )(),
+						n = t.createElement( 'script' );
+					return (
+						( n.textContent = e ),
+						t.body.appendChild( n ),
+						() => {
+							n.remove();
+						}
+					);
+				}, [ e ] ),
+				null
+			);
+		}
+		function v( e ) {
+			let t = e.name,
+				n = e.value,
+				r = acf.applyFilters( 'acf_blocks_parse_node_attr', ! 1, e );
+			if ( r ) return r;
+			switch ( t ) {
+				case 'class':
+					t = 'className';
+					break;
+				case 'style':
+					const e = {};
+					n.split( ';' ).forEach( ( t ) => {
+						const n = t.indexOf( ':' );
+						if ( n > 0 ) {
+							let r = t.substr( 0, n ).trim();
+							const o = t.substr( n + 1 ).trim();
+							'-' !== r.charAt( 0 ) &&
+								( r = acf.strCamelCase( r ) ),
+								( e[ r ] = o );
+						}
+					} ),
+						( n = e );
+					break;
+				default:
+					if ( 0 === t.indexOf( 'data-' ) ) break;
+					t = b( t );
+					const r = n.charAt( 0 );
+					( '[' !== r && '{' !== r ) || ( n = JSON.parse( n ) ),
+						( 'true' !== n && 'false' !== n ) ||
+							( n = 'true' === n );
+			}
+			return { name: t, value: n };
+		}
+		function y( e ) {
+			const t = JSON.parse( JSON.stringify( e.style ) ),
+				n = {},
+				r = Object.keys( t );
+			for ( let e = 0; e < r.length; e++ ) {
+				const o = r[ e ];
+				if ( Number.isInteger( parseInt( o ) ) ) continue;
+				const i = t[ r[ e ] ],
+					a = o.replace( /-([a-z])/g, ( e ) => e[ 1 ].toUpperCase() );
+				i && ( n[ a ] = i );
+			}
+			return n;
+		}
+		const { useState: x, useEffect: w } = wp.element,
+			{ subscribe: E, select: _ } = wp.data;
+		function C() {
+			return (
+				'edit-post/block' ===
+				_( 'core/interface' ).getActiveComplementaryArea( 'core' )
+			);
+		}
+		const { useEffect: j } = wp.element,
+			I = ( {
+				inspectorBlockFormRef: t,
+				setCurrentBlockFormContainer: n,
+			} ) => (
+				j( () => {
+					n( t.current );
+				}, [] ),
+				( 0, e.jsx )( 'div', { ref: t } )
+			),
+			{ useState: S, useEffect: A, useRef: T } = wp.element,
+			B = ( {
+				$: t,
+				clientId: n,
+				blockFormHtml: i,
+				onMount: a,
+				onChange: s,
+				validationErrors: l,
+				showValidationErrors: c,
+				acfFormRef: d,
+				userHasInteractedWithForm: u,
+				attributes: p,
+				hideFieldsInSidebar: f,
+			} ) => {
+				const [ h, m ] = S( ! 1 ),
+					[ b, g ] = S( i ),
+					[ k, v ] = S( ! 1 ),
+					y = T( null ),
+					[ x, w ] = S( ! 1 );
+				return (
+					A( () => {
+						a();
+					}, [] ),
+					A( () => {
+						k && ( u || x ) && ( s( k ), v( ! 1 ) );
+					}, [ k, u, v, s ] ),
+					A( () => {
+						! b && i && g( i );
+					}, [ i ] ),
+					A( () => {
+						if ( ! d?.current ) return;
+						const e = acf.getBlockFormValidator(
+							t( d.current ).find( '.acf-block-fields' )
+						);
+						if (
+							( e.clearErrors(),
+							e.set( 'notice', null ),
+							acf.doAction( 'blocks/validation/pre_apply', l ),
+							l )
+						)
+							c &&
+								( r( n ),
+								e.$el.find( '.acf-notice' ).remove(),
+								e.addErrors( l ),
+								e.showErrors( 'after' ) );
+						else {
+							if ( e.$el.find( '.acf-notice' ).length > 0 && c ) {
+								e.$el.find( '.acf-notice' ).remove(),
+									e.addErrors( [
+										{
+											message: acf.__(
+												'Validation successful'
+											),
+										},
+									] ),
+									e.showErrors( 'after' ),
+									e.get( 'notice' ).update( {
+										type: 'success',
+										text: acf.__( 'Validation successful' ),
+										timeout: 1e3,
+									} ),
+									e.set( 'notice', null ),
+									setTimeout( () => {
+										e.$el.find( '.acf-notice' ).remove();
+									}, 1001 );
+								const i = wp.data.dispatch( 'core/notices' );
+								function a( e ) {
+									return new Promise( function ( t ) {
+										return (
+											e.forEach( ( e ) => {
+												if (
+													( e.innerBlocks.length >
+														0 &&
+														a( e.innerBlocks ).then(
+															( e ) => {
+																if ( e )
+																	return t(
+																		! 0
+																	);
+															}
+														),
+													e.attributes.hasAcfError &&
+														e.clientId !== n )
+												)
+													return t( ! 0 );
+											} ),
+											t( ! 1 )
+										);
+									} );
+								}
+								a(
+									wp.data
+										.select( 'core/block-editor' )
+										.getBlocks()
+								).then( ( e ) => {
+									e
+										? i.createErrorNotice(
+												acf.__(
+													'An ACF Block on this page requires attention before you can save.'
+												),
+												{
+													id: 'acf-blocks-validation',
+													isDismissible: ! 0,
+												}
+										  )
+										: i.removeNotice(
+												'acf-blocks-validation'
+										  );
+								} );
+							}
+							o( n );
+						}
+						acf.doAction( 'blocks/validation/post_apply', l );
+					}, [ l, n, c ] ),
+					A( () => {
+						if ( ! d?.current || ! b ) return;
+						acf.debug( 'Remounting ACF Form' );
+						const e = d.current,
+							n = t( e );
+						let r = ! 0;
+						acf.doAction( 'remount', n ), h || ( s( n ), m( ! 0 ) );
+						const o = () => {
+								s( n );
+							},
+							i = () => {
+								if ( ! r ) return;
+								const t =
+										e.querySelectorAll( 'input, textarea' ),
+									i = e.querySelectorAll( 'select' );
+								t.forEach( ( e ) => {
+									e.removeEventListener( 'input', o ),
+										e.addEventListener( 'input', o );
+								} ),
+									i.forEach( ( e ) => {
+										e.removeEventListener( 'change', o ),
+											e.addEventListener( 'change', o );
+									} ),
+									clearTimeout( y.current ),
+									( y.current = setTimeout( () => {
+										r && v( n );
+									}, 300 ) );
+							},
+							a = new MutationObserver( i ),
+							l = new MutationObserver( () => {
+								r && ( w( ! 0 ), i() );
+							} ),
+							c = {
+								attributes: ! 0,
+								childList: ! 0,
+								subtree: ! 0,
+								characterData: ! 0,
+							};
+						return (
+							a.observe( e, c ),
+							[ ...e.querySelectorAll( 'iframe' ) ].forEach(
+								( e ) => {
+									if ( e && e.contentDocument ) {
+										const t = e.contentDocument.body;
+										t && l.observe( t, c );
+									}
+								}
+							),
+							e
+								.querySelectorAll( 'input, textarea' )
+								.forEach( ( e ) => {
+									e.addEventListener( 'input', o );
+								} ),
+							e.querySelectorAll( 'select' ).forEach( ( e ) => {
+								e.addEventListener( 'change', o );
+							} ),
+							() => {
+								( r = ! 1 ),
+									a.disconnect(),
+									l.disconnect(),
+									clearTimeout( y.current ),
+									e &&
+										( e
+											.querySelectorAll(
+												'input, textarea'
+											)
+											.forEach( ( e ) => {
+												e.removeEventListener(
+													'input',
+													o
+												);
+											} ),
+										e
+											.querySelectorAll( 'select' )
+											.forEach( ( e ) => {
+												e.removeEventListener(
+													'change',
+													o
+												);
+											} ) );
+							}
+						);
+					}, [ d, p, b ] ),
+					( 0, e.jsx )( 'div', {
+						ref: d,
+						className: 'acf-block-component acf-block-panel',
+						style: { display: f ? 'none' : null },
+						dangerouslySetInnerHTML: {
+							__html: acf.applyFilters(
+								'blocks/form/render',
+								b,
+								! 0
+							),
+						},
+					} )
+				);
+			};
+		var F = n( 540 );
+		const O = ( 0, F.createContext )( null ),
+			N = { didCatch: ! 1, error: null };
+		class R extends F.Component {
+			constructor( e ) {
+				super( e ),
+					( this.resetErrorBoundary =
+						this.resetErrorBoundary.bind( this ) ),
+					( this.state = N );
+			}
+			static getDerivedStateFromError( e ) {
+				return { didCatch: ! 0, error: e };
+			}
+			resetErrorBoundary() {
+				const { error: e } = this.state;
+				if ( null !== e ) {
+					for (
+						var t,
+							n,
+							r = arguments.length,
+							o = new Array( r ),
+							i = 0;
+						i < r;
+						i++
+					)
+						o[ i ] = arguments[ i ];
+					null === ( t = ( n = this.props ).onReset ) ||
+						void 0 === t ||
+						t.call( n, { args: o, reason: 'imperative-api' } ),
+						this.setState( N );
+				}
+			}
+			componentDidCatch( e, t ) {
+				var n, r;
+				null === ( n = ( r = this.props ).onError ) ||
+					void 0 === n ||
+					n.call( r, e, t );
+			}
+			componentDidUpdate( e, t ) {
+				const { didCatch: n } = this.state,
+					{ resetKeys: r } = this.props;
+				var o, i;
+				n &&
+					null !== t.error &&
+					( function () {
+						let e =
+								arguments.length > 0 &&
+								void 0 !== arguments[ 0 ]
+									? arguments[ 0 ]
+									: [],
+							t =
+								arguments.length > 1 &&
+								void 0 !== arguments[ 1 ]
+									? arguments[ 1 ]
+									: [];
+						return (
+							e.length !== t.length ||
+							e.some( ( e, n ) => ! Object.is( e, t[ n ] ) )
+						);
+					} )( e.resetKeys, r ) &&
+					( null === ( o = ( i = this.props ).onReset ) ||
+						void 0 === o ||
+						o.call( i, {
+							next: r,
+							prev: e.resetKeys,
+							reason: 'keys',
+						} ),
+					this.setState( N ) );
+			}
+			render() {
+				const {
+						children: e,
+						fallbackRender: t,
+						FallbackComponent: n,
+						fallback: r,
+					} = this.props,
+					{ didCatch: o, error: i } = this.state;
+				let a = e;
+				if ( o ) {
+					const e = {
+						error: i,
+						resetErrorBoundary: this.resetErrorBoundary,
+					};
+					if ( 'function' == typeof t ) a = t( e );
+					else if ( n ) a = ( 0, F.createElement )( n, e );
+					else {
+						if ( void 0 === r ) throw i;
+						a = r;
+					}
+				}
+				return ( 0, F.createElement )(
+					O.Provider,
+					{
+						value: {
+							didCatch: o,
+							error: i,
+							resetErrorBoundary: this.resetErrorBoundary,
+						},
+					},
+					a
+				);
+			}
+		}
+		const { Placeholder: P, Button: M, Icon: H } = wp.components,
+			L = ( 0, e.jsx )( 'svg', {
+				xmlns: 'http://www.w3.org/2000/svg',
+				viewBox: '0 0 24 24',
+				width: '24',
+				height: '24',
+				'aria-hidden': 'true',
+				focusable: 'false',
+				children: ( 0, e.jsx )( 'path', {
+					d: 'M19 8h-1V6h-5v2h-2V6H6v2H5c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-8c0-1.1-.9-2-2-2zm.5 10c0 .3-.2.5-.5.5H5c-.3 0-.5-.2-.5-.5v-8c0-.3.2-.5.5-.5h14c.3 0 .5.2.5.5v8z',
+				} ),
+			} ),
+			D = ( { setBlockFormModalOpen: t, blockLabel: n, error: r } ) => {
+				let o = null;
+				return (
+					r &&
+						( acf.debug( 'Block preview error:', r ),
+						( o = acf.__( 'Error previewing block v3' ) ) ),
+					( 0, e.jsx )( P, {
+						icon: ( 0, e.jsx )( H, { icon: L } ),
+						label: n,
+						instructions: o,
+						children: ( 0, e.jsx )( M, {
+							variant: 'primary',
+							onClick: () => {
+								t( ! 0 );
+							},
+							children: acf.__( 'Edit Block' ),
+						} ),
+					} )
+				);
+			},
+			$ = ( {
+				children: t,
+				blockPreviewHtml: n,
+				blockProps: r,
+				blockType: o,
+				setBlockFormModalOpen: i,
+			} ) =>
+				( 0, e.jsx )(
+					'div',
+					{
+						...r,
+						children: ( 0, e.jsx )( R, {
+							fallbackRender: ( { error: t } ) =>
+								( 0, e.jsx )( D, {
+									blockLabel:
+										o?.title || acf.__( 'ACF Block' ),
+									setBlockFormModalOpen: i,
+									error: t,
+								} ),
+							children: t,
+						} ),
+					},
+					n
+				),
+			{ useEffect: q, useRef: V } = wp.element,
+			{ Popover: U } = wp.components,
+			z = ( {
+				children: t,
+				className: n,
+				anchor: r,
+				placement: o,
+				onClose: i,
+				focusOnMount: a,
+				variant: s,
+				animate: l = ! 1,
+				gutenbergIframeOrDocument: c,
+				hidePrimaryBlockToolbar: d = ! 1,
+			} ) => {
+				const u = V();
+				return (
+					q( () => {
+						const e = ( e ) => {
+								'Escape' === e.key && i( e );
+							},
+							t = ( e ) => {
+								! r ||
+									e?.key ||
+									u?.current?.contains( e.target ) ||
+									e.target === r ||
+									( i( e ) &&
+										( c.removeEventListener(
+											'mousedown',
+											t
+										),
+										document.removeEventListener(
+											'mousedown',
+											t
+										) ) );
+							};
+						return (
+							setTimeout( () => {
+								document.addEventListener( 'keydown', e ),
+									c.addEventListener( 'mousedown', t ),
+									document.addEventListener( 'mousedown', t );
+							} ),
+							() => {
+								document.removeEventListener( 'keydown', e ),
+									c.removeEventListener( 'mousedown', t ),
+									document.removeEventListener(
+										'mousedown',
+										t
+									);
+							}
+						);
+					}, [] ),
+					( 0, e.jsx )( e.Fragment, {
+						children: ( 0, e.jsxs )( U, {
+							ref: u,
+							style: {
+								position: 'absolute',
+								top: 200,
+								zIndex: 59899,
+							},
+							className: n,
+							anchor: r,
+							focusOnMount: a,
+							placement: o,
+							variant: s,
+							animate: l,
+							children: [
+								d &&
+									( 0, e.jsx )( 'style', {
+										children:
+											'\n\t\t\t\t\t.components-popover.block-editor-block-popover.block-editor-block-list__block-popover{\n\t\t\t\t\t\tdisplay: none!important;\n\t\t\t\t\t}\n\t\t\t\t',
+									} ),
+								t,
+							],
+						} ),
+					} )
+				);
+			},
+			{ useState: W, useRef: J } = wp.element,
+			{ ToolbarGroup: X, ToolbarButton: Y, Modal: G } = wp.components,
+			{ BlockControls: K } = wp.blockEditor,
+			Q = ( {
+				blockToolbarFields: t,
+				blockFieldInfo: n,
+				setCurrentBlockFormContainer: r,
+				gutenbergIframeOrDocument: o,
+				setBlockFormModalOpen: i,
+				blockFormModalOpen: a,
+			} ) => {
+				const [ s, l ] = W( null ),
+					[ c, d ] = W(),
+					[ u, p ] = W( ! 0 ),
+					f = J();
+				function h( e ) {
+					if ( ! e ) return '';
+					if ( ! n ) return '';
+					const t = n.find( ( t ) => t.name === e );
+					return t?.type.replace( '_', '-' );
+				}
+				function m( e ) {
+					return e && n ? n.find( ( t ) => t.name === e ) : '';
+				}
+				function b( e ) {
+					if ( ! e ) return '';
+					if ( ! n ) return '';
+					const t = n.find( ( t ) => t.name === e );
+					return t ? t.label : '';
+				}
+				return ( 0, e.jsxs )( K, {
+					children: [
+						( 0, e.jsx )( X, {
+							children: ( 0, e.jsx )( Y, {
+								className:
+									'components-icon-button components-toolbar__control',
+								label: acf.__( 'Edit Block' ),
+								icon: 'edit',
+								onClick: () => {
+									i( ! 0 );
+								},
+								isPressed: a,
+							} ),
+						} ),
+						t.length > 0 &&
+							( 0, e.jsxs )( X, {
+								children: [
+									( function () {
+										let t = `[data-name="${ s }"]{ display: block!important; }`;
+										return ( 0, e.jsx )( 'style', {
+											children: t,
+										} );
+									} )(),
+									t &&
+										t.map( ( t ) => {
+											let n = '',
+												r = null,
+												o = null;
+											return (
+												'object' == typeof t
+													? ( ( n = t.fieldName
+															? t.fieldName
+															: index ),
+													  ( r = t.fieldIcon
+															? window.atob(
+																	t.fieldIcon
+															  )
+															: null ),
+													  ( o = t.fieldLabel
+															? t.fieldLabel
+															: n ) )
+													: ( n = t ),
+												( 0, e.jsx )(
+													Y,
+													{
+														icon: r
+															? ( 0, e.jsx )(
+																	'i',
+																	{
+																		dangerouslySetInnerHTML:
+																			{
+																				__html: r,
+																			},
+																	}
+															  )
+															: ( 0, e.jsx )(
+																	'i',
+																	{
+																		className: `field-type-icon field-type-icon-${ h(
+																			n
+																		) }`,
+																	}
+															  ),
+														label: o || b( n ),
+														isPressed: n === s,
+														ref: n === s ? d : null,
+														onMouseDown: () => {
+															s === n
+																? l( null )
+																: ( l( null ),
+																  setTimeout(
+																		() => {
+																			const e =
+																				m(
+																					n
+																				);
+																			'flexible_content' ===
+																				e.type ||
+																			'repeater' ===
+																				e.type
+																				? p(
+																						! 1
+																				  )
+																				: p(
+																						! 0
+																				  ),
+																				l(
+																					n
+																				);
+																		}
+																  ) );
+														},
+													},
+													n
+												)
+											);
+										} ),
+									s &&
+										c &&
+										u &&
+										( 0, e.jsx )(
+											z,
+											{
+												focusOnMount: ! 1,
+												className:
+													'acf-inline-fields-popover',
+												anchor: c,
+												animate: ! 0,
+												onClose: ( e ) =>
+													! (
+														( 'Escape' !== e.key &&
+															( e?.target.closest(
+																'.media-modal'
+															) ||
+																e?.target.closest(
+																	'.acf-tooltip'
+																) ||
+																( e?.target &&
+																	f?.current &&
+																	f?.current.contains(
+																		e.target
+																	) ) ||
+																( c?.current &&
+																	c?.current.contains(
+																		e?.target
+																	) ) ) ) ||
+														( l( null ), 0 )
+													),
+												variant: 'unstyled',
+												gutenbergIframeOrDocument: o,
+												children: ( 0, e.jsx )( 'div', {
+													ref: f,
+													children: ( 0, e.jsx )(
+														'div',
+														{
+															className:
+																'acf-inline-fields-popover-inner',
+															style: {
+																minWidth:
+																	'300px',
+															},
+															ref: r,
+														}
+													),
+												} ),
+											},
+											c
+										),
+									s &&
+										c &&
+										! u &&
+										( 0, e.jsx )( G, {
+											className: 'acf-block-form-modal',
+											isFullScreen: ! 0,
+											title: m( s ).label,
+											onRequestClose: () => {
+												l( null );
+											},
+											children: ( 0, e.jsx )( 'div', {
+												ref: f,
+												children: ( 0, e.jsx )( 'div', {
+													className:
+														'acf-inline-fields-popover-inner',
+													style: {
+														minWidth: '300px',
+													},
+													ref: r,
+												} ),
+											} ),
+										} ),
+								],
+							} ),
+					],
+				} );
+			},
+			{
+				useState: Z,
+				useEffect: ee,
+				useRef: te,
+				useMemo: ne,
+			} = wp.element,
+			{
+				Toolbar: re,
+				ToolbarGroup: oe,
+				ToolbarButton: ie,
+				Modal: ae,
+			} = wp.components,
+			se = ( {
+				blockIcon: t,
+				blockFieldInfo: n,
+				setInlineEditingToolbarHasFocus: r,
+				currentContentEditableElement: o,
+				currentInlineEditingElement: i,
+				currentInlineEditingElementUid: a,
+				gutenbergIframeOrDocument: s,
+				setCurrentBlockFormContainer: l,
+				contentEditableChangeInProgress: c,
+			} ) => {
+				const [ d, u ] = Z( null ),
+					[ p, f ] = Z(),
+					[ h, m ] = Z(),
+					[ b, g ] = Z( ! 0 ),
+					k = te(),
+					v = i ? i.getAttribute( 'data-acf-inline-fields' ) : null;
+				let y = [];
+				try {
+					y = JSON.parse( v );
+				} catch ( e ) {
+					acf.debug(
+						'Inline fields were not a properly formatted JSON array',
+						v
+					);
+				}
+				function x( e ) {
+					if ( ! e ) return '';
+					if ( ! n ) return '';
+					const t = n.find( ( t ) => t.name === e );
+					return t?.type.replace( '_', '-' );
+				}
+				function w( e ) {
+					if ( ! e ) return '';
+					if ( ! n ) return '';
+					const t = n.find( ( t ) => t.name === e );
+					return t ? t.label : '';
+				}
+				ee( () => {
+					u( null );
+				}, [ c ] );
+				const E = ne(
+						() =>
+							( function () {
+								let n =
+									o && ! i
+										? o.getAttribute(
+												'data-acf-toolbar-icon'
+										  )
+										: null;
+								if (
+									( ! n &&
+										i &&
+										( n = i
+											? i.getAttribute(
+													'data-acf-toolbar-icon'
+											  )
+											: null ),
+									n &&
+										( n = ( 0, e.jsx )( 'i', {
+											dangerouslySetInnerHTML: {
+												__html: n,
+											},
+										} ) ),
+									! n && o && ! i )
+								) {
+									const t = o.getAttribute(
+										'data-acf-inline-contenteditable-field-slug'
+									);
+									n = ( 0, e.jsx )( 'i', {
+										className: `field-type-icon field-type-icon-${ x(
+											t
+										) }`,
+									} );
+								}
+								return (
+									n ||
+										( n = React.isValidElement( t )
+											? t
+											: ( 0, e.jsx )( 'span', {
+													className: `dashicon dashicons dashicons-${ t }`,
+											  } ) ),
+									n
+								);
+							} )(),
+						[ n, o, i ]
+					),
+					_ = ne(
+						() =>
+							( function () {
+								let e;
+								if ( o && ! i ) {
+									const t = o.getAttribute(
+										'data-acf-toolbar-title'
+									);
+									if ( t ) return t;
+									e = o.getAttribute(
+										'data-acf-inline-contenteditable-field-slug'
+									);
+								} else if ( i ) {
+									const t = i.getAttribute(
+										'data-acf-toolbar-title'
+									);
+									if ( t ) return t;
+									if ( y.length > 1 )
+										return {
+											A: 'Link',
+											DIV: 'Division',
+											P: 'Paragraph',
+											SPAN: 'Span',
+											INPUT: 'Input',
+											BUTTON: 'Button',
+											IMG: 'Image',
+											UL: 'Unordered List',
+											OL: 'Ordered List',
+											LI: 'List Item',
+											H1: 'Heading 1',
+											H2: 'Heading 2',
+											H3: 'Heading 3',
+											H4: 'Heading 4',
+											H5: 'Heading 5',
+											H6: 'Heading 6',
+											TABLE: 'Table',
+											TR: 'Table Row',
+											TD: 'Table Cell',
+											TH: 'Table Header',
+											FORM: 'Form',
+											TEXTAREA: 'Text Area',
+											SELECT: 'Select',
+											OPTION: 'Option',
+										}[ i.tagName ];
+									e =
+										'object' == typeof y[ 0 ]
+											? y[ 0 ].fieldName
+											: y[ 0 ];
+								}
+								return w( e );
+							} )(),
+						[ n, o, i ]
+					);
+				return ( 0, e.jsxs )( e.Fragment, {
+					children: [
+						d &&
+							h &&
+							b &&
+							a &&
+							( 0, e.jsx )(
+								z,
+								{
+									focusOnMount: ! 1,
+									className: 'acf-inline-fields-popover',
+									anchor: h,
+									onClose: ( e ) =>
+										'Escape' === e.key
+											? ( u( null ), ! 0 )
+											: ! (
+													( e?.target &&
+														k?.current &&
+														k?.current.contains(
+															e.target
+														) ) ||
+													( h?.current &&
+														h?.current.contains(
+															e?.target
+														) )
+											  ) && void 0,
+									variant: i ? 'toolbar' : 'unstyled',
+									gutenbergIframeOrDocument: s,
+									hidePrimaryBlockToolbar: ! 0,
+									animate: ! 0,
+									children: ( 0, e.jsx )( 'div', {
+										ref: k,
+										onClick: () => {
+											r( ! 0 );
+										},
+										children: ( 0, e.jsx )( 'div', {
+											className:
+												'acf-inline-fields-popover-inner',
+											style: {
+												minWidth: p?.popoverMinWidth
+													? p?.popoverMinWidth
+													: '300px',
+											},
+											ref: l,
+										} ),
+									} ),
+								},
+								d || null
+							),
+						d &&
+							h &&
+							! b &&
+							a &&
+							( 0, e.jsx )( ae, {
+								className: 'acf-block-form-modal',
+								isFullScreen: ! 0,
+								title: ( ( C = d ),
+								C && n ? n.find( ( e ) => e.name === C ) : '' )
+									.label,
+								onRequestClose: () => {
+									u( null );
+								},
+								children: ( 0, e.jsx )( 'div', {
+									ref: k,
+									onClick: () => {
+										r( ! 0 );
+									},
+									children: ( 0, e.jsx )( 'div', {
+										className:
+											'acf-inline-fields-popover-inner',
+										style: {
+											minWidth: p?.popoverMinWidth
+												? p?.popoverMinWidth
+												: '300px',
+										},
+										ref: l,
+									} ),
+								} ),
+							} ),
+						( 0, e.jsx )( re, {
+							orientation: 'horizontal',
+							className:
+								'components-accessible-toolbar block-editor-block-contextual-toolbar',
+							style: { width: 'max-content' },
+							children: ( 0, e.jsxs )( 'div', {
+								className: 'block-editor-block-toolbar',
+								children: [
+									( 0, e.jsx )( oe, {
+										style: { alignItems: 'center' },
+										children: ( 0, e.jsxs )( 'div', {
+											className:
+												'acf-blocks-toolbar-icon components-toolbar-group block-editor-block-toolbar__block-controls',
+											label: _,
+											children: [
+												E,
+												( 0, e.jsx )( 'span', {
+													children: _,
+												} ),
+											],
+										} ),
+									} ),
+									( 0, e.jsx )( oe, {
+										children: ( function () {
+											if ( ! y || 0 === y.length )
+												return '';
+											let t = [];
+											return (
+												( t = y.map( ( t, n ) => {
+													let o = '',
+														i = null,
+														a = null;
+													return (
+														'object' == typeof t
+															? ( ( o =
+																	t.fieldName
+																		? t.fieldName
+																		: n ),
+															  ( i = t.fieldIcon
+																	? ( 0,
+																	  e.jsx )(
+																			'i',
+																			{
+																				dangerouslySetInnerHTML:
+																					{
+																						__html: window.atob(
+																							t.fieldIcon
+																						),
+																					},
+																			}
+																	  )
+																	: null ),
+															  ( a = t.fieldLabel
+																	? t.fieldLabel
+																	: o ) )
+															: ( o = t ),
+														! i &&
+															t?.useExpandedEditor &&
+															( i = 'edit' ),
+														( 0, e.jsx )(
+															ie,
+															{
+																disabled: c,
+																className:
+																	'acf-toolbar-button',
+																icon:
+																	i ||
+																	( 0,
+																	e.jsx )(
+																		'i',
+																		{
+																			className: `field-type-icon field-type-icon-${ x(
+																				o
+																			) }`,
+																		}
+																	),
+																label:
+																	a || w( o ),
+																isPressed:
+																	o === d,
+																ref:
+																	o === d
+																		? m
+																		: null,
+																onClick: () => {
+																	r( ! 0 ),
+																		d === o
+																			? u(
+																					null
+																			  )
+																			: ( g(
+																					! t?.useExpandedEditor
+																			  ),
+																			  u(
+																					o
+																			  ),
+																			  f(
+																					t
+																			  ) );
+																},
+															},
+															o
+														)
+													);
+												} ) ),
+												t
+											);
+										} )(),
+									} ),
+								],
+							} ),
+						} ),
+						( function () {
+							let t = `[data-name="${ d }"]{ display: block!important; }`;
+							return ( 0, e.jsx )( 'style', { children: t } );
+						} )(),
+					],
+				} );
+				var C;
+			},
+			{
+				useState: le,
+				useEffect: ce,
+				useRef: de,
+				createPortal: ue,
+				useMemo: pe,
+			} = wp.element,
+			{
+				InspectorControls: fe,
+				useBlockProps: he,
+				useBlockEditContext: me,
+			} = wp.blockEditor,
+			{
+				ToolbarGroup: be,
+				ToolbarButton: ge,
+				Placeholder: ke,
+				Spinner: ve,
+				Modal: ye,
+				Button: xe,
+				PanelBody: we,
+			} = wp.components,
+			Ee = ( t ) => {
+				const {
+						attributes: n,
+						setAttributes: i,
+						context: a,
+						isSelected: s,
+						$: c,
+						blockType: d,
+					} = t,
+					u = d.validate,
+					{ clientId: p } = me(),
+					[ f, h ] = le( null ),
+					[ m, b ] = le( '' ),
+					[ g, k ] = le( '' ),
+					v = pe( () => ue( l( n, a ), p, s ), [] ),
+					[ y, _ ] = le( () =>
+						v?.html
+							? acf.applyFilters(
+									'blocks/preview/render',
+									v.html,
+									! 0
+							  )
+							: 'acf-block-preview-loading'
+					),
+					[ j, I ] = le( () => {
+						var e;
+						return null !== ( e = v?.validation?.errors ) &&
+							void 0 !== e
+							? e
+							: null;
+					} ),
+					[ S, A ] = le( v?.fields ? v.fields : null ),
+					[ T, B ] = le( null ),
+					[ F, O ] = le( ! 1 ),
+					[ N, R ] = le(),
+					[ P, M ] = le( ! 1 ),
+					[ H, L ] = le( ! 1 ),
+					D = de( null ),
+					$ = de( null ),
+					[ q, V ] = le( [] ),
+					[ U, z ] = le( null ),
+					[ W, J ] = le( null ),
+					[ X, Y ] = le( null ),
+					[ G, K ] = le( ! 1 ),
+					[ Q, Z ] = le(
+						( function () {
+							const e = document.querySelector(
+								'[name="editor-canvas"]'
+							);
+							return e
+								? e.contentDocument || e.contentWindow.document
+								: document;
+						} )()
+					),
+					[ ee, te ] = le(),
+					[ ne, re ] = le( '' ),
+					oe = de( null ),
+					ie = ( function () {
+						const [ e, t ] = x( () => C() );
+						return (
+							w( () => {
+								const e = E( () => {
+									t( C() );
+								} );
+								return () => e();
+							}, [] ),
+							e
+						);
+					} )();
+				ce( () => {
+					s || ( J( null ), z( null ), Y( null ), g && _( g ) );
+				}, [ s ] ),
+					ce( () => {
+						if ( Q ) {
+							let e = Q.getElementById( 'acf-dynamic-styles' );
+							e ||
+								( ( e = document.createElement( 'style' ) ),
+								( e.id = 'acf-dynamic-styles' ),
+								Q.head.appendChild( e ) ),
+								te( e );
+						}
+					}, [ Q ] );
+				const ae = pe( () => {
+					const { hasAcfError: e, ...t } = n;
+					return t;
+				}, [ n ] );
+				function se( e, t ) {
+					if ( ! D?.current || ! t ) return;
+					const n = D.current.querySelector( `[data-name=${ t }]` );
+					if ( ! n ) return;
+					const r = n.attributes.getNamedItem( 'data-key' )?.value;
+					if ( ! r ) return;
+					const o = D.current.querySelector(
+						`[name="acf-block_${ p }[${ r }]"`
+					);
+					if ( ! o ) return;
+					e && L( ! 0 ), K( ! 1 ), ( o.value = e );
+					const i = c( D?.current ),
+						a = acf.serialize( i, `acf-block_${ p }` );
+					a ? h( JSON.stringify( a ) ) : L( ! 1 );
+				}
+				function ue( e, t, n ) {
+					if ( n ) return ! 1;
+					if (
+						( acf.debug( 'Preload check', e, t ),
+						( ( e ) => {
+							const t = wp.data
+								.select( 'core/block-editor' )
+								.getBlockParents( e );
+							return wp.data
+								.select( 'core/block-editor' )
+								.getBlocksByClientId( t )
+								.filter( ( e ) => 'core/query' === e.name )
+								.length;
+						} )( t ) )
+					)
+						return ! 1;
+					const r = acf.get( 'preloadedBlocks' );
+					return r && r[ e ]
+						? ( ( r[ e ].html = r[ e ].html.replaceAll( e, t ) ),
+						  r[ e ]?.validation &&
+								r[ e ]?.validation.errors &&
+								( r[ e ].validation.errors = r[
+									e
+								]?.validation.errors.map(
+									( n ) => (
+										( n.input = n.input.replaceAll(
+											e,
+											t
+										) ),
+										n
+									)
+								) ),
+						  acf.debug( 'Preload successful', r[ e ] ),
+						  r[ e ] )
+						: ( acf.debug( 'Preload failed: not preloaded.' ),
+						  ! 1 );
+				}
+				function fe( {
+					theAttributes: e,
+					theClientId: t,
+					theContext: n,
+					isSelected: i,
+				} ) {
+					if ( ! e ) return;
+					N && N.abort();
+					const s = ue( l( e, a ), t, i );
+					if ( s )
+						return (
+							X ||
+								( s.html
+									? _(
+											acf.applyFilters(
+												'blocks/preview/render',
+												s.html,
+												! 0
+											)
+									  )
+									: _(
+											acf.applyFilters(
+												'blocks/preview/render',
+												'acf-block-preview-no-html',
+												! 0
+											)
+									  ),
+								s?.blockToolbarFields &&
+									V( s?.blockToolbarFields ),
+								s?.fields && A( s.fields ) ),
+							void ( s?.validation &&
+							! s.validation.valid &&
+							s.validation.errors
+								? I( s.validation.errors )
+								: I( null ) )
+						);
+					const d = { preview: ! 0, form: ! 0, validate: ! 0 };
+					m || ( d.validate = ! 1 ), u || ( d.validate = ! 1 );
+					const p = { ...e };
+					r( 'acf-fetching-block' );
+					const f = c
+						.ajax( {
+							url: acf.get( 'ajaxurl' ),
+							dataType: 'json',
+							type: 'post',
+							cache: ! 1,
+							data: acf.prepareForAjax( {
+								action: 'acf/ajax/fetch-block',
+								block: JSON.stringify( p ),
+								clientId: t,
+								context: JSON.stringify( n ),
+								query: d,
+							} ),
+						} )
+						.done( ( e ) => {
+							L( ! 1 ),
+								o( 'acf-fetching-block' ),
+								A( e.data.fields ),
+								b( e.data.form );
+							const t = acf.applyFilters(
+								'blocks/preview/render',
+								e.data.preview
+									? e.data.preview
+									: 'acf-block-preview-no-html',
+								! 1
+							);
+							k( t ),
+								e.data?.validation &&
+								! e.data.validation.valid &&
+								e.data.validation.errors
+									? I( e.data.validation.errors )
+									: I( null ),
+								e.data?.blockToolbarFields &&
+									V( e.data?.blockToolbarFields ),
+								M( ! 0 );
+						} )
+						.fail( function () {
+							M( ! 0 ), L( ! 1 ), o( 'acf-fetching-block' );
+						} );
+					R( f );
+				}
+				return (
+					ce( () => {
+						function e() {
+							O( ! 0 ),
+								window.removeEventListener( 'click', e ),
+								window.removeEventListener( 'keydown', e );
+						}
+						return (
+							window.addEventListener( 'click', e ),
+							window.addEventListener( 'keydown', e ),
+							() => {
+								window.removeEventListener( 'click', e ),
+									window.removeEventListener( 'keydown', e );
+							}
+						);
+					}, [] ),
+					ce( () => {
+						i( j ? { hasAcfError: ! 0 } : { hasAcfError: ! 1 } );
+					}, [ j, i ] ),
+					ce( () => {
+						const e = ( e ) => {
+							p === e.detail.acfBlockWithValidationErrors &&
+								( r( p ), B( ! 0 ), J( null ) );
+						};
+						return (
+							document.addEventListener(
+								'acf/block/has-error',
+								e
+							),
+							() => {
+								document.removeEventListener(
+									'acf/block/has-error',
+									e
+								),
+									o( p );
+							}
+						);
+					}, [] ),
+					ce(
+						() => (
+							clearTimeout( oe.current ),
+							r( 'acf-fetching-block' ),
+							( oe.current = setTimeout( () => {
+								! ( function () {
+									const e = JSON.parse( f );
+									if ( ! e )
+										return (
+											fe( {
+												theAttributes: ae,
+												theClientId: p,
+												theContext: a,
+												isSelected: s,
+											} ),
+											void o( 'acf-fetching-block' )
+										);
+									if ( f === JSON.stringify( ae.data ) )
+										return (
+											fe( {
+												theAttributes: ae,
+												theClientId: p,
+												theContext: a,
+												isSelected: s,
+											} ),
+											void o( 'acf-fetching-block' )
+										);
+									const t = { ...n, data: { ...e } };
+									i( t );
+								} )();
+							}, 200 ) ),
+							() => {
+								clearTimeout( oe.current ),
+									o( 'acf-fetching-block' );
+							}
+						),
+						[ f, ae ]
+					),
+					ce( () => {
+						if ( $.current && y ) {
+							const e = n.name.replace( 'acf/', '' ),
+								t = c( $.current );
+							if (
+								( acf.doAction( 'render_block_preview', t, n ),
+								acf.doAction(
+									`render_block_preview/type=${ e }`,
+									t,
+									n
+								),
+								W )
+							) {
+								const e = $?.current.querySelector(
+									`[data-acf-inline-fields-uid="${ W }"]`
+								);
+								z( e );
+							}
+						}
+					}, [ y ] ),
+					ce( () => {
+						if ( ( X && ! G ) || ! g ) return;
+						const e = document.querySelector(
+							'.acf-inline-editing-toolbar'
+						);
+						e &&
+							e.style &&
+							e.style.cssText &&
+							re(
+								e.style.cssText.replaceAll( ';', '!important;' )
+							),
+							setTimeout( () => {
+								_( g ),
+									setTimeout( () => {
+										re( null );
+									}, 0 );
+							}, 0 );
+					}, [ g ] ),
+					ce( () => {
+						const e = new MutationObserver( ( e ) => {
+							for ( const t of e )
+								if ( 'characterData' === t.type ) {
+									let e = t.target.parentNode;
+									const n = e?.closest( '[data-block]' ),
+										r = n?.getAttribute( 'data-block' );
+									if ( ! e || ! n || r !== p ) return;
+									if (
+										( e &&
+											! e.hasAttribute(
+												'data-acf-inline-contenteditable'
+											) &&
+											( e = e.closest(
+												'[data-acf-inline-contenteditable]'
+											) ),
+										e &&
+											e.hasAttribute(
+												'data-acf-inline-contenteditable'
+											) )
+									) {
+										const t = e.attributes.getNamedItem(
+											'data-acf-inline-contenteditable-field-slug'
+										).value;
+										let n = e.innerHTML.trim();
+										n || ( n = '' ), se( n, t );
+									}
+								} else {
+									const e = t.target.closest(
+											'[data-acf-inline-contenteditable]'
+										),
+										n = e?.closest( '[data-block]' );
+									if (
+										! e ||
+										! n ||
+										n.getAttribute( 'data-block' ) !== p
+									)
+										return;
+									if ( e ) {
+										const t = e.attributes.getNamedItem(
+											'data-acf-inline-contenteditable-field-slug'
+										).value;
+										let n = e.innerHTML.trim();
+										( ! n ||
+											( 0 ===
+												e.textContent.trim().length &&
+												1 === e.children.length &&
+												e.firstElementChild &&
+												'BR' ===
+													e.firstElementChild
+														.nodeName ) ) &&
+											( ( e.innerHTML = '' ),
+											( n = '' ) ),
+											se( n, t );
+									}
+								}
+						} );
+						return (
+							e.observe( Q, {
+								attributes: ! 0,
+								childList: ! 0,
+								subtree: ! 0,
+								characterData: ! 0,
+								attributeFilter: [
+									'data-acf-inline-contenteditable',
+								],
+							} ),
+							() => {
+								e.disconnect();
+							}
+						);
+					}, [ y ] ),
+					( 0, e.jsx )( _e, {
+						...t,
+						validationErrors: j,
+						showValidationErrors: T,
+						theSerializedAcfData: f,
+						setTheSerializedAcfData: h,
+						acfFormRef: D,
+						blockFormHtml: m,
+						blockPreviewHtml: y,
+						blockFetcher: fe,
+						userHasInteractedWithForm: F,
+						setUserHasInteractedWithForm: O,
+						previewRef: $,
+						setInlineEditingToolbarHasFocus: K,
+						currentContentEditableElement: X,
+						setCurrentContentEditableElement: Y,
+						currentInlineEditingElement: U,
+						setCurrentInlineEditingElement: z,
+						currentInlineEditingElementUid: W,
+						onNewInlineEditingElementSelected: function ( e ) {
+							setTimeout( () => {
+								J( e );
+								const t = $?.current.querySelector(
+									`[data-acf-inline-fields-uid="${ e }"]`
+								);
+								z( t ),
+									t &&
+										t.scrollIntoView( {
+											behavior: 'smooth',
+											block: 'nearest',
+										} );
+							}, 1 );
+						},
+						onContentEditableChange: se,
+						onNewContentEditableElementSelected: function ( e ) {
+							if ( e ) {
+								const t = $?.current.querySelector(
+									`[data-acf-inline-contenteditable-field-slug="${ e }"]`
+								);
+								Y( t );
+							} else Y( null );
+						},
+						gutenbergIframeOrDocument: Q,
+						acfDynamicStylesElement: ee,
+						blockFieldInfo: S,
+						blockEditorInspectorSidebarOpen: ie,
+						blockToolbarFields: q,
+						hasFetchedOnce: P,
+						contentEditableChangeInProgress: H,
+						freezeInlineToolbarDuringReRender: ne,
+					} )
+				);
+			};
+		function _e( t ) {
+			const {
+					$: n,
+					isSelected: r,
+					blockType: o,
+					attributes: a,
+					context: s,
+					validationErrors: l,
+					showValidationErrors: c,
+					theSerializedAcfData: d,
+					setTheSerializedAcfData: u,
+					acfFormRef: p,
+					blockFormHtml: f,
+					blockPreviewHtml: m,
+					blockFetcher: b,
+					userHasInteractedWithForm: g,
+					previewRef: k,
+					setInlineEditingToolbarHasFocus: v,
+					currentContentEditableElement: y,
+					setCurrentContentEditableElement: x,
+					currentInlineEditingElement: w,
+					currentInlineEditingElementUid: E,
+					setCurrentInlineEditingElement: _,
+					onNewInlineEditingElementSelected: C,
+					onContentEditableChange: j,
+					onNewContentEditableElementSelected: S,
+					gutenbergIframeOrDocument: A,
+					acfDynamicStylesElement: T,
+					blockFieldInfo: F,
+					blockEditorInspectorSidebarOpen: O,
+					blockToolbarFields: N,
+					hasFetchedOnce: R,
+					contentEditableChangeInProgress: P,
+					freezeInlineToolbarDuringReRender: M,
+				} = t,
+				{ clientId: H } = me(),
+				L = de(),
+				[ q, V ] = le( ! 1 ),
+				U = de(),
+				[ W, J ] = le( ! 1 ),
+				[ X, Y ] = le(),
+				[ G, K ] = le();
+			ce( () => {
+				let e = document.getElementById( 'invisible-acf-form-element' );
+				e ||
+					( ( e = document.createElement( 'div' ) ),
+					( e.id = 'invisible-acf-form-element' ),
+					( e.style.display = 'none' ),
+					document.body.appendChild( e ) ),
+					K( e );
+			}, [ O ] ),
+				ce( () => {
+					Y( W && U?.current ? U.current : O ? L.current : G );
+				}, [ W, U ] ),
+				ce( () => {
+					O ? W || Y( L.current ) : Y( G );
+				}, [ O, G ] ),
+				ce( () => {
+					r && L?.current && L.current
+						? V( ! 0 )
+						: r &&
+						  ! L?.current &&
+						  setTimeout( () => {
+								V( ! 0 );
+						  }, 1 );
+				}, [ r, L, L.current ] ),
+				ce( () => {
+					r && l && c && o?.hide_fields_in_sidebar && J( ! 0 );
+				}, [ r, c, l, o ] );
+			let Z = 'acf-block-component acf-block-body';
+			( Z += ' acf-block-preview' ),
+				l && c && ( Z += ' acf-block-has-validation-error' );
+			const ee = { ...he( { className: Z, ref: k } ) };
+			let te = O && L?.current ? L.current : G;
+			X && ( te = X );
+			let ne = null;
+			return (
+				w && y && ( ne = w ),
+				w && ! y && ( ne = w ),
+				! w && y && ( ne = y ),
+				ne?.isConnected || ( ne = null ),
+				( 0, e.jsxs )( e.Fragment, {
+					children: [
+						( 0, e.jsx )( Q, {
+							blockToolbarFields: N,
+							blockFieldInfo: F,
+							setCurrentBlockFormContainer: Y,
+							gutenbergIframeOrDocument: A,
+							setBlockFormModalOpen: J,
+							blockFormModalOpen: W,
+							invisibleBlockFormContainer: G,
+						} ),
+						( 0, e.jsxs )( fe, {
+							children: [
+								( 0, e.jsx )( we, {
+									children: ( 0, e.jsx )( xe, {
+										icon: 'edit',
+										className:
+											'acf-blocks-open-expanded-editor-btn',
+										variant: 'secondary',
+										onClick: () => {
+											J( ! 0 );
+										},
+										children: acf.__(
+											'Open Expanded Editor'
+										),
+									} ),
+								} ),
+								( 0, e.jsx )( I, {
+									inspectorBlockFormRef: L,
+									setCurrentBlockFormContainer: Y,
+								} ),
+							],
+						} ),
+						te &&
+							q &&
+							ue(
+								( 0, e.jsxs )( e.Fragment, {
+									children: [
+										( 0, e.jsx )( B, {
+											$: n,
+											clientId: H,
+											blockFormHtml: f,
+											onMount: () => {
+												R ||
+													b( {
+														theAttributes: a,
+														theClientId: H,
+														theContext: s,
+														isSelected: r,
+													} );
+											},
+											onChange: function ( e ) {
+												const t = acf.serialize(
+													e,
+													`acf-block_${ H }`
+												);
+												t && u( JSON.stringify( t ) );
+											},
+											validationErrors: l,
+											showValidationErrors: c,
+											acfFormRef: p,
+											blockFormPortalElement: te,
+											theSerializedAcfData: d,
+											userHasInteractedWithForm: g,
+											attributes: a,
+											hideFieldsInSidebar:
+												( o?.auto_inline_editing &&
+													void 0 ===
+														o?.hide_fields_in_sidebar &&
+													L.current === X ) ||
+												( o?.hide_fields_in_sidebar &&
+													L.current === X ),
+										} ),
+										M &&
+											( 0, e.jsx )( 'style', {
+												children: `.acf-inline-editing-toolbar{${ M }}`,
+											} ),
+									],
+								} ),
+								te
+							),
+						( 0, e.jsxs )( e.Fragment, {
+							children: [
+								T &&
+									E &&
+									ue(
+										( 0, e.jsx )( e.Fragment, {
+											children: `\n\t\t\t\t[data-acf-inline-fields-uid="${ E }"]{\n\t\t\t\t\toutline: 2px solid var( --wp-admin-theme-color );\n\t\t\t\t\toutline-offset: 2px;\n\t\t\t\t}\n\t\t\t`,
+										} ),
+										T
+									),
+								W &&
+									( 0, e.jsx )( ye, {
+										className: 'acf-block-form-modal',
+										isFullScreen: ! 0,
+										title: o.title,
+										onRequestClose: () => {
+											i( 'acf-fetching-block' ) ||
+												J( ! 1 );
+										},
+										isDismissible: ! 1,
+										headerActions: [
+											( 0, e.jsx )(
+												xe,
+												{
+													variant: 'primary',
+													disabled:
+														i(
+															'acf-fetching-block'
+														),
+													onClick: () => {
+														Y( null ), J( ! 1 );
+													},
+													children: acf.__( 'Done' ),
+												},
+												'done'
+											),
+										],
+										children: ( 0, e.jsx )( 'div', {
+											className:
+												'acf-modal-block-form-container',
+											ref: U,
+										} ),
+									} ),
+							],
+						} ),
+						( 0, e.jsxs )( e.Fragment, {
+							children: [
+								ne &&
+									( 0, e.jsx )(
+										z,
+										{
+											focusOnMount: ( () => {
+												const e =
+													document.activeElement;
+												return (
+													e && e.isContentEditable,
+													! 1
+												);
+											} )(),
+											variant: 'unstyled',
+											anchor: ne,
+											className:
+												'acf-inline-editing-toolbar block-editor-block-list__block-popover',
+											placement: 'top-start',
+											onClose: ( e ) => {
+												if (
+													'Escape' !== e.key &&
+													e.target.closest(
+														'.acf-toolbar-button'
+													)
+												)
+													return ! 1;
+												if ( 'Escape' === e.key )
+													return (
+														! document.querySelector(
+															'.acf-inline-fields-popover-inner'
+														) &&
+														! y &&
+														( w && w.focus(),
+														x( null ),
+														_( null ),
+														! 0 )
+													);
+												if (
+													e.target.getAttribute(
+														'data-acf-inline-contenteditable'
+													)
+												)
+													return ! 1;
+												const t = e.target.closest(
+														'.acf-inline-fields-popover-inner'
+													),
+													n = e.target.closest(
+														'.components-modal__content'
+													);
+												return (
+													t ||
+														n ||
+														( x( null ),
+														_( null ) ),
+													! 0
+												);
+											},
+											gutenbergIframeOrDocument: A,
+											hidePrimaryBlockToolbar: ! 0,
+											children: ( 0, e.jsx )(
+												se,
+												{
+													blockIcon: o.icon,
+													blockFieldInfo: F,
+													acfFormRef: p,
+													setInlineEditingToolbarHasFocus:
+														v,
+													currentContentEditableElement:
+														y,
+													currentInlineEditingElement:
+														w,
+													currentInlineEditingElementUid:
+														E,
+													gutenbergIframeOrDocument:
+														A,
+													setCurrentBlockFormContainer:
+														Y,
+													contentEditableChangeInProgress:
+														P,
+												},
+												E
+											),
+										},
+										y
+									),
+								( 0, e.jsxs )( $, {
+									blockPreviewHtml: m,
+									blockProps: ee,
+									blockType: o,
+									setBlockFormModalOpen: J,
+									children: [
+										'acf-block-preview-no-html' === m
+											? ( 0, e.jsx )( D, {
+													setBlockFormModalOpen: J,
+													blockLabel: o.title,
+											  } )
+											: null,
+										'acf-block-preview-loading' === m &&
+											( 0, e.jsx )( ke, {
+												children: ( 0, e.jsx )(
+													ve,
+													{}
+												),
+											} ),
+										'acf-block-preview-loading' !== m &&
+											'acf-block-preview-no-html' !== m &&
+											m &&
+											h( m, C, j, S, F, n ),
+									],
+								} ),
+							],
+						} ),
+					],
+				} )
+			);
+		}
+		const Ce = ( e, t, n ) => ( ( e[ t ] = { type: n } ), e ),
+			je = ( e ) => {
+				const t = acf.get( 'rtl' ) ? 'right' : 'left';
+				return [ 'left', 'center', 'right' ].includes( e ) ? e : t;
+			},
+			{ Fragment: Ie, Component: Se } = wp.element,
+			{ BlockControls: Ae, AlignmentToolbar: Te } = wp.blockEditor,
+			Be = ( t, n ) => {
+				const r = je;
+				return (
+					( n.alignText = r( n.alignText ) ),
+					class extends Se {
+						render() {
+							const { attributes: n, setAttributes: o } =
+									this.props,
+								{ alignText: i } = n;
+							return ( 0, e.jsxs )( Ie, {
+								children: [
+									( 0, e.jsx )( Ae, {
+										group: 'block',
+										children: ( 0, e.jsx )( Te, {
+											value: r( i ),
+											onChange: function ( e ) {
+												o( { alignText: r( e ) } );
+											},
+										} ),
+									} ),
+									( 0, e.jsx )( t, { ...this.props } ),
+								],
+							} );
+						}
+					}
+				);
+			},
+			Fe = ( e ) =>
+				[ 'top', 'center', 'bottom' ].includes( e ) ? e : 'top',
+			Oe = ( e ) => {
+				if ( e ) {
+					const [ t, n ] = e.split( ' ' );
+					return `${ Fe( t ) } ${ je( n ) }`;
+				}
+				return 'center center';
+			},
+			{ Fragment: Ne, Component: Re } = wp.element,
+			{ BlockControls: Pe, BlockVerticalAlignmentToolbar: Me } =
+				wp.blockEditor,
+			He =
+				wp.blockEditor.__experimentalBlockAlignmentMatrixToolbar ||
+				wp.blockEditor.BlockAlignmentMatrixToolbar,
+			Le =
+				wp.blockEditor.__experimentalBlockAlignmentMatrixControl ||
+				wp.blockEditor.BlockAlignmentMatrixControl,
+			De = ( t, n ) => {
+				let r, o;
+				return (
+					'matrix' ===
+					( n.supports.align_content || n.supports.alignContent )
+						? ( ( r = Le || He ), ( o = Oe ) )
+						: ( ( r = Me ), ( o = Fe ) ),
+					void 0 === r
+						? t
+						: ( ( n.alignContent = o( n.alignContent ) ),
+						  class extends Re {
+								render() {
+									const { attributes: n, setAttributes: i } =
+											this.props,
+										{ alignContent: a } = n;
+									return ( 0, e.jsxs )( Ne, {
+										children: [
+											( 0, e.jsx )( Pe, {
+												group: 'block',
+												children: ( 0, e.jsx )( r, {
+													label: acf.__(
+														'Change content alignment'
+													),
+													value: o( a ),
+													onChange: function ( e ) {
+														i( {
+															alignContent:
+																o( e ),
+														} );
+													},
+												} ),
+											} ),
+											( 0, e.jsx )( t, {
+												...this.props,
+											} ),
+										],
+									} );
+								}
+						  } )
+				);
+			},
+			{ Fragment: $e, Component: qe } = wp.element,
+			{ BlockControls: Ve } = wp.blockEditor,
+			Ue =
+				wp.blockEditor.__experimentalBlockFullHeightAligmentControl ||
+				wp.blockEditor.__experimentalBlockFullHeightAlignmentControl ||
+				wp.blockEditor.BlockFullHeightAlignmentControl,
+			ze = ( t ) =>
+				Ue
+					? class extends qe {
+							render() {
+								const { attributes: n, setAttributes: r } =
+										this.props,
+									{ fullHeight: o } = n;
+								return ( 0, e.jsxs )( $e, {
+									children: [
+										( 0, e.jsx )( Ve, {
+											group: 'block',
+											children: ( 0, e.jsx )( Ue, {
+												isActive: o,
+												onToggle: function ( e ) {
+													r( { fullHeight: e } );
+												},
+											} ),
+										} ),
+										( 0, e.jsx )( t, { ...this.props } ),
+									],
+								} );
+							}
+					  }
+					: t;
+		( ( t, n ) => {
+			const { InnerBlocks: r } = wp.blockEditor,
+				{ Component: o } = wp.element,
+				{ createHigherOrderComponent: i } = wp.compose,
+				a = {};
+			function s( n ) {
+				const o = n.post_types || [];
+				if ( o.length ) {
+					o.push( 'wp_block' );
+					const e = acf.get( 'postType' );
+					if ( ! o.includes( e ) ) return ! 1;
+				}
+				if (
+					'string' == typeof n.icon &&
+					'<svg' === n.icon.substr( 0, 4 )
+				) {
+					const t = n.icon;
+					n.icon = ( 0, e.jsx )( 'div', {
+						dangerouslySetInnerHTML: { __html: t },
+					} );
+				}
+				n.icon || delete n.icon,
+					wp.blocks
+						.getCategories()
+						.filter( ( { slug: e } ) => e === n.category )
+						.pop() || ( n.category = 'common' ),
+					( n = acf.parseArgs( n, {
+						title: '',
+						name: '',
+						category: '',
+						api_version: 2,
+						acf_block_version: 3,
+					} ) );
+				for ( const e in n.attributes )
+					'default' in n.attributes[ e ] &&
+						0 === n.attributes[ e ].default.length &&
+						delete n.attributes[ e ].default;
+				n.supports.anchor &&
+					( n.attributes.anchor = { type: 'string' } ),
+					( n.attributes.hasAcfError = {
+						type: 'boolean',
+						default: ! 1,
+					} );
+				let i = Ee;
+				( n.supports.alignText || n.supports.align_text ) &&
+					( ( n.attributes = Ce(
+						n.attributes,
+						'align_text',
+						'string'
+					) ),
+					( i = Be( i, n ) ) ),
+					( n.supports.alignContent || n.supports.align_content ) &&
+						( ( n.attributes = Ce(
+							n.attributes,
+							'align_content',
+							'string'
+						) ),
+						( i = De( i, n ) ) ),
+					( n.supports.fullHeight || n.supports.full_height ) &&
+						( ( n.attributes = Ce(
+							n.attributes,
+							'full_height',
+							'boolean'
+						) ),
+						( i = ze( i ) ) ),
+					( n.edit = function ( r ) {
+						return ( 0, e.jsx )( i, { ...r, blockType: n, $: t } );
+					} ),
+					( n.save = () => ( 0, e.jsx )( r.Content, {} ) ),
+					( a[ n.name ] = n );
+				const s = wp.blocks.registerBlockType( n.name, n );
+				return (
+					s.attributes.anchor &&
+						( s.attributes.anchor = { type: 'string' } ),
+					s
+				);
+			}
+			acf.addAction( 'prepare', function () {
+				wp.blockEditor || ( wp.blockEditor = wp.editor );
+				const e = acf.get( 'blockTypes' );
+				e &&
+					e.forEach( ( e ) => {
+						parseInt( e.acf_block_version ) >= 3 && s( e );
+					} );
+			} );
+			const l = i(
+				( t ) =>
+					class extends o {
+						constructor( e ) {
+							super( e );
+							const { name: t, attributes: r } = this.props,
+								o = ( function ( e ) {
+									return a[ e ] || ! 1;
+								} )( t );
+							if ( ! o ) return;
+							Object.keys( r ).forEach( ( e ) => {
+								'' === r[ e ] && delete r[ e ];
+							} );
+							const i = {
+								full_height: 'fullHeight',
+								align_content: 'alignContent',
+								align_text: 'alignText',
+							};
+							Object.keys( i ).forEach( ( e ) => {
+								r[ e ] !== n
+									? ( r[ i[ e ] ] = r[ e ] )
+									: r[ i[ e ] ] === n &&
+									  o[ e ] !== n &&
+									  ( r[ i[ e ] ] = o[ e ] ),
+									delete o[ e ],
+									delete r[ e ];
+							} );
+							for ( let e in o.attributes )
+								r[ e ] === n &&
+									o[ e ] !== n &&
+									( r[ e ] = o[ e ] );
+						}
+						render() {
+							return ( 0, e.jsx )( t, { ...this.props } );
+						}
+					},
+				'withDefaultAttributes'
+			);
+			wp.hooks.addFilter(
+				'editor.BlockListBlock',
+				'acf/with-default-attributes',
+				l
+			);
+		} )( jQuery );
+	} )();
+} )();

--- a/assets/src/js/pro/blocks-v3/components/block-edit.js
+++ b/assets/src/js/pro/blocks-v3/components/block-edit.js
@@ -14,23 +14,18 @@ import {
 } from '@wordpress/element';
 
 import {
-	BlockControls,
 	InspectorControls,
 	useBlockProps,
 	useBlockEditContext,
 } from '@wordpress/block-editor';
-import {
-	Button,
-	ToolbarGroup,
-	ToolbarButton,
-	Placeholder,
-	Spinner,
-	Modal,
-} from '@wordpress/components';
+import { Button, Placeholder, Spinner, Modal } from '@wordpress/components';
 import { BlockPlaceholder } from './block-placeholder';
 import { BlockForm } from './block-form';
 import { BlockPreview } from './block-preview';
 import { ErrorBoundary, BlockPreviewErrorFallback } from './error-boundary';
+import { BlockToolbarFields } from './block-toolbar-fields';
+import { InlineEditingToolbar } from './inline-editing-toolbar';
+import { PopoverWrapper } from './popover-wrapper';
 import {
 	lockPostSaving,
 	unlockPostSaving,
@@ -109,6 +104,33 @@ export const BlockEdit = ( props ) => {
 	const [ hasFetchedOnce, setHasFetchedOnce ] = useState( false );
 	const [ ajaxRequest, setAjaxRequest ] = useState();
 
+	// New state for inline editing features
+	const [ blockToolbarFields, setBlockToolbarFields ] = useState( [] );
+	const [ blockFieldInfo, setBlockFieldInfo ] = useState( null );
+	const [ gutenbergIframeOrDocument, setGutenbergIframeOrDocument ] =
+		useState( () => {
+			const iframe = document.querySelector( '[name="editor-canvas"]' );
+			return iframe
+				? iframe.contentDocument || iframe.contentWindow.document
+				: document;
+		} );
+	const [ currentInlineEditingElement, setCurrentInlineEditingElement ] =
+		useState( null );
+	const [
+		currentInlineEditingElementUid,
+		setCurrentInlineEditingElementUid,
+	] = useState( null );
+	const [ currentContentEditableElement, setCurrentContentEditableElement ] =
+		useState( null );
+	const [ inlineEditingToolbarHasFocus, setInlineEditingToolbarHasFocus ] =
+		useState( false );
+	const [
+		contentEditableChangeInProgress,
+		setContentEditableChangeInProgress,
+	] = useState( false );
+	const [ acfDynamicStylesElement, setAcfDynamicStylesElement ] =
+		useState( null );
+
 	const acfFormRef = useRef( null );
 	const previewRef = useRef( null );
 	const debounceRef = useRef( null );
@@ -186,6 +208,16 @@ export const BlockEdit = ( props ) => {
 				unlockPostSavingByName( 'acf-fetching-block' );
 
 				setBlockFormHtml( response.data.form );
+
+				// Handle new field metadata for inline editing
+				if ( response.data.fields ) {
+					setBlockFieldInfo( response.data.fields );
+				}
+
+				// Handle block toolbar fields configuration
+				if ( response.data.blockToolbarFields ) {
+					setBlockToolbarFields( response.data.blockToolbarFields );
+				}
 
 				if ( response.data.preview ) {
 					setBlockPreviewHtml(
@@ -318,6 +350,16 @@ export const BlockEdit = ( props ) => {
 			);
 		}
 
+		// Handle block toolbar fields from preloaded data
+		if ( data?.blockToolbarFields ) {
+			setBlockToolbarFields( data.blockToolbarFields );
+		}
+
+		// Handle field info from preloaded data
+		if ( data?.fields ) {
+			setBlockFieldInfo( data.fields );
+		}
+
 		if (
 			data?.validation &&
 			! data.validation.valid &&
@@ -362,9 +404,13 @@ export const BlockEdit = ( props ) => {
 
 	// Listen for validation error events from other blocks
 	useEffect( () => {
-		const handleErrorEvent = () => {
-			lockPostSaving( clientId );
-			setShowValidationErrors( true );
+		const handleErrorEvent = ( event ) => {
+			// Only handle if this event is for this specific block
+			if ( clientId === event.detail.acfBlockWithValidationErrors ) {
+				lockPostSaving( clientId );
+				setShowValidationErrors( true );
+				setCurrentInlineEditingElementUid( null );
+			}
 		};
 
 		document.addEventListener( 'acf/block/has-error', handleErrorEvent );
@@ -374,7 +420,6 @@ export const BlockEdit = ( props ) => {
 				'acf/block/has-error',
 				handleErrorEvent
 			);
-			unlockPostSaving( clientId );
 		};
 	}, [] );
 
@@ -389,6 +434,7 @@ export const BlockEdit = ( props ) => {
 	// Handle form data changes with debouncing
 	useEffect( () => {
 		clearTimeout( debounceRef.current );
+		lockPostSavingByName( 'acf-fetching-block' );
 
 		debounceRef.current = setTimeout( () => {
 			const parsedData = JSON.parse( theSerializedAcfData );
@@ -421,6 +467,12 @@ export const BlockEdit = ( props ) => {
 			};
 			setAttributes( updatedAttributes );
 		}, 200 );
+
+		// Cleanup function to unlock post saving
+		return () => {
+			clearTimeout( debounceRef.current );
+			unlockPostSavingByName( 'acf-fetching-block' );
+		};
 	}, [ theSerializedAcfData, attributesWithoutError ] );
 
 	// Trigger ACF actions when preview is rendered
@@ -435,6 +487,14 @@ export const BlockEdit = ( props ) => {
 				$preview,
 				attributes
 			);
+
+			// If there's an active inline editing element, re-initialize it after preview renders
+			if ( currentInlineEditingElementUid ) {
+				const inlineElement = previewRef?.current.querySelector(
+					`[data-acf-inline-fields-uid="${ currentInlineEditingElementUid }"]`
+				);
+				setCurrentInlineEditingElement( inlineElement );
+			}
 		}
 	}, [ blockPreviewHtml ] );
 
@@ -453,6 +513,28 @@ export const BlockEdit = ( props ) => {
 			setUserHasInteractedWithForm={ setUserHasInteractedWithForm }
 			previewRef={ previewRef }
 			hasFetchedOnce={ hasFetchedOnce }
+			blockToolbarFields={ blockToolbarFields }
+			blockFieldInfo={ blockFieldInfo }
+			gutenbergIframeOrDocument={ gutenbergIframeOrDocument }
+			setGutenbergIframeOrDocument={ setGutenbergIframeOrDocument }
+			currentInlineEditingElement={ currentInlineEditingElement }
+			setCurrentInlineEditingElement={ setCurrentInlineEditingElement }
+			currentInlineEditingElementUid={ currentInlineEditingElementUid }
+			setCurrentInlineEditingElementUid={
+				setCurrentInlineEditingElementUid
+			}
+			currentContentEditableElement={ currentContentEditableElement }
+			setCurrentContentEditableElement={
+				setCurrentContentEditableElement
+			}
+			inlineEditingToolbarHasFocus={ inlineEditingToolbarHasFocus }
+			setInlineEditingToolbarHasFocus={ setInlineEditingToolbarHasFocus }
+			contentEditableChangeInProgress={ contentEditableChangeInProgress }
+			setContentEditableChangeInProgress={
+				setContentEditableChangeInProgress
+			}
+			acfDynamicStylesElement={ acfDynamicStylesElement }
+			setAcfDynamicStylesElement={ setAcfDynamicStylesElement }
 		/>
 	);
 };
@@ -477,15 +559,59 @@ function BlockEditInner( props ) {
 		blockPreviewHtml,
 		blockFetcher,
 		userHasInteractedWithForm,
+		setUserHasInteractedWithForm,
 		previewRef,
 		hasFetchedOnce,
+		blockToolbarFields,
+		blockFieldInfo,
+		gutenbergIframeOrDocument,
+		setGutenbergIframeOrDocument,
+		currentInlineEditingElement,
+		setCurrentInlineEditingElement,
+		currentInlineEditingElementUid,
+		setCurrentInlineEditingElementUid,
+		currentContentEditableElement,
+		setCurrentContentEditableElement,
+		inlineEditingToolbarHasFocus,
+		setInlineEditingToolbarHasFocus,
+		contentEditableChangeInProgress,
+		setContentEditableChangeInProgress,
+		acfDynamicStylesElement,
+		setAcfDynamicStylesElement,
 	} = props;
 
 	const { clientId } = useBlockEditContext();
 	const inspectorControlsRef = useRef();
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const [ blockFormModalOpen, setBlockFormModalOpen ] = useState( false );
 	const modalFormContainerRef = useRef();
 	const [ currentFormContainer, setCurrentFormContainer ] = useState();
+
+	// Detect Gutenberg iframe or document
+	useEffect( () => {
+		const gutenbergIframe = document.querySelector(
+			'iframe[name="editor-canvas"]'
+		);
+		if ( gutenbergIframe?.contentDocument ) {
+			setGutenbergIframeOrDocument( gutenbergIframe.contentDocument );
+		} else {
+			setGutenbergIframeOrDocument( document );
+		}
+	}, [] );
+
+	// Create/get dynamic styles element for inline field highlighting
+	useEffect( () => {
+		if ( ! gutenbergIframeOrDocument ) return;
+
+		let styleElement =
+			gutenbergIframeOrDocument.getElementById( 'acf-dynamic-styles' );
+		if ( ! styleElement ) {
+			styleElement = document.createElement( 'style' );
+			styleElement.id = 'acf-dynamic-styles';
+			gutenbergIframeOrDocument.head.appendChild( styleElement );
+		}
+		setAcfDynamicStylesElement( styleElement );
+	}, [ gutenbergIframeOrDocument ] );
 
 	// Set current form container when modal opens
 	useEffect( () => {
@@ -531,6 +657,161 @@ function BlockEditInner( props ) {
 		...useBlockProps( { className: blockClasses, ref: previewRef } ),
 	};
 
+	// Update field value from contentEditable changes (matches 6.7.0.2)
+	const updateFieldValueFromContentEditable = ( content, fieldSlug ) => {
+		if ( ! acfFormRef?.current || ! fieldSlug ) return;
+
+		const fieldWrapper = acfFormRef.current.querySelector(
+			`[data-name=${ fieldSlug }]`
+		);
+		if ( ! fieldWrapper ) return;
+
+		const fieldKey = fieldWrapper.attributes.getNamedItem( 'data-key' )
+			?.value;
+		if ( ! fieldKey ) return;
+
+		const fieldInput = acfFormRef.current.querySelector(
+			`[name="acf-block_${ clientId }[${ fieldKey }]"`
+		);
+		if ( ! fieldInput ) return;
+
+		// Update field value and trigger serialization (debouncing happens in useEffect)
+		if ( content ) {
+			setUserHasInteractedWithForm( true );
+		}
+		setContentEditableChangeInProgress( false );
+		fieldInput.value = content;
+
+		const $form = $( acfFormRef?.current );
+		const serializedData = acf.serialize( $form, `acf-block_${ clientId }` );
+		if ( serializedData ) {
+			setTheSerializedAcfData( JSON.stringify( serializedData ) );
+		} else {
+			setUserHasInteractedWithForm( false );
+		}
+	};
+
+	// Watch for changes in contentEditable fields using MutationObserver
+	useEffect( () => {
+		if ( ! gutenbergIframeOrDocument || ! blockPreviewHtml ) return;
+
+		const observer = new MutationObserver( ( mutations ) => {
+			for ( const mutation of mutations ) {
+				// Handle text content changes
+				if ( mutation.type === 'characterData' ) {
+					let element = mutation.target.parentNode;
+					const blockElement = element?.closest( '[data-block]' );
+					const blockId = blockElement?.getAttribute( 'data-block' );
+
+					if ( ! element || ! blockElement || blockId !== clientId )
+						return;
+
+					// Find the contentEditable element
+					if (
+						element &&
+						! element.hasAttribute(
+							'data-acf-inline-contenteditable'
+						)
+					) {
+						element = element.closest(
+							'[data-acf-inline-contenteditable]'
+						);
+					}
+
+					if (
+						element &&
+						element.hasAttribute( 'data-acf-inline-contenteditable' )
+					) {
+						const fieldSlug = element.attributes.getNamedItem(
+							'data-acf-inline-contenteditable-field-slug'
+						).value;
+						let content = element.innerHTML.trim();
+						if ( ! content ) content = '';
+						updateFieldValueFromContentEditable( content, fieldSlug );
+					}
+				}
+				// Handle attribute or child list changes
+				else {
+					const element = mutation.target.closest(
+						'[data-acf-inline-contenteditable]'
+					);
+					const blockElement = element?.closest( '[data-block]' );
+
+					if (
+						! element ||
+						! blockElement ||
+						blockElement.getAttribute( 'data-block' ) !== clientId
+					)
+						return;
+
+					if ( element ) {
+						const fieldSlug = element.attributes.getNamedItem(
+							'data-acf-inline-contenteditable-field-slug'
+						).value;
+						let content = element.innerHTML.trim();
+
+						// Handle empty content - remove empty BR tags
+						if (
+							! content ||
+							( element.textContent.trim().length === 0 &&
+								element.children.length === 1 &&
+								element.firstElementChild &&
+								element.firstElementChild.nodeName === 'BR' )
+						) {
+							element.innerHTML = '';
+							content = '';
+						}
+
+						updateFieldValueFromContentEditable( content, fieldSlug );
+					}
+				}
+			}
+		} );
+
+		// Observe the gutenberg iframe/document for changes
+		observer.observe( gutenbergIframeOrDocument, {
+			attributes: true,
+			childList: true,
+			subtree: true,
+			characterData: true,
+			attributeFilter: [ 'data-acf-inline-contenteditable' ],
+		} );
+
+		// Cleanup
+		return () => {
+			observer.disconnect();
+		};
+	}, [ blockPreviewHtml, gutenbergIframeOrDocument ] );
+
+	// Callback when a new inline editing element is selected
+	const handleNewInlineEditingElementSelected = ( uid ) => {
+		setTimeout( () => {
+			setCurrentInlineEditingElementUid( uid );
+			const element = previewRef?.current.querySelector(
+				`[data-acf-inline-fields-uid="${ uid }"]`
+			);
+			setCurrentInlineEditingElement( element );
+			if ( element ) {
+				element.scrollIntoView( {
+					behavior: 'smooth',
+					block: 'nearest',
+				} );
+			}
+		}, 1 );
+	};
+
+	// Callback when a new contentEditable element is selected
+	const handleNewContentEditableElementSelected = ( fieldSlug ) => {
+		if ( fieldSlug ) {
+			const element = previewRef?.current.querySelector(
+				`[data-acf-inline-contenteditable-field-slug="${ fieldSlug }"]`
+			);
+			setCurrentContentEditableElement( element );
+		} else {
+			setCurrentContentEditableElement( null );
+		}
+	};
+
 	// Determine portal target
 	let portalTarget = null;
 	if ( currentFormContainer ) {
@@ -539,21 +820,37 @@ function BlockEditInner( props ) {
 		portalTarget = inspectorControlsRef.current;
 	}
 
+	// Determine inline editing toolbar anchor (matches 6.7.0.2 logic)
+	let inlineEditingToolbarAnchor = null;
+	if ( currentInlineEditingElement && currentContentEditableElement ) {
+		inlineEditingToolbarAnchor = currentInlineEditingElement;
+	} else if ( currentInlineEditingElement && ! currentContentEditableElement ) {
+		inlineEditingToolbarAnchor = currentInlineEditingElement;
+	} else if ( ! currentInlineEditingElement && currentContentEditableElement ) {
+		inlineEditingToolbarAnchor = currentContentEditableElement;
+	}
+	// Ensure anchor is connected to DOM
+	if ( inlineEditingToolbarAnchor && ! inlineEditingToolbarAnchor.isConnected ) {
+		inlineEditingToolbarAnchor = null;
+	}
+
 	return (
 		<>
-			{ /* Block toolbar controls */ }
-			<BlockControls>
-				<ToolbarGroup>
-					<ToolbarButton
-						className="components-icon-button components-toolbar__control"
-						label={ acf.__( 'Edit Block' ) }
-						icon="edit"
-						onClick={ () => {
-							setIsModalOpen( true );
-						} }
-					/>
-				</ToolbarGroup>
-			</BlockControls>
+			{ /* Block toolbar controls with inline editing support */ }
+			<BlockToolbarFields
+				blockToolbarFields={ blockToolbarFields }
+				blockFieldInfo={ blockFieldInfo }
+				setCurrentBlockFormContainer={ setCurrentFormContainer }
+				gutenbergIframeOrDocument={ gutenbergIframeOrDocument }
+				setBlockFormModalOpen={ setBlockFormModalOpen }
+				blockFormModalOpen={ blockFormModalOpen }
+				currentInlineEditingElement={ currentInlineEditingElement }
+				setCurrentInlineEditingElement={ setCurrentInlineEditingElement }
+				currentInlineEditingElementUid={ currentInlineEditingElementUid }
+				onNewInlineEditingElementSelected={
+					handleNewInlineEditingElementSelected
+				}
+			/>
 
 			{ /* Inspector panel container */ }
 			<InspectorControls>
@@ -637,9 +934,32 @@ function BlockEditInner( props ) {
 						isFullScreen={ true }
 						title={ blockType.title }
 						onRequestClose={ () => {
-							setCurrentFormContainer( null );
-							setIsModalOpen( false );
+							// Check if block is fetching
+							const isFetching =
+								document.body.classList.contains(
+									'acf-fetching-block'
+								);
+							if ( ! isFetching ) {
+								setCurrentFormContainer( null );
+								setIsModalOpen( false );
+							}
 						} }
+						isDismissible={ false }
+						headerActions={ [
+							<Button
+								key="done"
+								variant="primary"
+								disabled={ document.body.classList.contains(
+									'acf-fetching-block'
+								) }
+								onClick={ () => {
+									setCurrentFormContainer( null );
+									setIsModalOpen( false );
+								} }
+							>
+								{ acf.__( 'Done' ) }
+							</Button>,
+						] }
 					>
 						<div
 							className="acf-modal-block-form-container"
@@ -648,6 +968,109 @@ function BlockEditInner( props ) {
 					</Modal>
 				) }
 			</>
+
+			{ /* Inline Editing Toolbar */ }
+			{ inlineEditingToolbarAnchor && (
+					<PopoverWrapper
+						key={ currentContentEditableElement }
+						focusOnMount={ ( () => {
+							const activeElement = document.activeElement;
+							return activeElement && activeElement.isContentEditable, false;
+						} )() }
+						variant="unstyled"
+						anchor={ inlineEditingToolbarAnchor }
+						className="acf-inline-editing-toolbar block-editor-block-list__block-popover"
+						placement="top-start"
+						onClose={ ( event ) => {
+							// Don't close if clicking toolbar button
+							if (
+								event.key !== 'Escape' &&
+								event.target.closest( '.acf-toolbar-button' )
+							) {
+								return false;
+							}
+
+							// Handle Escape key
+							if ( event.key === 'Escape' ) {
+								return (
+									! document.querySelector(
+										'.acf-inline-fields-popover-inner'
+									) &&
+									! inlineEditingToolbarHasFocus &&
+									( currentInlineEditingElement &&
+										currentInlineEditingElement.focus(),
+									setCurrentInlineEditingElementUid( null ),
+									setCurrentContentEditableElement( null ),
+									true )
+								);
+							}
+
+							// Don't close if clicking on contenteditable element
+							if (
+								event.target.getAttribute(
+									'data-acf-inline-contenteditable'
+								)
+							) {
+								return false;
+							}
+
+							// Don't close if clicking inside popover or modal
+							const inlineFieldsPopover = event.target.closest(
+								'.acf-inline-fields-popover-inner'
+							);
+							const modal = event.target.closest(
+								'.components-modal__content'
+							);
+
+							return (
+								inlineFieldsPopover ||
+									modal ||
+									( setCurrentInlineEditingElementUid( null ),
+									setCurrentContentEditableElement( null ) ),
+								true
+							);
+						} }
+						gutenbergIframeOrDocument={ gutenbergIframeOrDocument }
+						hidePrimaryBlockToolbar={ true }
+					>
+						<InlineEditingToolbar
+							key={ currentInlineEditingElementUid }
+							blockIcon={ blockType.icon }
+							blockFieldInfo={ blockFieldInfo }
+							acfFormRef={ acfFormRef }
+							setInlineEditingToolbarHasFocus={
+								setInlineEditingToolbarHasFocus
+							}
+							currentContentEditableElement={
+								currentContentEditableElement
+							}
+							currentInlineEditingElement={
+								currentInlineEditingElement
+							}
+							currentInlineEditingElementUid={
+								currentInlineEditingElementUid
+							}
+							gutenbergIframeOrDocument={ gutenbergIframeOrDocument }
+							setCurrentBlockFormContainer={ setCurrentFormContainer }
+							contentEditableChangeInProgress={
+								contentEditableChangeInProgress
+							}
+						/>
+					</PopoverWrapper>
+				) }
+
+			{ /* Dynamic styles for inline field highlighting */ }
+			{ currentInlineEditingElementUid &&
+				acfDynamicStylesElement &&
+				createPortal(
+					<style>
+						{ `[data-acf-inline-fields-uid="${ currentInlineEditingElementUid }"]{
+							outline: 2px solid var(--wp-admin-theme-color);
+							outline-offset: 2px;
+						}` }
+					</style>,
+					acfDynamicStylesElement
+				) }
 
 			{ /* Block preview */ }
 			<>
@@ -701,10 +1124,20 @@ function BlockEditInner( props ) {
 						) }
 
 						{ /* Render actual preview HTML */ }
-						{ blockPreviewHtml !== 'acf-block-preview-loading' &&
+					{ useMemo(
+						() =>
+							blockPreviewHtml !== 'acf-block-preview-loading' &&
 							blockPreviewHtml !== 'acf-block-preview-no-html' &&
-							blockPreviewHtml &&
-							acf.parseJSX( blockPreviewHtml ) }
+							blockPreviewHtml
+								? acf.parseJSX(
+										blockPreviewHtml,
+										setCurrentInlineEditingElementUid,
+										handleNewContentEditableElementSelected,
+										blockFieldInfo
+								  )
+								: null,
+						[ blockPreviewHtml, blockFieldInfo ]
+					) }
 					</ErrorBoundary>
 				</BlockPreview>
 			</>

--- a/assets/src/js/pro/blocks-v3/components/block-edit.js
+++ b/assets/src/js/pro/blocks-v3/components/block-edit.js
@@ -418,7 +418,7 @@ export const BlockEdit = ( props ) => {
 	useEffect( () => {
 		const handleErrorEvent = ( event ) => {
 			// Only handle if this event is for this specific block
-			if ( clientId === event.detail.acfBlockWithValidationErrors ) {
+			if ( clientId === event.detail.acfBlocksWithValidationErrors ) {
 				lockPostSaving( clientId );
 				setShowValidationErrors( true );
 				setCurrentInlineEditingElementUid( null );

--- a/assets/src/js/pro/blocks-v3/components/block-edit.js
+++ b/assets/src/js/pro/blocks-v3/components/block-edit.js
@@ -8,6 +8,7 @@ import md5 from 'md5';
 import {
 	useState,
 	useEffect,
+	useLayoutEffect,
 	useRef,
 	createPortal,
 	useMemo,
@@ -587,6 +588,10 @@ function BlockEditInner( props ) {
 	const modalFormContainerRef = useRef();
 	const [ currentFormContainer, setCurrentFormContainer ] = useState();
 
+	// Render counter for debugging
+	const renderCount = useRef( 0 );
+	renderCount.current++;
+
 	// Detect Gutenberg iframe or document
 	useEffect( () => {
 		const gutenbergIframe = document.querySelector(
@@ -666,8 +671,8 @@ function BlockEditInner( props ) {
 		);
 		if ( ! fieldWrapper ) return;
 
-		const fieldKey = fieldWrapper.attributes.getNamedItem( 'data-key' )
-			?.value;
+		const fieldKey =
+			fieldWrapper.attributes.getNamedItem( 'data-key' )?.value;
 		if ( ! fieldKey ) return;
 
 		const fieldInput = acfFormRef.current.querySelector(
@@ -683,7 +688,10 @@ function BlockEditInner( props ) {
 		fieldInput.value = content;
 
 		const $form = $( acfFormRef?.current );
-		const serializedData = acf.serialize( $form, `acf-block_${ clientId }` );
+		const serializedData = acf.serialize(
+			$form,
+			`acf-block_${ clientId }`
+		);
 		if ( serializedData ) {
 			setTheSerializedAcfData( JSON.stringify( serializedData ) );
 		} else {
@@ -720,14 +728,19 @@ function BlockEditInner( props ) {
 
 					if (
 						element &&
-						element.hasAttribute( 'data-acf-inline-contenteditable' )
+						element.hasAttribute(
+							'data-acf-inline-contenteditable'
+						)
 					) {
 						const fieldSlug = element.attributes.getNamedItem(
 							'data-acf-inline-contenteditable-field-slug'
 						).value;
 						let content = element.innerHTML.trim();
 						if ( ! content ) content = '';
-						updateFieldValueFromContentEditable( content, fieldSlug );
+						updateFieldValueFromContentEditable(
+							content,
+							fieldSlug
+						);
 					}
 				}
 				// Handle attribute or child list changes
@@ -762,7 +775,10 @@ function BlockEditInner( props ) {
 							content = '';
 						}
 
-						updateFieldValueFromContentEditable( content, fieldSlug );
+						updateFieldValueFromContentEditable(
+							content,
+							fieldSlug
+						);
 					}
 				}
 			}
@@ -782,6 +798,120 @@ function BlockEditInner( props ) {
 			observer.disconnect();
 		};
 	}, [ blockPreviewHtml, gutenbergIframeOrDocument ] );
+
+	// Preserve cursor position during re-renders
+	const savedSelection = useRef( null );
+
+	// Save cursor position BEFORE rendering (capture during effect)
+	useEffect( () => {
+		const activeElement = document.activeElement;
+		if (
+			activeElement &&
+			activeElement.hasAttribute( 'data-acf-inline-contenteditable' ) &&
+			activeElement.isContentEditable
+		) {
+			const selection = window.getSelection();
+			if ( selection && selection.rangeCount > 0 ) {
+				const range = selection.getRangeAt( 0 );
+				const fieldSlug = activeElement.getAttribute(
+					'data-acf-inline-contenteditable-field-slug'
+				);
+				console.log(
+					'🟢 Saving cursor position - offset:',
+					range.startOffset,
+					'field:',
+					fieldSlug
+				);
+				savedSelection.current = {
+					fieldSlug, // Save field identifier instead of element reference
+					offset: range.startOffset,
+					textContent: activeElement.textContent,
+				};
+			}
+		}
+	}, [ theSerializedAcfData ] ); // Save when data changes (before re-render)
+
+	// Restore cursor position AFTER DOM updates
+	useLayoutEffect( () => {
+		if ( ! savedSelection.current ) return;
+
+		const { fieldSlug, offset, textContent } = savedSelection.current;
+		console.log(
+			'🔵 Restoring cursor - field:',
+			fieldSlug,
+			'offset:',
+			offset
+		);
+
+		try {
+			// Find the new element by field slug instead of using stale reference
+			const element = previewRef?.current?.querySelector(
+				`[data-acf-inline-contenteditable-field-slug="${ fieldSlug }"]`
+			);
+
+			if ( ! element || ! element.isContentEditable ) {
+				console.warn(
+					'🟡 Element not found or not editable for field:',
+					fieldSlug
+				);
+				savedSelection.current = null;
+				return;
+			}
+
+			// Verify the content is still the same (sanity check)
+			if ( element.textContent !== textContent ) {
+				console.warn(
+					'🟡 Content changed, skipping cursor restore for field:',
+					fieldSlug
+				);
+				savedSelection.current = null;
+				return;
+			}
+
+			const selection = window.getSelection();
+			const range = document.createRange();
+
+			// Get the first text node in the element
+			const walker = document.createTreeWalker(
+				element,
+				NodeFilter.SHOW_TEXT,
+				null,
+				false
+			);
+			let textNode = walker.nextNode();
+
+			if ( textNode ) {
+				const safeOffset = Math.min(
+					offset,
+					textNode.textContent?.length || 0
+				);
+				range.setStart( textNode, safeOffset );
+				range.collapse( true );
+
+				selection.removeAllRanges();
+				selection.addRange( range );
+
+				// Focus the element to ensure cursor is visible and editable
+				element.focus();
+
+				console.log(
+					'🔵 Restored cursor to offset:',
+					safeOffset,
+					'in field:',
+					fieldSlug
+				);
+			} else {
+				console.warn(
+					'🟡 No text node found in element for field:',
+					fieldSlug
+				);
+			}
+		} catch ( error ) {
+			console.error( '🔴 Error restoring cursor:', error );
+		} finally {
+			savedSelection.current = null;
+		}
+	} );
 
 	// Callback when a new inline editing element is selected
 	const handleNewInlineEditingElementSelected = ( uid ) => {
@@ -824,13 +954,22 @@ function BlockEditInner( props ) {
 	let inlineEditingToolbarAnchor = null;
 	if ( currentInlineEditingElement && currentContentEditableElement ) {
 		inlineEditingToolbarAnchor = currentInlineEditingElement;
-	} else if ( currentInlineEditingElement && ! currentContentEditableElement ) {
+	} else if (
+		currentInlineEditingElement &&
+		! currentContentEditableElement
+	) {
 		inlineEditingToolbarAnchor = currentInlineEditingElement;
-	} else if ( ! currentInlineEditingElement && currentContentEditableElement ) {
+	} else if (
+		! currentInlineEditingElement &&
+		currentContentEditableElement
+	) {
 		inlineEditingToolbarAnchor = currentContentEditableElement;
 	}
 	// Ensure anchor is connected to DOM
-	if ( inlineEditingToolbarAnchor && ! inlineEditingToolbarAnchor.isConnected ) {
+	if (
+		inlineEditingToolbarAnchor &&
+		! inlineEditingToolbarAnchor.isConnected
+	) {
 		inlineEditingToolbarAnchor = null;
 	}
 
@@ -845,8 +984,12 @@ function BlockEditInner( props ) {
 				setBlockFormModalOpen={ setBlockFormModalOpen }
 				blockFormModalOpen={ blockFormModalOpen }
 				currentInlineEditingElement={ currentInlineEditingElement }
-				setCurrentInlineEditingElement={ setCurrentInlineEditingElement }
-				currentInlineEditingElementUid={ currentInlineEditingElementUid }
+				setCurrentInlineEditingElement={
+					setCurrentInlineEditingElement
+				}
+				currentInlineEditingElementUid={
+					currentInlineEditingElementUid
+				}
 				onNewInlineEditingElementSelected={
 					handleNewInlineEditingElementSelected
 				}
@@ -971,93 +1114,96 @@ function BlockEditInner( props ) {
 
 			{ /* Inline Editing Toolbar */ }
 			{ inlineEditingToolbarAnchor && (
-					<PopoverWrapper
-						key={ currentContentEditableElement }
-						focusOnMount={ ( () => {
-							const activeElement = document.activeElement;
-							return activeElement && activeElement.isContentEditable, false;
-						} )() }
-						variant="unstyled"
-						anchor={ inlineEditingToolbarAnchor }
-						className="acf-inline-editing-toolbar block-editor-block-list__block-popover"
-						placement="top-start"
-						onClose={ ( event ) => {
-							// Don't close if clicking toolbar button
-							if (
-								event.key !== 'Escape' &&
-								event.target.closest( '.acf-toolbar-button' )
-							) {
-								return false;
-							}
+				<PopoverWrapper
+					key={ currentContentEditableElement }
+					focusOnMount={ ( () => {
+						const activeElement = document.activeElement;
+						return (
+							activeElement && activeElement.isContentEditable,
+							false
+						);
+					} )() }
+					variant="unstyled"
+					anchor={ inlineEditingToolbarAnchor }
+					className="acf-inline-editing-toolbar block-editor-block-list__block-popover"
+					placement="top-start"
+					onClose={ ( event ) => {
+						// Don't close if clicking toolbar button
+						if (
+							event.key !== 'Escape' &&
+							event.target.closest( '.acf-toolbar-button' )
+						) {
+							return false;
+						}
 
-							// Handle Escape key
-							if ( event.key === 'Escape' ) {
-								return (
-									! document.querySelector(
-										'.acf-inline-fields-popover-inner'
-									) &&
-									! inlineEditingToolbarHasFocus &&
-									( currentInlineEditingElement &&
-										currentInlineEditingElement.focus(),
-									setCurrentInlineEditingElementUid( null ),
-									setCurrentContentEditableElement( null ),
-									true )
-								);
-							}
-
-							// Don't close if clicking on contenteditable element
-							if (
-								event.target.getAttribute(
-									'data-acf-inline-contenteditable'
-								)
-							) {
-								return false;
-							}
-
-							// Don't close if clicking inside popover or modal
-							const inlineFieldsPopover = event.target.closest(
-								'.acf-inline-fields-popover-inner'
-							);
-							const modal = event.target.closest(
-								'.components-modal__content'
-							);
-
+						// Handle Escape key
+						if ( event.key === 'Escape' ) {
 							return (
-								inlineFieldsPopover ||
-									modal ||
-									( setCurrentInlineEditingElementUid( null ),
-									setCurrentContentEditableElement( null ) ),
-								true
+								! document.querySelector(
+									'.acf-inline-fields-popover-inner'
+								) &&
+								! inlineEditingToolbarHasFocus &&
+								( currentInlineEditingElement &&
+									currentInlineEditingElement.focus(),
+								setCurrentInlineEditingElementUid( null ),
+								setCurrentContentEditableElement( null ),
+								true )
 							);
-						} }
+						}
+
+						// Don't close if clicking on contenteditable element
+						if (
+							event.target.getAttribute(
+								'data-acf-inline-contenteditable'
+							)
+						) {
+							return false;
+						}
+
+						// Don't close if clicking inside popover or modal
+						const inlineFieldsPopover = event.target.closest(
+							'.acf-inline-fields-popover-inner'
+						);
+						const modal = event.target.closest(
+							'.components-modal__content'
+						);
+
+						return (
+							inlineFieldsPopover ||
+								modal ||
+								( setCurrentInlineEditingElementUid( null ),
+								setCurrentContentEditableElement( null ) ),
+							true
+						);
+					} }
+					gutenbergIframeOrDocument={ gutenbergIframeOrDocument }
+					hidePrimaryBlockToolbar={ true }
+				>
+					<InlineEditingToolbar
+						key={ currentInlineEditingElementUid }
+						blockIcon={ blockType.icon }
+						blockFieldInfo={ blockFieldInfo }
+						acfFormRef={ acfFormRef }
+						setInlineEditingToolbarHasFocus={
+							setInlineEditingToolbarHasFocus
+						}
+						currentContentEditableElement={
+							currentContentEditableElement
+						}
+						currentInlineEditingElement={
+							currentInlineEditingElement
+						}
+						currentInlineEditingElementUid={
+							currentInlineEditingElementUid
+						}
 						gutenbergIframeOrDocument={ gutenbergIframeOrDocument }
-						hidePrimaryBlockToolbar={ true }
-					>
-						<InlineEditingToolbar
-							key={ currentInlineEditingElementUid }
-							blockIcon={ blockType.icon }
-							blockFieldInfo={ blockFieldInfo }
-							acfFormRef={ acfFormRef }
-							setInlineEditingToolbarHasFocus={
-								setInlineEditingToolbarHasFocus
-							}
-							currentContentEditableElement={
-								currentContentEditableElement
-							}
-							currentInlineEditingElement={
-								currentInlineEditingElement
-							}
-							currentInlineEditingElementUid={
-								currentInlineEditingElementUid
-							}
-							gutenbergIframeOrDocument={ gutenbergIframeOrDocument }
-							setCurrentBlockFormContainer={ setCurrentFormContainer }
-							contentEditableChangeInProgress={
-								contentEditableChangeInProgress
-							}
-						/>
-					</PopoverWrapper>
-				) }
+						setCurrentBlockFormContainer={ setCurrentFormContainer }
+						contentEditableChangeInProgress={
+							contentEditableChangeInProgress
+						}
+					/>
+				</PopoverWrapper>
+			) }
 
 			{ /* Dynamic styles for inline field highlighting */ }
 			{ currentInlineEditingElementUid &&
@@ -1108,7 +1254,6 @@ function BlockEditInner( props ) {
 							}
 						} }
 					>
-						{ /* Show placeholder when no HTML */ }
 						{ blockPreviewHtml === 'acf-block-preview-no-html' ? (
 							<BlockPlaceholder
 								setBlockFormModalOpen={ setIsModalOpen }
@@ -1124,20 +1269,17 @@ function BlockEditInner( props ) {
 						) }
 
 						{ /* Render actual preview HTML */ }
-					{ useMemo(
-						() =>
-							blockPreviewHtml !== 'acf-block-preview-loading' &&
+						{ blockPreviewHtml !== 'acf-block-preview-loading' &&
 							blockPreviewHtml !== 'acf-block-preview-no-html' &&
-							blockPreviewHtml
-								? acf.parseJSX(
-										blockPreviewHtml,
-										setCurrentInlineEditingElementUid,
-										handleNewContentEditableElementSelected,
-										blockFieldInfo
-								  )
-								: null,
-						[ blockPreviewHtml, blockFieldInfo ]
-					) }
+							blockPreviewHtml &&
+							acf.parseJSX(
+								blockPreviewHtml,
+								setCurrentInlineEditingElementUid,
+								null,
+								handleNewContentEditableElementSelected,
+								blockFieldInfo,
+								$
+							) }
 					</ErrorBoundary>
 				</BlockPreview>
 			</>

--- a/assets/src/js/pro/blocks-v3/components/block-edit.js
+++ b/assets/src/js/pro/blocks-v3/components/block-edit.js
@@ -8,7 +8,6 @@ import md5 from 'md5';
 import {
 	useState,
 	useEffect,
-	useLayoutEffect,
 	useRef,
 	createPortal,
 	useMemo,
@@ -135,6 +134,18 @@ export const BlockEdit = ( props ) => {
 	const acfFormRef = useRef( null );
 	const previewRef = useRef( null );
 	const debounceRef = useRef( null );
+
+	// Initialize acf.blockEdit namespace for jsx-parser to use
+	if ( ! acf.blockEdit ) {
+		acf.blockEdit = {};
+	}
+	acf.blockEdit.setCurrentInlineEditingElementUid =
+		setCurrentInlineEditingElementUid;
+	acf.blockEdit.setCurrentInlineEditingElement =
+		setCurrentInlineEditingElement;
+	acf.blockEdit.setCurrentContentEditableElement =
+		setCurrentContentEditableElement;
+	acf.blockEdit.getBlockFieldInfo = () => blockFieldInfo;
 
 	const attributesWithoutError = useMemo( () => {
 		const { hasAcfError, ...rest } = attributes;
@@ -799,120 +810,6 @@ function BlockEditInner( props ) {
 		};
 	}, [ blockPreviewHtml, gutenbergIframeOrDocument ] );
 
-	// Preserve cursor position during re-renders
-	const savedSelection = useRef( null );
-
-	// Save cursor position BEFORE rendering (capture during effect)
-	useEffect( () => {
-		const activeElement = document.activeElement;
-		if (
-			activeElement &&
-			activeElement.hasAttribute( 'data-acf-inline-contenteditable' ) &&
-			activeElement.isContentEditable
-		) {
-			const selection = window.getSelection();
-			if ( selection && selection.rangeCount > 0 ) {
-				const range = selection.getRangeAt( 0 );
-				const fieldSlug = activeElement.getAttribute(
-					'data-acf-inline-contenteditable-field-slug'
-				);
-				console.log(
-					'🟢 Saving cursor position - offset:',
-					range.startOffset,
-					'field:',
-					fieldSlug
-				);
-				savedSelection.current = {
-					fieldSlug, // Save field identifier instead of element reference
-					offset: range.startOffset,
-					textContent: activeElement.textContent,
-				};
-			}
-		}
-	}, [ theSerializedAcfData ] ); // Save when data changes (before re-render)
-
-	// Restore cursor position AFTER DOM updates
-	useLayoutEffect( () => {
-		if ( ! savedSelection.current ) return;
-
-		const { fieldSlug, offset, textContent } = savedSelection.current;
-		console.log(
-			'🔵 Restoring cursor - field:',
-			fieldSlug,
-			'offset:',
-			offset
-		);
-
-		try {
-			// Find the new element by field slug instead of using stale reference
-			const element = previewRef?.current?.querySelector(
-				`[data-acf-inline-contenteditable-field-slug="${ fieldSlug }"]`
-			);
-
-			if ( ! element || ! element.isContentEditable ) {
-				console.warn(
-					'🟡 Element not found or not editable for field:',
-					fieldSlug
-				);
-				savedSelection.current = null;
-				return;
-			}
-
-			// Verify the content is still the same (sanity check)
-			if ( element.textContent !== textContent ) {
-				console.warn(
-					'🟡 Content changed, skipping cursor restore for field:',
-					fieldSlug
-				);
-				savedSelection.current = null;
-				return;
-			}
-
-			const selection = window.getSelection();
-			const range = document.createRange();
-
-			// Get the first text node in the element
-			const walker = document.createTreeWalker(
-				element,
-				NodeFilter.SHOW_TEXT,
-				null,
-				false
-			);
-			let textNode = walker.nextNode();
-
-			if ( textNode ) {
-				const safeOffset = Math.min(
-					offset,
-					textNode.textContent?.length || 0
-				);
-				range.setStart( textNode, safeOffset );
-				range.collapse( true );
-
-				selection.removeAllRanges();
-				selection.addRange( range );
-
-				// Focus the element to ensure cursor is visible and editable
-				element.focus();
-
-				console.log(
-					'🔵 Restored cursor to offset:',
-					safeOffset,
-					'in field:',
-					fieldSlug
-				);
-			} else {
-				console.warn(
-					'🟡 No text node found in element for field:',
-					fieldSlug
-				);
-			}
-		} catch ( error ) {
-			console.error( '🔴 Error restoring cursor:', error );
-		} finally {
-			savedSelection.current = null;
-		}
-	} );
-
 	// Callback when a new inline editing element is selected
 	const handleNewInlineEditingElementSelected = ( uid ) => {
 		setTimeout( () => {
@@ -1272,14 +1169,7 @@ function BlockEditInner( props ) {
 						{ blockPreviewHtml !== 'acf-block-preview-loading' &&
 							blockPreviewHtml !== 'acf-block-preview-no-html' &&
 							blockPreviewHtml &&
-							acf.parseJSX(
-								blockPreviewHtml,
-								setCurrentInlineEditingElementUid,
-								null,
-								handleNewContentEditableElementSelected,
-								blockFieldInfo,
-								$
-							) }
+							acf.parseJSX( blockPreviewHtml, $ ) }
 					</ErrorBoundary>
 				</BlockPreview>
 			</>

--- a/assets/src/js/pro/blocks-v3/components/block-preview.js
+++ b/assets/src/js/pro/blocks-v3/components/block-preview.js
@@ -9,12 +9,9 @@
  *
  * @param {Object} props - Component props
  * @param {React.ReactNode} props.children - Child elements to render
- * @param {string} props.blockPreviewHtml - HTML string of the block preview (used as key)
  * @param {Object} props.blockProps - Block props from useBlockProps hook
  * @returns {JSX.Element} - Rendered preview wrapper
  */
-export const BlockPreview = ( { children, blockPreviewHtml, blockProps } ) => (
-	<div { ...blockProps } key={ blockPreviewHtml }>
-		{ children }
-	</div>
+export const BlockPreview = ( { children, blockProps } ) => (
+	<div { ...blockProps }>{ children }</div>
 );

--- a/assets/src/js/pro/blocks-v3/components/block-toolbar-fields.js
+++ b/assets/src/js/pro/blocks-v3/components/block-toolbar-fields.js
@@ -1,0 +1,243 @@
+/**
+ * BlockToolbarFields Component
+ * Renders field buttons in the WordPress block toolbar (top toolbar)
+ * Allows quick access to edit specific fields from the block toolbar
+ */
+
+import { useState, useRef } from '@wordpress/element';
+import { BlockControls } from '@wordpress/blockEditor';
+import { ToolbarGroup, ToolbarButton, Modal } from '@wordpress/components';
+import { PopoverWrapper } from './popover-wrapper';
+
+/**
+ * BlockToolbarFields component
+ * Displays field editing buttons in the WordPress block toolbar
+ *
+ * @param {Object} props - Component props
+ * @param {Array} props.blockToolbarFields - Array of field names or field config objects to show in toolbar
+ * @param {Array} props.blockFieldInfo - Array of all field information
+ * @param {Function} props.setCurrentBlockFormContainer - Setter for form container ref
+ * @param {Document|HTMLIFrameElement} props.gutenbergIframeOrDocument - Document or iframe reference
+ * @param {Function} props.setBlockFormModalOpen - Setter for block form modal state
+ * @param {boolean} props.blockFormModalOpen - Whether block form modal is open
+ * @returns {JSX.Element} - Rendered toolbar controls
+ */
+export const BlockToolbarFields = ( {
+	blockToolbarFields,
+	blockFieldInfo,
+	setCurrentBlockFormContainer,
+	gutenbergIframeOrDocument,
+	setBlockFormModalOpen,
+	blockFormModalOpen,
+} ) => {
+	const [ selectedFieldKey, setSelectedFieldKey ] = useState( null );
+	const [ selectedFieldButtonRef, setSelectedFieldButtonRef ] = useState();
+	const [ usePopover, setUsePopover ] = useState( true );
+	const fieldPopoverContainerRef = useRef();
+
+	/**
+	 * Get field type class name from field name
+	 */
+	const getFieldTypeClassName = ( fieldName ) => {
+		if ( ! fieldName || ! blockFieldInfo ) return '';
+		const field = blockFieldInfo.find( ( f ) => f.name === fieldName );
+		return field?.type ? field.type.replace( /_/g, '-' ) : '';
+	};
+
+	/**
+	 * Get field info object from field name
+	 */
+	const getFieldInfo = ( fieldName ) => {
+		return fieldName && blockFieldInfo
+			? blockFieldInfo.find( ( f ) => f.name === fieldName )
+			: null;
+	};
+
+	/**
+	 * Get field label from field name
+	 */
+	const getFieldLabel = ( fieldName ) => {
+		if ( ! fieldName || ! blockFieldInfo ) return fieldName || '';
+		const field = blockFieldInfo.find( ( f ) => f.name === fieldName );
+		// Fallback to fieldName when label not found to ensure toolbar shows a title
+		return field?.label || fieldName || '';
+	};
+	return (
+		<BlockControls>
+			{ /* Edit Block button */ }
+			<ToolbarGroup>
+				<ToolbarButton
+					className="components-icon-button components-toolbar__control acf-edit-block-button"
+					label={ acf.__( 'Edit Block' ) }
+					icon="edit"
+					onClick={ () => {
+						setBlockFormModalOpen( true );
+					} }
+					isPressed={ blockFormModalOpen }
+				/>
+			</ToolbarGroup>
+
+			{ /* Field buttons */ }
+			{ blockToolbarFields.length > 0 && (
+				<ToolbarGroup>
+					{ /* Style to show selected field in form */ }
+					{ ( () => {
+						const styleContent = `[data-name="${ selectedFieldKey }"]{ display: block!important; }`;
+						return <style>{ styleContent }</style>;
+					} )() }
+
+					{ /* Render field buttons */ }
+					{ blockToolbarFields &&
+						blockToolbarFields.map( ( field ) => {
+							let fieldName = '';
+							let fieldIconSvg = null;
+							let fieldLabel = null;
+
+							// Handle field config object or simple string
+							if ( typeof field === 'object' ) {
+								fieldName = field.fieldName
+									? field.fieldName
+									: field.index;
+								fieldIconSvg = field.fieldIcon
+									? window.atob( field.fieldIcon )
+									: null;
+								fieldLabel = field.fieldLabel
+									? field.fieldLabel
+									: fieldName;
+							} else {
+								fieldName = field;
+							}
+
+							return (
+								<ToolbarButton
+									key={ fieldName }
+									icon={
+										fieldIconSvg ? (
+											<i
+												dangerouslySetInnerHTML={ {
+													__html: fieldIconSvg,
+												} }
+											/>
+										) : (
+											<i
+												className={ `field-type-icon field-type-icon-${ getFieldTypeClassName(
+													fieldName
+												) }` }
+											/>
+										)
+									}
+									label={
+										fieldLabel || getFieldLabel( fieldName )
+									}
+									isPressed={ fieldName === selectedFieldKey }
+									ref={
+										fieldName === selectedFieldKey
+											? setSelectedFieldButtonRef
+											: null
+									}
+									onMouseDown={ () => {
+										if ( selectedFieldKey === fieldName ) {
+											setSelectedFieldKey( null );
+										} else {
+											setSelectedFieldKey( null );
+											setTimeout( () => {
+												const fieldInfo =
+													getFieldInfo( fieldName );
+												// Use modal for complex field types
+												if (
+													fieldInfo?.type ===
+														'flexible_content' ||
+													fieldInfo?.type ===
+														'repeater'
+												) {
+													setUsePopover( false );
+												} else {
+													setUsePopover( true );
+												}
+												setSelectedFieldKey(
+													fieldName
+												);
+											} );
+										}
+									} }
+								/>
+							);
+						} ) }
+
+					{ /* Popover for simple field types */ }
+					{ selectedFieldKey &&
+						selectedFieldButtonRef &&
+						usePopover && (
+							<PopoverWrapper
+								focusOnMount={ false }
+								className="acf-inline-fields-popover"
+								anchor={ selectedFieldButtonRef }
+								animate={ true }
+								onClose={ ( event ) => {
+									// Don't close on certain events
+									if (
+										event.key !== 'Escape' &&
+										( event?.target.closest(
+											'.media-modal'
+										) ||
+											event?.target.closest(
+												'.acf-tooltip'
+											) ||
+											( event?.target &&
+												fieldPopoverContainerRef?.current &&
+												fieldPopoverContainerRef?.current.contains(
+													event.target
+												) ) ||
+											( selectedFieldButtonRef?.current &&
+												selectedFieldButtonRef?.current.contains(
+													event?.target
+												) ) )
+									) {
+										return false;
+									}
+									setSelectedFieldKey( null );
+									return true;
+								} }
+								variant="unstyled"
+								gutenbergIframeOrDocument={
+									gutenbergIframeOrDocument
+								}
+							>
+								<div ref={ fieldPopoverContainerRef }>
+									<div
+										className="acf-inline-fields-popover-inner"
+										style={ { minWidth: '300px' } }
+										ref={ setCurrentBlockFormContainer }
+									/>
+								</div>
+							</PopoverWrapper>
+						) }
+
+					{ /* Modal for complex field types */ }
+					{ selectedFieldKey &&
+						selectedFieldButtonRef &&
+						! usePopover && (
+							<Modal
+								className="acf-block-form-modal"
+								isFullScreen={ true }
+								title={
+									getFieldInfo( selectedFieldKey )?.label
+								}
+								onRequestClose={ () => {
+									setSelectedFieldKey( null );
+								} }
+							>
+								<div ref={ fieldPopoverContainerRef }>
+									<div
+										className="acf-inline-fields-popover-inner"
+										style={ { minWidth: '300px' } }
+										ref={ setCurrentBlockFormContainer }
+									/>
+								</div>
+							</Modal>
+						) }
+				</ToolbarGroup>
+			) }
+		</BlockControls>
+	);
+};

--- a/assets/src/js/pro/blocks-v3/components/inline-editing-toolbar.js
+++ b/assets/src/js/pro/blocks-v3/components/inline-editing-toolbar.js
@@ -4,10 +4,9 @@
  * Handles field selection and editing for inline editable elements
  */
 
-import { useState, useEffect, useMemo, createPortal } from '@wordpress/element';
-import { Button, Modal } from '@wordpress/components';
+import { useState, useEffect, useMemo, useRef } from '@wordpress/element';
+import { Toolbar, ToolbarGroup, ToolbarButton, Modal } from '@wordpress/components';
 import { PopoverWrapper } from './popover-wrapper';
-import { BlockForm } from './block-form';
 
 /**
  * InlineEditingToolbar component
@@ -16,7 +15,6 @@ import { BlockForm } from './block-form';
  * @param {Object} props - Component props
  * @param {Object} props.blockIcon - Block icon configuration
  * @param {Array} props.blockFieldInfo - Array of field information
- * @param {React.RefObject} props.acfFormRef - Reference to ACF form
  * @param {Function} props.setInlineEditingToolbarHasFocus - Setter for toolbar focus state
  * @param {Element|null} props.currentContentEditableElement - Current content editable element
  * @param {Element|null} props.currentInlineEditingElement - Current inline editing element
@@ -29,7 +27,6 @@ import { BlockForm } from './block-form';
 export const InlineEditingToolbar = ( {
 	blockIcon,
 	blockFieldInfo,
-	acfFormRef,
 	setInlineEditingToolbarHasFocus,
 	currentContentEditableElement,
 	currentInlineEditingElement,
@@ -38,19 +35,20 @@ export const InlineEditingToolbar = ( {
 	setCurrentBlockFormContainer,
 	contentEditableChangeInProgress,
 } ) => {
-	const [ isFieldPopoverOpen, setIsFieldPopoverOpen ] = useState( false );
-	const [ isFieldModalOpen, setIsFieldModalOpen ] = useState( false );
 	const [ selectedFieldKey, setSelectedFieldKey ] = useState( null );
-	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
-	const fieldPopoverContainerRef = useState( null );
+	const [ selectedFieldConfig, setSelectedFieldConfig ] = useState();
+	const [ selectedFieldButtonRef, setSelectedFieldButtonRef ] = useState();
+	const [ usePopover, setUsePopover ] = useState( true );
+	const fieldPopoverContainerRef = useRef();
 
-	// Parse inline fields from data attribute
+	// Get inline fields from data attribute
 	const inlineFieldsAttr = currentInlineEditingElement
 		? currentInlineEditingElement.getAttribute( 'data-acf-inline-fields' )
 		: null;
+
 	let inlineFields = [];
 	try {
-		inlineFields = JSON.parse( inlineFieldsAttr || '[]' );
+		inlineFields = JSON.parse( inlineFieldsAttr );
 	} catch ( e ) {
 		acf.debug(
 			'Inline fields were not a properly formatted JSON array',
@@ -59,243 +57,331 @@ export const InlineEditingToolbar = ( {
 	}
 
 	/**
-	 * Get field type by field name
+	 * Get field type class name from field name
 	 */
-	const getFieldType = ( fieldName ) => {
+	function getFieldTypeClassName( fieldName ) {
+		if ( ! fieldName || ! blockFieldInfo ) return '';
 		const field = blockFieldInfo.find( ( f ) => f.name === fieldName );
-		return field?.type || null;
-	};
-
-	/**
-	 * Get field info by field name
-	 */
-	const getFieldInfo = ( fieldName ) => {
-		return blockFieldInfo.find( ( f ) => f.name === fieldName ) || null;
-	};
-
-	/**
-	 * Get field label by field name
-	 */
-	const getFieldLabel = ( fieldName ) => {
-		const field = getFieldInfo( fieldName );
-		return field?.label || fieldName;
-	};
-
-	/**
-	 * Check if field type requires modal
-	 */
-	const isComplexFieldType = ( fieldType ) => {
-		return [ 'flexible_content', 'repeater', 'group' ].includes(
-			fieldType
-		);
-	};
-
-	/**
-	 * Get toolbar icon from data attribute or field or default
-	 */
-	const toolbarIcon = useMemo( () => {
-		// Check for custom toolbar icon in data attribute
-		const customIcon = currentInlineEditingElement?.getAttribute(
-			'data-acf-toolbar-icon'
-		);
-		if ( customIcon ) {
-			// Decode base64 SVG if present
-			try {
-				if ( customIcon.startsWith( 'data:image/svg+xml;base64,' ) ) {
-					return customIcon;
-				}
-			} catch ( e ) {
-				// Ignore
-			}
-		}
-
-		// Use field icon if available
-		if ( currentContentEditableElement ) {
-			const fieldSlug = currentContentEditableElement.getAttribute(
-				'data-acf-inline-contenteditable-field-slug'
-			);
-			const field = getFieldInfo( fieldSlug );
-			if ( field?.icon ) {
-				return field.icon;
-			}
-		}
-
-		// Default icon
-		return blockIcon || 'edit';
-	}, [
-		currentInlineEditingElement,
-		currentContentEditableElement,
-		blockIcon,
-	] );
-
-	/**
-	 * Get toolbar title from data attribute or element type or field label
-	 */
-	const toolbarTitle = useMemo( () => {
-		// Check for custom toolbar title in data attribute
-		const customTitle = currentInlineEditingElement?.getAttribute(
-			'data-acf-toolbar-title'
-		);
-		if ( customTitle ) {
-			return customTitle;
-		}
-
-		// Use content editable field label if available
-		if ( currentContentEditableElement ) {
-			const fieldSlug = currentContentEditableElement.getAttribute(
-				'data-acf-inline-contenteditable-field-slug'
-			);
-			return getFieldLabel( fieldSlug );
-		}
-
-		// Use element type (DIV, P, SPAN, etc.) if no field is selected
-		if ( currentInlineEditingElement ) {
-			const tagName = currentInlineEditingElement.tagName;
-			return tagName.charAt( 0 ) + tagName.slice( 1 ).toLowerCase();
-		}
-
-		return acf.__( 'Edit' );
-	}, [
-		currentInlineEditingElement,
-		currentContentEditableElement,
-		blockFieldInfo,
-	] );
-
-	/**
-	 * Handle field button click
-	 */
-	const handleFieldButtonClick = ( fieldName, buttonElement ) => {
-		const fieldType = getFieldType( fieldName );
-
-		// Set selected field
-		setSelectedFieldKey( fieldName );
-
-		// Open modal for complex field types
-		if ( isComplexFieldType( fieldType ) ) {
-			setIsFieldModalOpen( true );
-			setIsFieldPopoverOpen( false );
-		} else {
-			// Open popover for simple fields
-			setPopoverAnchor( buttonElement );
-			setIsFieldPopoverOpen( true );
-		}
-	};
-
-	/**
-	 * Close field popover/modal
-	 */
-	const closeFieldEditor = () => {
-		setIsFieldPopoverOpen( false );
-		setIsFieldModalOpen( false );
-		setSelectedFieldKey( null );
-		setPopoverAnchor( null );
-	};
-
-	// Clean up when toolbar loses focus
-	useEffect( () => {
-		setInlineEditingToolbarHasFocus( true );
-		return () => {
-			setInlineEditingToolbarHasFocus( false );
-		};
-	}, [] );
-
-	if ( ! currentInlineEditingElement || ! currentInlineEditingElementUid ) {
-		return null;
+		return field?.type ? field.type.replace( /_/g, '-' ) : '';
 	}
 
+	/**
+	 * Get field label from field name
+	 */
+	function getFieldLabel( fieldName ) {
+		if ( ! fieldName || ! blockFieldInfo ) return '';
+		const field = blockFieldInfo.find( ( f ) => f.name === fieldName );
+		return field ? field.label : '';
+	}
+
+	// Clear selected field when content editable changes
+	useEffect( () => {
+		setSelectedFieldKey( null );
+	}, [ contentEditableChangeInProgress ] );
+
+	// Generate toolbar icon
+	const toolbarIcon = useMemo( () => {
+		let icon =
+			currentContentEditableElement && ! currentInlineEditingElement
+				? currentContentEditableElement.getAttribute(
+						'data-acf-toolbar-icon'
+				  )
+				: null;
+
+		if ( ! icon && currentInlineEditingElement ) {
+			icon = currentInlineEditingElement
+				? currentInlineEditingElement.getAttribute(
+						'data-acf-toolbar-icon'
+				  )
+				: null;
+		}
+
+		if ( icon ) {
+			icon = <i dangerouslySetInnerHTML={ { __html: icon } } />;
+		}
+
+		if ( ! icon && currentContentEditableElement && ! currentInlineEditingElement ) {
+			const fieldSlug = currentContentEditableElement.getAttribute(
+				'data-acf-inline-contenteditable-field-slug'
+			);
+			icon = (
+				<i
+					className={ `field-type-icon field-type-icon-${ getFieldTypeClassName(
+						fieldSlug
+					) }` }
+				/>
+			);
+		}
+
+		if ( ! icon ) {
+			icon = React.isValidElement( blockIcon ) ? (
+				blockIcon
+			) : (
+				<span className={ `dashicon dashicons dashicons-${ blockIcon }` } />
+			);
+		}
+
+		return icon;
+	}, [ blockFieldInfo, currentContentEditableElement, currentInlineEditingElement ] );
+
+	// Generate toolbar title
+	const toolbarTitle = useMemo( () => {
+		let fieldName;
+
+		if ( currentContentEditableElement && ! currentInlineEditingElement ) {
+			const title = currentContentEditableElement.getAttribute(
+				'data-acf-toolbar-title'
+			);
+			if ( title ) return title;
+
+			fieldName = currentContentEditableElement.getAttribute(
+				'data-acf-inline-contenteditable-field-slug'
+			);
+		} else if ( currentInlineEditingElement ) {
+			const title =
+				currentInlineEditingElement.getAttribute( 'data-acf-toolbar-title' );
+			if ( title ) return title;
+
+			if ( inlineFields.length > 1 ) {
+				const elementTypeLabels = {
+					A: 'Link',
+					DIV: 'Division',
+					P: 'Paragraph',
+					SPAN: 'Span',
+					INPUT: 'Input',
+					BUTTON: 'Button',
+					IMG: 'Image',
+					UL: 'Unordered List',
+					OL: 'Ordered List',
+					LI: 'List Item',
+					H1: 'Heading 1',
+					H2: 'Heading 2',
+					H3: 'Heading 3',
+					H4: 'Heading 4',
+					H5: 'Heading 5',
+					H6: 'Heading 6',
+					TABLE: 'Table',
+					TR: 'Table Row',
+					TD: 'Table Cell',
+					TH: 'Table Header',
+					FORM: 'Form',
+					TEXTAREA: 'Text Area',
+					SELECT: 'Select',
+					OPTION: 'Option',
+				};
+				return elementTypeLabels[ currentInlineEditingElement.tagName ];
+			}
+
+			fieldName =
+				typeof inlineFields[ 0 ] === 'object'
+					? inlineFields[ 0 ].fieldName
+					: inlineFields[ 0 ];
+		}
+
+		return getFieldLabel( fieldName );
+	}, [ currentInlineEditingElement, currentContentEditableElement, blockFieldInfo ] );
+
 	return (
-		<div className="acf-inline-editing-toolbar-content">
-			<div className="acf-inline-editing-toolbar-header">
-				<div className="acf-inline-editing-toolbar-icon">
-					{ typeof toolbarIcon === 'string' &&
-					toolbarIcon.startsWith( 'data:image' ) ? (
-						<img src={ toolbarIcon } alt="" />
-					) : (
-						<span className={ `dashicons dashicons-${ toolbarIcon }` } />
-					) }
-				</div>
-				<div className="acf-inline-editing-toolbar-title">
-					{ toolbarTitle }
-				</div>
-			</div>
-
-			{ inlineFields.length > 0 && (
-				<div className="acf-inline-editing-toolbar-fields">
-					{ inlineFields.map( ( fieldName ) => {
-						const field = getFieldInfo( fieldName );
-						if ( ! field ) {
-							return null;
-						}
-
-						return (
-							<Button
-								key={ fieldName }
-								className="acf-toolbar-button"
-								onClick={ ( e ) => {
-									handleFieldButtonClick(
-										fieldName,
-										e.currentTarget
-									);
-								} }
-								icon={ field.icon || 'edit' }
-								label={ field.label }
-								showTooltip={ true }
-							/>
-						);
-					} ) }
-				</div>
-			) }
-
+		<>
 			{ /* Field popover for simple fields */ }
-			{ isFieldPopoverOpen && popoverAnchor && selectedFieldKey && (
-				<PopoverWrapper
-					className="acf-inline-fields-popover"
-					anchor={ popoverAnchor }
-					placement="bottom-start"
-					onClose={ closeFieldEditor }
-					focusOnMount={ false }
-					variant="unstyled"
-					gutenbergIframeOrDocument={ gutenbergIframeOrDocument }
-				>
-					<div className="acf-inline-fields-popover-inner">
-						{ acfFormRef?.current &&
-							createPortal(
-								<div style={ { padding: '16px' } }>
-									{ /* Render specific field from form */ }
-									<div
-										dangerouslySetInnerHTML={ {
-											__html: acfFormRef.current.querySelector(
-												`[data-name="${ selectedFieldKey }"]`
-											)?.outerHTML,
+			{ selectedFieldKey &&
+				selectedFieldButtonRef &&
+				usePopover &&
+				currentInlineEditingElementUid && (
+					<PopoverWrapper
+						focusOnMount={ false }
+						className="acf-inline-fields-popover"
+						anchor={ selectedFieldButtonRef }
+						onClose={ ( event ) => {
+							if ( event.key === 'Escape' ) {
+								setSelectedFieldKey( null );
+								return true;
+							}
+							// Don't close if clicking inside the popover or anchor
+							if (
+								( event?.target &&
+									fieldPopoverContainerRef?.current &&
+									fieldPopoverContainerRef?.current.contains(
+										event.target
+									) ) ||
+								( selectedFieldButtonRef?.current &&
+									selectedFieldButtonRef?.current.contains(
+										event?.target
+									) )
+							) {
+								return false;
+							}
+							return undefined;
+						} }
+						variant={ usePopover ? 'toolbar' : 'unstyled' }
+						gutenbergIframeOrDocument={ gutenbergIframeOrDocument }
+						hidePrimaryBlockToolbar={ true }
+						animate={ true }
+					>
+						<div
+							ref={ fieldPopoverContainerRef }
+							onClick={ () => {
+								setInlineEditingToolbarHasFocus( true );
+							} }
+						>
+							<div
+								className="acf-inline-fields-popover-inner"
+								style={ {
+									minWidth: selectedFieldConfig?.popoverMinWidth
+										? selectedFieldConfig?.popoverMinWidth
+										: '300px',
+								} }
+								ref={ setCurrentBlockFormContainer }
+							/>
+						</div>
+					</PopoverWrapper>
+				) }
+
+			{ /* Modal for complex field types */ }
+			{ selectedFieldKey &&
+				selectedFieldButtonRef &&
+				! usePopover &&
+				currentInlineEditingElementUid && (
+					<Modal
+						className="acf-block-form-modal"
+						isFullScreen={ true }
+						title={
+							blockFieldInfo && selectedFieldKey
+								? blockFieldInfo.find(
+										( f ) => f.name === selectedFieldKey
+								  )?.label
+								: ''
+						}
+						onRequestClose={ () => {
+							setSelectedFieldKey( null );
+						} }
+					>
+						<div
+							ref={ fieldPopoverContainerRef }
+							onClick={ () => {
+								setInlineEditingToolbarHasFocus( true );
+							} }
+						>
+							<div
+								className="acf-inline-fields-popover-inner"
+								style={ {
+									minWidth: selectedFieldConfig?.popoverMinWidth
+										? selectedFieldConfig?.popoverMinWidth
+										: '300px',
+								} }
+								ref={ setCurrentBlockFormContainer }
+							/>
+						</div>
+					</Modal>
+				) }
+
+			{ /* Toolbar */ }
+			<Toolbar
+				orientation="horizontal"
+				className="components-accessible-toolbar block-editor-block-contextual-toolbar"
+				style={ { width: 'max-content' } }
+			>
+				<div className="block-editor-block-toolbar">
+					{ /* Toolbar icon and title */ }
+					<ToolbarGroup style={ { alignItems: 'center' } }>
+						<div
+							className="acf-blocks-toolbar-icon components-toolbar-group block-editor-block-toolbar__block-controls"
+							label={ toolbarTitle }
+						>
+							{ toolbarIcon }
+							<span>{ toolbarTitle }</span>
+						</div>
+					</ToolbarGroup>
+
+					{ /* Field buttons */ }
+					<ToolbarGroup>
+						{ ( () => {
+							if ( ! inlineFields || inlineFields.length === 0 ) {
+								return null;
+							}
+
+							const buttons = inlineFields.map( ( field, index ) => {
+								let fieldName = '';
+								let fieldIconSvg = null;
+								let fieldLabel = null;
+
+								if ( typeof field === 'object' ) {
+									fieldName = field.fieldName
+										? field.fieldName
+										: index;
+									fieldIconSvg = field.fieldIcon
+										? window.atob( field.fieldIcon )
+										: null;
+									fieldLabel = field.fieldLabel
+										? field.fieldLabel
+										: fieldName;
+								} else {
+									fieldName = field;
+								}
+
+								// Use 'edit' icon if field has useExpandedEditor flag
+								if ( ! fieldIconSvg && field?.useExpandedEditor ) {
+									fieldIconSvg = 'edit';
+								}
+
+								return (
+									<ToolbarButton
+										key={ fieldName }
+										disabled={ contentEditableChangeInProgress }
+										className="acf-toolbar-button"
+										icon={
+											fieldIconSvg ? (
+												typeof fieldIconSvg === 'string' &&
+												fieldIconSvg === 'edit' ? (
+													'edit'
+												) : (
+													<i
+														dangerouslySetInnerHTML={ {
+															__html: fieldIconSvg,
+														} }
+													/>
+												)
+											) : (
+												<i
+													className={ `field-type-icon field-type-icon-${ getFieldTypeClassName(
+														fieldName
+													) }` }
+												/>
+											)
+										}
+										label={ fieldLabel || getFieldLabel( fieldName ) }
+										isPressed={ fieldName === selectedFieldKey }
+										ref={
+											fieldName === selectedFieldKey
+												? setSelectedFieldButtonRef
+												: null
+										}
+										onClick={ () => {
+											setInlineEditingToolbarHasFocus( true );
+											if ( selectedFieldKey === fieldName ) {
+												setSelectedFieldKey( null );
+											} else {
+												// Determine if we should use modal or popover
+												setUsePopover( ! field?.useExpandedEditor );
+												setSelectedFieldKey( fieldName );
+												setSelectedFieldConfig( field );
+											}
 										} }
 									/>
-								</div>,
-								fieldPopoverContainerRef
-							) }
-					</div>
-				</PopoverWrapper>
-			) }
+								);
+							} );
 
-			{ /* Field modal for complex fields */ }
-			{ isFieldModalOpen && selectedFieldKey && (
-				<Modal
-					className="acf-inline-field-modal"
-					title={ getFieldLabel( selectedFieldKey ) }
-					onRequestClose={ closeFieldEditor }
-				>
-					<div className="acf-inline-field-modal-content">
-						{ acfFormRef?.current && (
-							<div
-								dangerouslySetInnerHTML={ {
-									__html: acfFormRef.current.querySelector(
-										`[data-name="${ selectedFieldKey }"]`
-									)?.outerHTML,
-								} }
-							/>
-						) }
-					</div>
-				</Modal>
-			) }
-		</div>
+							return buttons;
+						} )() }
+					</ToolbarGroup>
+				</div>
+			</Toolbar>
+
+			{ /* Style to show selected field */ }
+			{ ( () => {
+				const styleContent = `[data-name="${ selectedFieldKey }"]{ display: block!important; }`;
+				return <style>{ styleContent }</style>;
+			} )() }
+		</>
 	);
 };

--- a/assets/src/js/pro/blocks-v3/components/inline-editing-toolbar.js
+++ b/assets/src/js/pro/blocks-v3/components/inline-editing-toolbar.js
@@ -1,0 +1,301 @@
+/**
+ * InlineEditingToolbar Component
+ * Main inline editing toolbar for ACF blocks
+ * Handles field selection and editing for inline editable elements
+ */
+
+import { useState, useEffect, useMemo, createPortal } from '@wordpress/element';
+import { Button, Modal } from '@wordpress/components';
+import { PopoverWrapper } from './popover-wrapper';
+import { BlockForm } from './block-form';
+
+/**
+ * InlineEditingToolbar component
+ * Displays a toolbar with field buttons for inline editing
+ *
+ * @param {Object} props - Component props
+ * @param {Object} props.blockIcon - Block icon configuration
+ * @param {Array} props.blockFieldInfo - Array of field information
+ * @param {React.RefObject} props.acfFormRef - Reference to ACF form
+ * @param {Function} props.setInlineEditingToolbarHasFocus - Setter for toolbar focus state
+ * @param {Element|null} props.currentContentEditableElement - Current content editable element
+ * @param {Element|null} props.currentInlineEditingElement - Current inline editing element
+ * @param {string|null} props.currentInlineEditingElementUid - Current element UID
+ * @param {Document|HTMLIFrameElement} props.gutenbergIframeOrDocument - Document or iframe reference
+ * @param {Function} props.setCurrentBlockFormContainer - Setter for form container
+ * @param {boolean} props.contentEditableChangeInProgress - Whether content change is in progress
+ * @returns {JSX.Element|null} - Rendered toolbar or null
+ */
+export const InlineEditingToolbar = ( {
+	blockIcon,
+	blockFieldInfo,
+	acfFormRef,
+	setInlineEditingToolbarHasFocus,
+	currentContentEditableElement,
+	currentInlineEditingElement,
+	currentInlineEditingElementUid,
+	gutenbergIframeOrDocument,
+	setCurrentBlockFormContainer,
+	contentEditableChangeInProgress,
+} ) => {
+	const [ isFieldPopoverOpen, setIsFieldPopoverOpen ] = useState( false );
+	const [ isFieldModalOpen, setIsFieldModalOpen ] = useState( false );
+	const [ selectedFieldKey, setSelectedFieldKey ] = useState( null );
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+	const fieldPopoverContainerRef = useState( null );
+
+	// Parse inline fields from data attribute
+	const inlineFieldsAttr = currentInlineEditingElement
+		? currentInlineEditingElement.getAttribute( 'data-acf-inline-fields' )
+		: null;
+	let inlineFields = [];
+	try {
+		inlineFields = JSON.parse( inlineFieldsAttr || '[]' );
+	} catch ( e ) {
+		acf.debug(
+			'Inline fields were not a properly formatted JSON array',
+			inlineFieldsAttr
+		);
+	}
+
+	/**
+	 * Get field type by field name
+	 */
+	const getFieldType = ( fieldName ) => {
+		const field = blockFieldInfo.find( ( f ) => f.name === fieldName );
+		return field?.type || null;
+	};
+
+	/**
+	 * Get field info by field name
+	 */
+	const getFieldInfo = ( fieldName ) => {
+		return blockFieldInfo.find( ( f ) => f.name === fieldName ) || null;
+	};
+
+	/**
+	 * Get field label by field name
+	 */
+	const getFieldLabel = ( fieldName ) => {
+		const field = getFieldInfo( fieldName );
+		return field?.label || fieldName;
+	};
+
+	/**
+	 * Check if field type requires modal
+	 */
+	const isComplexFieldType = ( fieldType ) => {
+		return [ 'flexible_content', 'repeater', 'group' ].includes(
+			fieldType
+		);
+	};
+
+	/**
+	 * Get toolbar icon from data attribute or field or default
+	 */
+	const toolbarIcon = useMemo( () => {
+		// Check for custom toolbar icon in data attribute
+		const customIcon = currentInlineEditingElement?.getAttribute(
+			'data-acf-toolbar-icon'
+		);
+		if ( customIcon ) {
+			// Decode base64 SVG if present
+			try {
+				if ( customIcon.startsWith( 'data:image/svg+xml;base64,' ) ) {
+					return customIcon;
+				}
+			} catch ( e ) {
+				// Ignore
+			}
+		}
+
+		// Use field icon if available
+		if ( currentContentEditableElement ) {
+			const fieldSlug = currentContentEditableElement.getAttribute(
+				'data-acf-inline-contenteditable-field-slug'
+			);
+			const field = getFieldInfo( fieldSlug );
+			if ( field?.icon ) {
+				return field.icon;
+			}
+		}
+
+		// Default icon
+		return blockIcon || 'edit';
+	}, [
+		currentInlineEditingElement,
+		currentContentEditableElement,
+		blockIcon,
+	] );
+
+	/**
+	 * Get toolbar title from data attribute or element type or field label
+	 */
+	const toolbarTitle = useMemo( () => {
+		// Check for custom toolbar title in data attribute
+		const customTitle = currentInlineEditingElement?.getAttribute(
+			'data-acf-toolbar-title'
+		);
+		if ( customTitle ) {
+			return customTitle;
+		}
+
+		// Use content editable field label if available
+		if ( currentContentEditableElement ) {
+			const fieldSlug = currentContentEditableElement.getAttribute(
+				'data-acf-inline-contenteditable-field-slug'
+			);
+			return getFieldLabel( fieldSlug );
+		}
+
+		// Use element type (DIV, P, SPAN, etc.) if no field is selected
+		if ( currentInlineEditingElement ) {
+			const tagName = currentInlineEditingElement.tagName;
+			return tagName.charAt( 0 ) + tagName.slice( 1 ).toLowerCase();
+		}
+
+		return acf.__( 'Edit' );
+	}, [
+		currentInlineEditingElement,
+		currentContentEditableElement,
+		blockFieldInfo,
+	] );
+
+	/**
+	 * Handle field button click
+	 */
+	const handleFieldButtonClick = ( fieldName, buttonElement ) => {
+		const fieldType = getFieldType( fieldName );
+
+		// Set selected field
+		setSelectedFieldKey( fieldName );
+
+		// Open modal for complex field types
+		if ( isComplexFieldType( fieldType ) ) {
+			setIsFieldModalOpen( true );
+			setIsFieldPopoverOpen( false );
+		} else {
+			// Open popover for simple fields
+			setPopoverAnchor( buttonElement );
+			setIsFieldPopoverOpen( true );
+		}
+	};
+
+	/**
+	 * Close field popover/modal
+	 */
+	const closeFieldEditor = () => {
+		setIsFieldPopoverOpen( false );
+		setIsFieldModalOpen( false );
+		setSelectedFieldKey( null );
+		setPopoverAnchor( null );
+	};
+
+	// Clean up when toolbar loses focus
+	useEffect( () => {
+		setInlineEditingToolbarHasFocus( true );
+		return () => {
+			setInlineEditingToolbarHasFocus( false );
+		};
+	}, [] );
+
+	if ( ! currentInlineEditingElement || ! currentInlineEditingElementUid ) {
+		return null;
+	}
+
+	return (
+		<div className="acf-inline-editing-toolbar-content">
+			<div className="acf-inline-editing-toolbar-header">
+				<div className="acf-inline-editing-toolbar-icon">
+					{ typeof toolbarIcon === 'string' &&
+					toolbarIcon.startsWith( 'data:image' ) ? (
+						<img src={ toolbarIcon } alt="" />
+					) : (
+						<span className={ `dashicons dashicons-${ toolbarIcon }` } />
+					) }
+				</div>
+				<div className="acf-inline-editing-toolbar-title">
+					{ toolbarTitle }
+				</div>
+			</div>
+
+			{ inlineFields.length > 0 && (
+				<div className="acf-inline-editing-toolbar-fields">
+					{ inlineFields.map( ( fieldName ) => {
+						const field = getFieldInfo( fieldName );
+						if ( ! field ) {
+							return null;
+						}
+
+						return (
+							<Button
+								key={ fieldName }
+								className="acf-toolbar-button"
+								onClick={ ( e ) => {
+									handleFieldButtonClick(
+										fieldName,
+										e.currentTarget
+									);
+								} }
+								icon={ field.icon || 'edit' }
+								label={ field.label }
+								showTooltip={ true }
+							/>
+						);
+					} ) }
+				</div>
+			) }
+
+			{ /* Field popover for simple fields */ }
+			{ isFieldPopoverOpen && popoverAnchor && selectedFieldKey && (
+				<PopoverWrapper
+					className="acf-inline-fields-popover"
+					anchor={ popoverAnchor }
+					placement="bottom-start"
+					onClose={ closeFieldEditor }
+					focusOnMount={ false }
+					variant="unstyled"
+					gutenbergIframeOrDocument={ gutenbergIframeOrDocument }
+				>
+					<div className="acf-inline-fields-popover-inner">
+						{ acfFormRef?.current &&
+							createPortal(
+								<div style={ { padding: '16px' } }>
+									{ /* Render specific field from form */ }
+									<div
+										dangerouslySetInnerHTML={ {
+											__html: acfFormRef.current.querySelector(
+												`[data-name="${ selectedFieldKey }"]`
+											)?.outerHTML,
+										} }
+									/>
+								</div>,
+								fieldPopoverContainerRef
+							) }
+					</div>
+				</PopoverWrapper>
+			) }
+
+			{ /* Field modal for complex fields */ }
+			{ isFieldModalOpen && selectedFieldKey && (
+				<Modal
+					className="acf-inline-field-modal"
+					title={ getFieldLabel( selectedFieldKey ) }
+					onRequestClose={ closeFieldEditor }
+				>
+					<div className="acf-inline-field-modal-content">
+						{ acfFormRef?.current && (
+							<div
+								dangerouslySetInnerHTML={ {
+									__html: acfFormRef.current.querySelector(
+										`[data-name="${ selectedFieldKey }"]`
+									)?.outerHTML,
+								} }
+							/>
+						) }
+					</div>
+				</Modal>
+			) }
+		</div>
+	);
+};

--- a/assets/src/js/pro/blocks-v3/components/jsx-parser.js
+++ b/assets/src/js/pro/blocks-v3/components/jsx-parser.js
@@ -129,17 +129,10 @@ function parseAttribute( attribute ) {
 }
 
 /**
- * Main parseNodeToJSX function - Based on 6.7.0.2's function `m`
- * This is the exact logic from 6.7.0.2
+ * Main parseNodeToJSX function - Based on 6.7.0.2's function `O`
+ * Recursively converts DOM nodes to React/JSX elements
  */
-function parseNodeToJSX(
-	node,
-	depth = 0,
-	setCurrentInlineEditingElementUid = null,
-	onContentEditableChange = null,
-	setCurrentContentEditableElement = null,
-	blockFieldInfo = null
-) {
+function parseNodeToJSX( node, depth = 0 ) {
 	// Determine component type
 	const nodeName = node.nodeName.toLowerCase();
 	let componentType;
@@ -183,11 +176,18 @@ function parseNodeToJSX(
 
 		props.onFocus = ( event ) => {
 			event.stopPropagation();
-			setCurrentInlineEditingElementUid &&
-				setCurrentInlineEditingElementUid(
-					node.attributes.getNamedItem( 'data-acf-inline-fields-uid' )
-						.value
+			const uid = node.attributes.getNamedItem(
+				'data-acf-inline-fields-uid'
+			).value;
+			if ( acf.blockEdit?.setCurrentInlineEditingElementUid ) {
+				acf.blockEdit.setCurrentInlineEditingElementUid( uid );
+			}
+			// Also set the element reference for the toolbar to use
+			if ( acf.blockEdit?.setCurrentInlineEditingElement ) {
+				acf.blockEdit.setCurrentInlineEditingElement(
+					event.currentTarget
 				);
+			}
 		};
 
 		props.onMouseDown = ( event ) => event.stopPropagation();
@@ -202,12 +202,17 @@ function parseNodeToJSX(
 			if (
 				! event.target.hasAttribute( 'data-acf-inline-contenteditable' )
 			) {
-				setCurrentInlineEditingElementUid &&
-					setCurrentInlineEditingElementUid(
-						node.attributes.getNamedItem(
-							'data-acf-inline-fields-uid'
-						).value
+				const uid = node.attributes.getNamedItem(
+					'data-acf-inline-fields-uid'
+				).value;
+				if ( acf.blockEdit?.setCurrentInlineEditingElementUid ) {
+					acf.blockEdit.setCurrentInlineEditingElementUid( uid );
+				}
+				if ( acf.blockEdit?.setCurrentInlineEditingElement ) {
+					acf.blockEdit.setCurrentInlineEditingElement(
+						event.currentTarget
 					);
+				}
 			}
 		};
 
@@ -220,12 +225,12 @@ function parseNodeToJSX(
 				const button = toolbar?.querySelector( 'button' );
 				if ( button ) {
 					button.focus();
-					setCurrentInlineEditingElementUid &&
-						setCurrentInlineEditingElementUid(
-							node.attributes.getNamedItem(
-								'data-acf-inline-fields-uid'
-							).value
-						);
+					const uid = node.attributes.getNamedItem(
+						'data-acf-inline-fields-uid'
+					).value;
+					if ( acf.blockEdit?.setCurrentInlineEditingElementUid ) {
+						acf.blockEdit.setCurrentInlineEditingElementUid( uid );
+					}
 				}
 			}
 			if ( event.key === 'Enter' ) {
@@ -235,12 +240,17 @@ function parseNodeToJSX(
 					event.preventDefault();
 					acf.debug( `Navigation prevented for ${ link.href }` );
 				}
-				setCurrentInlineEditingElementUid &&
-					setCurrentInlineEditingElementUid(
-						node.attributes.getNamedItem(
-							'data-acf-inline-fields-uid'
-						).value
+				const uid = node.attributes.getNamedItem(
+					'data-acf-inline-fields-uid'
+				).value;
+				if ( acf.blockEdit?.setCurrentInlineEditingElementUid ) {
+					acf.blockEdit.setCurrentInlineEditingElementUid( uid );
+				}
+				if ( acf.blockEdit?.setCurrentInlineEditingElement ) {
+					acf.blockEdit.setCurrentInlineEditingElement(
+						event.currentTarget
 					);
+				}
 			}
 		};
 	}
@@ -251,6 +261,8 @@ function parseNodeToJSX(
 			'data-acf-inline-contenteditable-field-slug'
 		).value;
 
+		// Get block field info from state if available
+		const blockFieldInfo = acf.blockEdit?.getBlockFieldInfo?.();
 		const editableFields = blockFieldInfo
 			? blockFieldInfo.filter(
 					( field ) =>
@@ -264,8 +276,6 @@ function parseNodeToJSX(
 			props.suppressContentEditableWarning = true;
 			props.role = 'input';
 			props.tabIndex = 0;
-			// Add key to give React stable identity for this element
-			props.key = 'contenteditable-' + fieldSlug;
 
 			props.onFocus = ( event ) => {
 				const link = event.target.closest( 'a' );
@@ -274,22 +284,19 @@ function parseNodeToJSX(
 					acf.debug( `Navigation prevented for ${ link.href }` );
 				}
 				event.stopPropagation();
-				setCurrentContentEditableElement &&
-					setCurrentContentEditableElement(
-						node.attributes.getNamedItem(
-							'data-acf-inline-contenteditable-field-slug'
-						).value
-					);
 				if ( node.hasAttribute( 'data-acf-inline-fields' ) ) {
-					setCurrentInlineEditingElementUid &&
-						setCurrentInlineEditingElementUid(
-							node.attributes.getNamedItem(
-								'data-acf-inline-fields-uid'
-							).value
-						);
-				} else {
-					setCurrentInlineEditingElementUid &&
-						setCurrentInlineEditingElementUid( null );
+					const uid = node.attributes.getNamedItem(
+						'data-acf-inline-fields-uid'
+					).value;
+					if ( acf.blockEdit?.setCurrentInlineEditingElementUid ) {
+						acf.blockEdit.setCurrentInlineEditingElementUid( uid );
+					}
+					if ( acf.blockEdit?.setCurrentInlineEditingElement ) {
+						acf.blockEdit.setCurrentInlineEditingElement( event.currentTarget );
+					}
+				}
+				if ( acf.blockEdit?.setCurrentContentEditableElement ) {
+					acf.blockEdit.setCurrentContentEditableElement( event.currentTarget );
 				}
 			};
 
@@ -313,8 +320,15 @@ function parseNodeToJSX(
 	) {
 		props.onClick = ( event ) => {
 			if ( event.target === event.currentTarget ) {
-				setCurrentInlineEditingElementUid &&
-					setCurrentInlineEditingElementUid( null );
+				if ( acf.blockEdit?.setCurrentInlineEditingElementUid ) {
+					acf.blockEdit.setCurrentInlineEditingElementUid( null );
+				}
+				if ( acf.blockEdit?.setCurrentInlineEditingElement ) {
+					acf.blockEdit.setCurrentInlineEditingElement( null );
+				}
+				if ( acf.blockEdit?.setCurrentContentEditableElement ) {
+					acf.blockEdit.setCurrentContentEditableElement( null );
+				}
 			}
 		};
 	}
@@ -334,47 +348,20 @@ function parseNodeToJSX(
 				elementArgs.push( textContent );
 			}
 		} else {
-			elementArgs.push(
-				parseNodeToJSX(
-					childNode,
-					depth + 1,
-					setCurrentInlineEditingElementUid,
-					onContentEditableChange,
-					setCurrentContentEditableElement,
-					blockFieldInfo
-				)
-			);
+			elementArgs.push( parseNodeToJSX( childNode, depth + 1 ) );
 		}
 	} );
 
 	const element = createElement.apply( this, elementArgs );
-
-	// Debug logging for contentEditable elements
-	if ( props.contentEditable ) {
-		console.log( '🔵 Created contentEditable element:', {
-			componentType,
-			key: props.key,
-			textContent: element?.props?.children,
-		} );
-	}
 
 	return element;
 }
 
 /**
  * Main parseJSX function exposed on the acf global object
- * Wrapper function that matches 6.7.0.2's `h` function
+ * Matches 6.7.0.2's implementation exactly
  */
-export function parseJSX(
-	htmlString,
-	setCurrentInlineEditingElementUid = null,
-	onContentEditableChange = null,
-	setCurrentContentEditableElement = null,
-	blockFieldInfo = null,
-	$ = jQuery
-) {
-	console.log( '🟣 parseJSX called, React version:', React?.version );
-
+export function parseJSX( htmlString, $ = jQuery ) {
 	// Wrap in div to ensure valid HTML structure
 	htmlString = '<div>' + htmlString + '</div>';
 
@@ -385,14 +372,7 @@ export function parseJSX(
 	);
 
 	// Parse with jQuery, convert to React, and extract children from wrapper div
-	const parsedElement = parseNodeToJSX(
-		$( htmlString )[ 0 ],
-		0,
-		setCurrentInlineEditingElementUid,
-		onContentEditableChange,
-		setCurrentContentEditableElement,
-		blockFieldInfo
-	);
+	const parsedElement = parseNodeToJSX( $( htmlString )[ 0 ], 0 );
 	return parsedElement.props.children;
 }
 

--- a/assets/src/js/pro/blocks-v3/components/jsx-parser.js
+++ b/assets/src/js/pro/blocks-v3/components/jsx-parser.js
@@ -154,9 +154,18 @@ function parseAttribute( attribute ) {
  *
  * @param {Node} node - The DOM node to parse
  * @param {number} depth - Current recursion depth (0-based)
+ * @param {Function} setCurrentInlineEditingElementUid - Setter for inline editing UID
+ * @param {Function} setCurrentContentEditableElement - Setter for contentEditable element
+ * @param {Array} blockFieldInfo - Array of field info objects
  * @returns {JSX.Element|null} - React element or null if node should be skipped
  */
-function parseNodeToJSX( node, depth = 0 ) {
+function parseNodeToJSX(
+	node,
+	depth = 0,
+	setCurrentInlineEditingElementUid = null,
+	setCurrentContentEditableElement = null,
+	blockFieldInfo = null
+) {
 	// Determine the component type for this node
 	const componentType = getComponentType( node.nodeName.toLowerCase() );
 
@@ -176,6 +185,152 @@ function parseNodeToJSX( node, depth = 0 ) {
 			props[ name ] = value;
 		} );
 
+	// Add inline fields event handlers
+	if ( node.hasAttribute( 'data-acf-inline-fields' ) ) {
+		props.style = {
+			...parseStyleAttribute( node.getAttribute( 'style' ) || '' ),
+			pointerEvents: 'all',
+		};
+		props.role = 'button';
+		props.tabIndex = 0;
+
+		props.onFocus = ( event ) => {
+			event.stopPropagation();
+			setCurrentInlineEditingElementUid &&
+				setCurrentInlineEditingElementUid(
+					node.attributes.getNamedItem(
+						'data-acf-inline-fields-uid'
+					).value
+				);
+		};
+
+		props.onMouseDown = ( event ) => event.stopPropagation();
+
+		props.onClick = ( event ) => {
+			event.stopPropagation();
+			const link = event.target.closest( 'a' );
+			if ( link && link.tagName === 'A' ) {
+				event.preventDefault();
+				acf.debug( `Navigation prevented for ${ link.href }` );
+			}
+			if (
+				! event.target.hasAttribute( 'data-acf-inline-contenteditable' )
+			) {
+				setCurrentInlineEditingElementUid &&
+					setCurrentInlineEditingElementUid(
+						node.attributes.getNamedItem(
+							'data-acf-inline-fields-uid'
+						).value
+					);
+			}
+		};
+
+		props.onKeyDown = ( event ) => {
+			if ( event.key === 'Tab' && event.shiftKey ) {
+				event.preventDefault();
+				const toolbar = document.querySelector(
+					'.acf-inline-editing-toolbar'
+				);
+				const button = toolbar?.querySelector( 'button' );
+				if ( button ) {
+					button.focus();
+					setCurrentInlineEditingElementUid &&
+						setCurrentInlineEditingElementUid(
+							node.attributes.getNamedItem(
+								'data-acf-inline-fields-uid'
+							).value
+						);
+				}
+			}
+			if ( event.key === 'Enter' ) {
+				event.stopPropagation();
+				const link = event.target.closest( 'a' );
+				if ( link && link.tagName === 'A' ) {
+					event.preventDefault();
+					acf.debug( `Navigation prevented for ${ link.href }` );
+				}
+				setCurrentInlineEditingElementUid &&
+					setCurrentInlineEditingElementUid(
+						node.attributes.getNamedItem(
+							'data-acf-inline-fields-uid'
+						).value
+					);
+			}
+		};
+	}
+
+	// Add contentEditable handlers
+	if ( node.hasAttribute( 'data-acf-inline-contenteditable' ) ) {
+		const fieldSlug = node.attributes.getNamedItem(
+			'data-acf-inline-contenteditable-field-slug'
+		).value;
+		const editableFields = blockFieldInfo
+			? blockFieldInfo.filter(
+					( field ) =>
+						field.name === fieldSlug &&
+						( field.type === 'text' || field.type === 'textarea' )
+			  )
+			: [];
+
+		if ( editableFields.length > 0 ) {
+			props.contentEditable = true;
+			props.suppressContentEditableWarning = true;
+			props.role = 'input';
+			props.tabIndex = 0;
+
+			props.onFocus = ( event ) => {
+				const link = event.target.closest( 'a' );
+				if ( link && link.tagName === 'A' ) {
+					event.preventDefault();
+					acf.debug( `Navigation prevented for ${ link.href }` );
+				}
+				event.stopPropagation();
+				setCurrentContentEditableElement &&
+					setCurrentContentEditableElement(
+						node.attributes.getNamedItem(
+							'data-acf-inline-contenteditable-field-slug'
+						).value
+					);
+
+				if ( node.hasAttribute( 'data-acf-inline-fields' ) ) {
+					setCurrentInlineEditingElementUid &&
+						setCurrentInlineEditingElementUid(
+							node.attributes.getNamedItem(
+								'data-acf-inline-fields-uid'
+							).value
+						);
+				} else {
+					setCurrentInlineEditingElementUid &&
+						setCurrentInlineEditingElementUid( null );
+				}
+			};
+
+			props.onPaste = ( event ) => {
+				event.preventDefault();
+				const text = event.clipboardData.getData( 'text/plain' );
+				event.currentTarget.textContent =
+					event.currentTarget.textContent + text;
+			};
+		} else {
+			// Remove invalid contentEditable attributes
+			delete props[ 'data-acf-inline-contenteditable-field-slug' ];
+			delete props[ 'data-acf-inline-contenteditable' ];
+		}
+	}
+
+	// Add click handler to clear selection if clicking outside inline fields
+	if (
+		! node.hasAttribute( 'data-acf-inline-fields' ) &&
+		! node.hasAttribute( 'data-acf-inline-contenteditable' )
+	) {
+		props.onClick = ( event ) => {
+			if ( event.target === event.currentTarget ) {
+				setCurrentInlineEditingElementUid &&
+					setCurrentInlineEditingElementUid( null );
+			}
+		};
+	}
+
 	// Handle special ACFInnerBlocks component
 	if ( componentType === 'ACFInnerBlocks' ) {
 		return createElement( ACFInnerBlocksComponent, { ...props } );
@@ -192,7 +347,15 @@ function parseNodeToJSX( node, depth = 0 ) {
 				elementArray.push( textContent );
 			}
 		} else {
-			elementArray.push( parseNodeToJSX( childNode, depth + 1 ) );
+			elementArray.push(
+				parseNodeToJSX(
+					childNode,
+					depth + 1,
+					setCurrentInlineEditingElementUid,
+					setCurrentContentEditableElement,
+					blockFieldInfo
+				)
+			);
 		}
 	} );
 
@@ -201,13 +364,45 @@ function parseNodeToJSX( node, depth = 0 ) {
 }
 
 /**
+ * Helper function to parse style attribute string into object
+ *
+ * @param {string} styleString - CSS style string
+ * @returns {Object} - Style object for React
+ */
+function parseStyleAttribute( styleString ) {
+	const styleObj = {};
+	if ( ! styleString ) return styleObj;
+
+	styleString.split( ';' ).forEach( ( rule ) => {
+		const [ property, value ] = rule.split( ':' ).map( ( s ) => s.trim() );
+		if ( property && value ) {
+			// Convert CSS property to camelCase
+			const camelProperty = property.replace( /-([a-z])/g, ( g ) =>
+				g[ 1 ].toUpperCase()
+			);
+			styleObj[ camelProperty ] = value;
+		}
+	} );
+
+	return styleObj;
+}
+
+/**
  * Main parseJSX function exposed on the acf global object
  * Converts HTML string to React elements for use in ACF blocks
  *
  * @param {string} htmlString - HTML markup to parse
+ * @param {Function} setCurrentInlineEditingElementUid - Setter for inline editing UID
+ * @param {Function} setCurrentContentEditableElement - Setter for contentEditable element
+ * @param {Array} blockFieldInfo - Array of field info objects
  * @returns {Array|JSX.Element} - React children from parsed HTML
  */
-export function parseJSX( htmlString ) {
+export function parseJSX(
+	htmlString,
+	setCurrentInlineEditingElementUid = null,
+	setCurrentContentEditableElement = null,
+	blockFieldInfo = null
+) {
 	// Wrap in div to ensure valid HTML structure
 	htmlString = '<div>' + htmlString + '</div>';
 
@@ -218,7 +413,13 @@ export function parseJSX( htmlString ) {
 	);
 
 	// Parse with jQuery, convert to React, and extract children from wrapper div
-	const parsedElement = parseNodeToJSX( jQuery( htmlString )[ 0 ], 0 );
+	const parsedElement = parseNodeToJSX(
+		jQuery( htmlString )[ 0 ],
+		0,
+		setCurrentInlineEditingElementUid,
+		setCurrentContentEditableElement,
+		blockFieldInfo
+	);
 	return parsedElement.props.children;
 }
 

--- a/assets/src/js/pro/blocks-v3/components/jsx-parser.js
+++ b/assets/src/js/pro/blocks-v3/components/jsx-parser.js
@@ -1,31 +1,38 @@
 /**
- * JSX Parser for ACF Blocks
+ * JSX Parser for ACF Blocks - Based on 6.7.0.2
  * Converts HTML strings to React/JSX elements for rendering in the block editor
  */
 
 import jQuery from 'jquery';
+import { createElement, createRef } from '@wordpress/element';
 
-const { createElement, createRef, Component } = wp.element;
 const useInnerBlocksProps =
 	wp.blockEditor.__experimentalUseInnerBlocksProps ||
 	wp.blockEditor.useInnerBlocksProps;
 
 /**
  * Gets the JSX-compatible name for an HTML attribute
- * Maps HTML attribute names to React prop names
- *
- * @param {string} attrName - HTML attribute name
- * @returns {string} - JSX/React prop name
  */
 function getJSXNameReplacement( attrName ) {
 	return acf.isget( acf, 'jsxNameReplacements', attrName ) || attrName;
 }
 
 /**
- * Script component for handling <script> tags in parsed content
- * Uses jQuery to safely inject and execute script content
+ * ACF InnerBlocks wrapper component
  */
-class ScriptComponent extends Component {
+function ACFInnerBlocksComponent( props ) {
+	const { className = 'acf-innerblocks-container' } = props;
+	const innerBlocksProps = useInnerBlocksProps( { className }, props );
+	return createElement( 'div', {
+		...innerBlocksProps,
+		children: innerBlocksProps.children,
+	} );
+}
+
+/**
+ * Script component for handling <script> tags
+ */
+class ScriptComponent extends React.Component {
 	render() {
 		return createElement( 'div', {
 			ref: ( element ) => ( this.el = element ),
@@ -46,54 +53,38 @@ class ScriptComponent extends Component {
 }
 
 /**
- * Gets the component type for a given node name
- * Handles special cases like InnerBlocks, script tags, and comments
- *
- * @param {string} nodeName - Lowercase node name
- * @returns {string|Function|null} - Component type or null
+ * Helper function to parse style attribute string into object
  */
-function getComponentType( nodeName ) {
-	switch ( nodeName ) {
-		case 'innerblocks':
-			return 'ACFInnerBlocks';
-		case 'script':
-			return ScriptComponent;
-		case '#comment':
-			return null;
-		default:
-			return getJSXNameReplacement( nodeName );
-	}
-}
+function parseStyleAttribute( styleString ) {
+	const styleObj = {};
+	if ( ! styleString ) return styleObj;
 
-/**
- * ACF InnerBlocks wrapper component
- * Provides a container for WordPress InnerBlocks with proper props
- *
- * @param {Object} props - Component props
- * @returns {JSX.Element} - Wrapped InnerBlocks component
- */
-function ACFInnerBlocksComponent( props ) {
-	const { className = 'acf-innerblocks-container' } = props;
-	const innerBlocksProps = useInnerBlocksProps( { className }, props );
+	styleString.split( ';' ).forEach( ( rule ) => {
+		const colonIndex = rule.indexOf( ':' );
+		if ( colonIndex > 0 ) {
+			let property = rule.substr( 0, colonIndex ).trim();
+			const value = rule.substr( colonIndex + 1 ).trim();
 
-	return createElement( 'div', {
-		...innerBlocksProps,
-		children: innerBlocksProps.children,
+			// Convert to camelCase
+			if ( property.charAt( 0 ) !== '-' ) {
+				property = acf.strCamelCase( property );
+			}
+			styleObj[ property ] = value;
+		}
 	} );
+
+	return styleObj;
 }
 
 /**
  * Parses and transforms a DOM attribute to React props format
- * Handles special cases: class -> className, style string -> style object, JSON values, booleans
- *
- * @param {Attr} attribute - DOM attribute object with name and value
- * @returns {Object} - Transformed attribute {name, value}
+ * Based on 6.7.0.2's implementation
  */
 function parseAttribute( attribute ) {
 	let attrName = attribute.name;
 	let attrValue = attribute.value;
 
-	// Allow custom filtering via ACF hooks
+	// Allow custom filtering
 	const customParsed = acf.applyFilters(
 		'acf_blocks_parse_node_attr',
 		false,
@@ -103,44 +94,32 @@ function parseAttribute( attribute ) {
 
 	switch ( attrName ) {
 		case 'class':
-			// Convert HTML class to React className
 			attrName = 'className';
 			break;
-
 		case 'style':
-			// Parse inline CSS string to JavaScript style object
-			const styleObject = {};
-			attrValue.split( ';' ).forEach( ( declaration ) => {
-				const colonIndex = declaration.indexOf( ':' );
+			const styleObj = {};
+			attrValue.split( ';' ).forEach( ( rule ) => {
+				const colonIndex = rule.indexOf( ':' );
 				if ( colonIndex > 0 ) {
-					let property = declaration.substr( 0, colonIndex ).trim();
-					const value = declaration.substr( colonIndex + 1 ).trim();
-
-					// Convert kebab-case to camelCase (except CSS variables starting with -)
+					let property = rule.substr( 0, colonIndex ).trim();
+					const value = rule.substr( colonIndex + 1 ).trim();
 					if ( property.charAt( 0 ) !== '-' ) {
 						property = acf.strCamelCase( property );
 					}
-
-					styleObject[ property ] = value;
+					styleObj[ property ] = value;
 				}
 			} );
-			attrValue = styleObject;
+			attrValue = styleObj;
 			break;
-
 		default:
-			// Preserve data- attributes as-is
+			// Skip data- attributes processing, keep them as-is
 			if ( attrName.indexOf( 'data-' ) === 0 ) break;
 
-			// Apply JSX name transformations (e.g., onclick -> onClick)
 			attrName = getJSXNameReplacement( attrName );
-
-			// Parse JSON array/object values
 			const firstChar = attrValue.charAt( 0 );
 			if ( firstChar === '[' || firstChar === '{' ) {
 				attrValue = JSON.parse( attrValue );
 			}
-
-			// Convert string booleans to actual booleans
 			if ( attrValue === 'true' || attrValue === 'false' ) {
 				attrValue = attrValue === 'true';
 			}
@@ -150,24 +129,32 @@ function parseAttribute( attribute ) {
 }
 
 /**
- * Recursively parses a DOM node and converts it to React/JSX elements
- *
- * @param {Node} node - The DOM node to parse
- * @param {number} depth - Current recursion depth (0-based)
- * @param {Function} setCurrentInlineEditingElementUid - Setter for inline editing UID
- * @param {Function} setCurrentContentEditableElement - Setter for contentEditable element
- * @param {Array} blockFieldInfo - Array of field info objects
- * @returns {JSX.Element|null} - React element or null if node should be skipped
+ * Main parseNodeToJSX function - Based on 6.7.0.2's function `m`
+ * This is the exact logic from 6.7.0.2
  */
 function parseNodeToJSX(
 	node,
 	depth = 0,
 	setCurrentInlineEditingElementUid = null,
+	onContentEditableChange = null,
 	setCurrentContentEditableElement = null,
 	blockFieldInfo = null
 ) {
-	// Determine the component type for this node
-	const componentType = getComponentType( node.nodeName.toLowerCase() );
+	// Determine component type
+	const nodeName = node.nodeName.toLowerCase();
+	let componentType;
+	switch ( nodeName ) {
+		case 'innerblocks':
+			componentType = 'ACFInnerBlocks';
+			break;
+		case 'script':
+			componentType = ScriptComponent;
+			break;
+		case '#comment':
+			return null;
+		default:
+			componentType = getJSXNameReplacement( nodeName );
+	}
 
 	if ( ! componentType ) return null;
 
@@ -178,14 +165,14 @@ function parseNodeToJSX(
 		props.ref = createRef();
 	}
 
-	// Parse all attributes and add to props
+	// Parse attributes
 	acf.arrayArgs( node.attributes )
 		.map( parseAttribute )
 		.forEach( ( { name, value } ) => {
 			props[ name ] = value;
 		} );
 
-	// Add inline fields event handlers
+	// Handle data-acf-inline-fields attributes
 	if ( node.hasAttribute( 'data-acf-inline-fields' ) ) {
 		props.style = {
 			...parseStyleAttribute( node.getAttribute( 'style' ) || '' ),
@@ -198,9 +185,8 @@ function parseNodeToJSX(
 			event.stopPropagation();
 			setCurrentInlineEditingElementUid &&
 				setCurrentInlineEditingElementUid(
-					node.attributes.getNamedItem(
-						'data-acf-inline-fields-uid'
-					).value
+					node.attributes.getNamedItem( 'data-acf-inline-fields-uid' )
+						.value
 				);
 		};
 
@@ -259,11 +245,12 @@ function parseNodeToJSX(
 		};
 	}
 
-	// Add contentEditable handlers
+	// Handle data-acf-inline-contenteditable attributes
 	if ( node.hasAttribute( 'data-acf-inline-contenteditable' ) ) {
 		const fieldSlug = node.attributes.getNamedItem(
 			'data-acf-inline-contenteditable-field-slug'
 		).value;
+
 		const editableFields = blockFieldInfo
 			? blockFieldInfo.filter(
 					( field ) =>
@@ -277,6 +264,8 @@ function parseNodeToJSX(
 			props.suppressContentEditableWarning = true;
 			props.role = 'input';
 			props.tabIndex = 0;
+			// Add key to give React stable identity for this element
+			props.key = 'contenteditable-' + fieldSlug;
 
 			props.onFocus = ( event ) => {
 				const link = event.target.closest( 'a' );
@@ -291,7 +280,6 @@ function parseNodeToJSX(
 							'data-acf-inline-contenteditable-field-slug'
 						).value
 					);
-
 				if ( node.hasAttribute( 'data-acf-inline-fields' ) ) {
 					setCurrentInlineEditingElementUid &&
 						setCurrentInlineEditingElementUid(
@@ -331,27 +319,27 @@ function parseNodeToJSX(
 		};
 	}
 
-	// Handle special ACFInnerBlocks component
+	// Handle ACFInnerBlocks component
 	if ( componentType === 'ACFInnerBlocks' ) {
 		return createElement( ACFInnerBlocksComponent, { ...props } );
 	}
 
-	// Build element array: [type, props, ...children]
-	const elementArray = [ componentType, props ];
+	// Build element with children
+	const elementArgs = [ componentType, props ];
 
-	// Recursively process child nodes
 	acf.arrayArgs( node.childNodes ).forEach( ( childNode ) => {
 		if ( childNode instanceof Text ) {
 			const textContent = childNode.textContent;
 			if ( textContent ) {
-				elementArray.push( textContent );
+				elementArgs.push( textContent );
 			}
 		} else {
-			elementArray.push(
+			elementArgs.push(
 				parseNodeToJSX(
 					childNode,
 					depth + 1,
 					setCurrentInlineEditingElementUid,
+					onContentEditableChange,
 					setCurrentContentEditableElement,
 					blockFieldInfo
 				)
@@ -359,54 +347,38 @@ function parseNodeToJSX(
 		}
 	} );
 
-	// Create and return React element
-	return createElement.apply( this, elementArray );
-}
+	const element = createElement.apply( this, elementArgs );
 
-/**
- * Helper function to parse style attribute string into object
- *
- * @param {string} styleString - CSS style string
- * @returns {Object} - Style object for React
- */
-function parseStyleAttribute( styleString ) {
-	const styleObj = {};
-	if ( ! styleString ) return styleObj;
+	// Debug logging for contentEditable elements
+	if ( props.contentEditable ) {
+		console.log( '🔵 Created contentEditable element:', {
+			componentType,
+			key: props.key,
+			textContent: element?.props?.children,
+		} );
+	}
 
-	styleString.split( ';' ).forEach( ( rule ) => {
-		const [ property, value ] = rule.split( ':' ).map( ( s ) => s.trim() );
-		if ( property && value ) {
-			// Convert CSS property to camelCase
-			const camelProperty = property.replace( /-([a-z])/g, ( g ) =>
-				g[ 1 ].toUpperCase()
-			);
-			styleObj[ camelProperty ] = value;
-		}
-	} );
-
-	return styleObj;
+	return element;
 }
 
 /**
  * Main parseJSX function exposed on the acf global object
- * Converts HTML string to React elements for use in ACF blocks
- *
- * @param {string} htmlString - HTML markup to parse
- * @param {Function} setCurrentInlineEditingElementUid - Setter for inline editing UID
- * @param {Function} setCurrentContentEditableElement - Setter for contentEditable element
- * @param {Array} blockFieldInfo - Array of field info objects
- * @returns {Array|JSX.Element} - React children from parsed HTML
+ * Wrapper function that matches 6.7.0.2's `h` function
  */
 export function parseJSX(
 	htmlString,
 	setCurrentInlineEditingElementUid = null,
+	onContentEditableChange = null,
 	setCurrentContentEditableElement = null,
-	blockFieldInfo = null
+	blockFieldInfo = null,
+	$ = jQuery
 ) {
+	console.log( '🟣 parseJSX called, React version:', React?.version );
+
 	// Wrap in div to ensure valid HTML structure
 	htmlString = '<div>' + htmlString + '</div>';
 
-	// Handle self-closing InnerBlocks tags (not valid HTML, but used in ACF)
+	// Handle self-closing InnerBlocks tags
 	htmlString = htmlString.replace(
 		/<InnerBlocks([^>]+)?\/>/,
 		'<InnerBlocks$1></InnerBlocks>'
@@ -414,9 +386,10 @@ export function parseJSX(
 
 	// Parse with jQuery, convert to React, and extract children from wrapper div
 	const parsedElement = parseNodeToJSX(
-		jQuery( htmlString )[ 0 ],
+		$( htmlString )[ 0 ],
 		0,
 		setCurrentInlineEditingElementUid,
+		onContentEditableChange,
 		setCurrentContentEditableElement,
 		blockFieldInfo
 	);

--- a/assets/src/js/pro/blocks-v3/components/popover-wrapper.js
+++ b/assets/src/js/pro/blocks-v3/components/popover-wrapper.js
@@ -50,9 +50,7 @@ export const PopoverWrapper = ( {
 		 */
 		const handleEscapeKey = ( event ) => {
 			if ( event.key === 'Escape' ) {
-				event.preventDefault();
-				event.stopPropagation();
-				onClose?.();
+				onClose?.( event );
 			}
 		};
 
@@ -65,7 +63,7 @@ export const PopoverWrapper = ( {
 				'.' + className.split( ' ' ).join( '.' )
 			);
 			if ( ! popoverElement ) {
-				onClose?.();
+				onClose?.( event );
 			}
 		};
 
@@ -114,6 +112,15 @@ export const PopoverWrapper = ( {
 			placement={ placement }
 			animate={ animate }
 		>
+			{ hidePrimaryBlockToolbar && (
+				<style>
+					{ `
+					.components-popover.block-editor-block-popover.block-editor-block-list__block-popover{
+						display: none!important;
+					}
+				` }
+				</style>
+			) }
 			{ children }
 		</Popover>
 	);

--- a/assets/src/js/pro/blocks-v3/components/popover-wrapper.js
+++ b/assets/src/js/pro/blocks-v3/components/popover-wrapper.js
@@ -1,0 +1,120 @@
+/**
+ * PopoverWrapper Component
+ * Custom Popover wrapper that handles inline editing toolbar behavior
+ * - Escape key to close
+ * - Click outside to close
+ * - Focus management
+ * - Hiding primary block toolbar when active
+ */
+
+import { useEffect } from '@wordpress/element';
+import { Popover } from '@wordpress/components';
+
+/**
+ * PopoverWrapper component
+ * Wraps the WordPress Popover component with custom event handlers
+ *
+ * @param {Object} props - Component props
+ * @param {React.ReactNode} props.children - Child elements to render inside popover
+ * @param {string} props.className - CSS class for the popover
+ * @param {Element|null} props.anchor - Anchor element for positioning
+ * @param {string} props.placement - Placement relative to anchor (e.g., 'top-start')
+ * @param {Function} props.onClose - Callback when popover should close
+ * @param {boolean|string} props.focusOnMount - Whether to focus on mount
+ * @param {string} props.variant - Popover variant (e.g., 'unstyled')
+ * @param {boolean} props.animate - Whether to animate popover
+ * @param {Document|HTMLIFrameElement} props.gutenbergIframeOrDocument - Document or iframe reference
+ * @param {boolean} props.hidePrimaryBlockToolbar - Whether to hide the primary block toolbar
+ * @returns {JSX.Element} - Wrapped Popover component
+ */
+export const PopoverWrapper = ( {
+	children,
+	className,
+	anchor,
+	placement,
+	onClose,
+	focusOnMount,
+	variant,
+	animate = false,
+	gutenbergIframeOrDocument,
+	hidePrimaryBlockToolbar = false,
+} ) => {
+	useEffect( () => {
+		// Get the appropriate document (iframe or regular document)
+		const doc = gutenbergIframeOrDocument?.contentDocument
+			? gutenbergIframeOrDocument.contentDocument
+			: gutenbergIframeOrDocument || document;
+
+		/**
+		 * Handle escape key to close popover
+		 */
+		const handleEscapeKey = ( event ) => {
+			if ( event.key === 'Escape' ) {
+				event.preventDefault();
+				event.stopPropagation();
+				onClose?.();
+			}
+		};
+
+		/**
+		 * Handle click outside popover to close it
+		 */
+		const handleClickOutside = ( event ) => {
+			// Check if click is outside the popover
+			const popoverElement = event.target.closest(
+				'.' + className.split( ' ' ).join( '.' )
+			);
+			if ( ! popoverElement ) {
+				onClose?.();
+			}
+		};
+
+		// Add event listeners
+		doc.addEventListener( 'keydown', handleEscapeKey, true );
+		doc.addEventListener( 'mousedown', handleClickOutside, true );
+
+		// Hide primary block toolbar if requested
+		if ( hidePrimaryBlockToolbar ) {
+			const toolbar = doc.querySelector(
+				'.block-editor-block-list__block.is-selected > .block-editor-block-contextual-toolbar'
+			);
+			if ( toolbar ) {
+				toolbar.style.display = 'none';
+			}
+		}
+
+		// Cleanup
+		return () => {
+			doc.removeEventListener( 'keydown', handleEscapeKey, true );
+			doc.removeEventListener( 'mousedown', handleClickOutside, true );
+
+			// Restore primary block toolbar
+			if ( hidePrimaryBlockToolbar ) {
+				const toolbar = doc.querySelector(
+					'.block-editor-block-list__block.is-selected > .block-editor-block-contextual-toolbar'
+				);
+				if ( toolbar ) {
+					toolbar.style.display = '';
+				}
+			}
+		};
+	}, [
+		gutenbergIframeOrDocument,
+		onClose,
+		className,
+		hidePrimaryBlockToolbar,
+	] );
+
+	return (
+		<Popover
+			focusOnMount={ focusOnMount }
+			variant={ variant }
+			anchor={ anchor }
+			className={ className }
+			placement={ placement }
+			animate={ animate }
+		>
+			{ children }
+		</Popover>
+	);
+};

--- a/assets/src/js/pro/blocks-v3/utils/post-locking.js
+++ b/assets/src/js/pro/blocks-v3/utils/post-locking.js
@@ -30,6 +30,20 @@ export const unlockPostSaving = ( clientId ) => {
 };
 
 /**
+ * Checks if post saving is currently locked for a specific block
+ *
+ * @param {string} clientId - The block's client ID
+ * @returns {boolean} - True if post saving is locked for this block
+ */
+export const isPostSavingLocked = ( clientId ) => {
+	const dispatch = wp.data.dispatch( 'core/editor' );
+	if ( ! dispatch ) {
+		return false;
+	}
+	return wp.data.select( 'core/editor' ).isPostSavingLocked( `acf/block/${ clientId }` );
+};
+
+/**
  * Locks post saving with a custom lock name
  * Used for global operations that aren't tied to a specific block
  *

--- a/assets/src/sass/acf-global.scss
+++ b/assets/src/sass/acf-global.scss
@@ -808,11 +808,14 @@ a.acf-icon.dark.-minus:hover, a.acf-icon.dark.-cancel:hover {
   background: #b4b9be;
   color: #fff !important;
 }
-.acf-icon.grey:hover {
+.acf-icon.grey:hover, .acf-icon.grey:focus {
   background: #00a0d2;
   color: #fff;
 }
-.acf-icon.grey.-minus:hover, .acf-icon.grey.-cancel:hover {
+.acf-icon.grey.-minus:hover,
+.acf-icon.grey.-minus:focus,
+.acf-icon.grey.-cancel:hover,
+.acf-icon.grey.-cancel:focus {
   background: #32373c;
 }
 

--- a/assets/src/sass/acf-input.scss
+++ b/assets/src/sass/acf-input.scss
@@ -2394,6 +2394,10 @@ html[dir=rtl] .acf-range-wrap .acf-prepend {
 .acf-accordion .acf-accordion-title:hover {
   background: #f3f4f5;
 }
+.acf-accordion .acf-accordion-title:focus-visible {
+    box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+    outline-offset: -2px;
+}
 .acf-accordion .acf-accordion-title label {
   margin: 0;
   padding: 0;

--- a/assets/src/sass/pro/_blocks.scss
+++ b/assets/src/sass/pro/_blocks.scss
@@ -234,6 +234,34 @@
 	margin: 16px -16px -16px;
 }
 
+.acf-block-form-modal .components-modal__content {
+    padding: 4px 8px 8px !important;
+}
+
+.acf-block-form-modal .components-modal__content .acf-block-panel .acf-block-fields {
+    border: none !important;
+}
+
+.acf-block-form-modal .components-modal__content .acf-fields>.acf-field {
+    border: none !important;
+}
+
+.acf-block-form-modal .components-modal__header {
+    padding: 24px;
+    border-bottom: #ddd solid 1px !important;
+    max-height: 64px !important;
+}
+
+.acf-block-form-modal .components-modal__header h1 {
+    font-weight: 500;
+    font-size: 15px !important;
+}
+
+html[dir=rtl] .acf-block-form-modal .components-modal__header .components-button {
+    left: 0;
+    right: auto;
+}
+
 
 @media(min-width: 600px)and (min-width: 782px) {
     .acf-block-form-modal {
@@ -247,11 +275,6 @@
 	html[dir=rtl] .acf-block-form-modal {
         right: auto;
         left: 0
-    }
-
-    html[dir=rtl] .acf-block-form-modal .components-modal__header .components-button {
-        left: 0;
-        right: auto
     }
 
     @keyframes components-modal__appear-animation {
@@ -343,6 +366,10 @@
 .acf-inline-fields-popover-inner>.acf-block-panel>.acf-block-fields>.acf-field {
     display: none;
     border-top-style: none !important;
+}
+
+.acf-inline-fields-popover-inner .acf-tab-wrap {
+    display: none;
 }
 
 .acf-inline-fields-popover-inner .acf-block-fields>.acf-error-message {

--- a/assets/src/sass/pro/_blocks.scss
+++ b/assets/src/sass/pro/_blocks.scss
@@ -323,3 +323,47 @@
     width: 100%;
     justify-content: center
 }
+
+.acf-blocks-toolbar-icon {
+    display: flex;
+    align-items: center;
+    gap: .3rem;
+    padding-right: .6rem;
+}
+
+.acf-blocks-toolbar-icon i {
+    display: flex;
+}
+
+.acf-inline-fields-popover {
+    z-index: 59899;
+    min-width: 300px;
+}
+
+.acf-inline-fields-popover-inner>.acf-block-panel>.acf-block-fields>.acf-field {
+    display: none;
+    border-top-style: none !important;
+}
+
+.acf-inline-fields-popover-inner .acf-block-fields>.acf-error-message {
+    display: none;
+}
+
+.acf-inline-editing-toolbar .acf-inline-fields-popover-inner .acf-tab-group {
+    display: flex;
+    white-space: nowrap;
+}
+
+.block-editor-block-toolbar .field-type-icon {
+    top: 0;
+    background-color: initial;
+    border: 0;
+}
+
+.block-editor-block-toolbar .field-type-icon:before {
+    background-color: #000;
+}
+
+.block-editor-block-toolbar .is-pressed .field-type-icon:before {
+    background-color: #fff;
+}

--- a/assets/src/sass/pro/acf-styles-in-iframe-for-blocks.min.scss
+++ b/assets/src/sass/pro/acf-styles-in-iframe-for-blocks.min.scss
@@ -1,0 +1,14 @@
+[data-acf-inline-contenteditable="1"][contenteditable=true]:empty::before {
+    content: attr(data-acf-placeholder);
+    opacity: .62;
+}
+
+[data-acf-inline-contenteditable="1"][contenteditable=true]:empty {
+    border: 1px dashed rgba(255, 0, 0, 0);
+}
+
+[data-acf-inline-fields-uid]:hover,
+[data-acf-inline-contenteditable]:hover {
+    outline: 2px solid var(--wp-admin-theme-color);
+    outline-offset: 2px;
+}

--- a/assets/src/sass/pro/acf-styles-in-iframe-for-blocks.scss
+++ b/assets/src/sass/pro/acf-styles-in-iframe-for-blocks.scss
@@ -12,3 +12,7 @@
     outline: 2px solid var(--wp-admin-theme-color);
     outline-offset: 2px;
 }
+
+.acf-block-has-validation-error {
+    border: 2px solid #d94f4f;
+}

--- a/includes/api/api-helpers.php
+++ b/includes/api/api-helpers.php
@@ -1288,8 +1288,19 @@ function acf_get_grouped_posts( $args ) {
 
 	// find array of post_type
 	$post_types          = acf_get_array( $args['post_type'] );
-	$post_types_labels   = acf_get_pretty_post_types( $post_types );
-	$is_single_post_type = ( count( $post_types ) == 1 );
+	$is_single_post_type = ( count( $post_types ) === 1 );
+
+	// WordPress 6.8+ sorts post_type arrays for cache key generation
+	// We need to use the same sorted order when processing results
+	if (
+		! $is_single_post_type &&
+		-1 !== $args['posts_per_page'] &&
+		version_compare( get_bloginfo( 'version' ), '6.8', '>=' )
+	) {
+		sort( $post_types );
+	}
+
+	$post_types_labels = acf_get_pretty_post_types( $post_types );
 
 	// attachment doesn't work if it is the only item in an array
 	if ( $is_single_post_type ) {

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -8,6 +8,9 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
+require_once 'blocks-auto-inline-editing.php';
+use function SCF\Blocks\AutoInlineEditing\apply_inline_editing_attributes_to_render_template;
+
 // Register store.
 acf_register_store( 'block-types' );
 acf_register_store( 'block-cache' );
@@ -124,6 +127,7 @@ function acf_handle_json_block_registration( $settings, $metadata ) {
 		'validateOnLoad'      => 'validate_on_load',
 		'usePostMeta'         => 'use_post_meta',
 		'hideFieldsInSidebar' => 'hide_fields_in_sidebar',
+		'autoInlineEditing'   => 'auto_inline_editing',
 	);
 	$textdomain        = ! empty( $metadata['textdomain'] ) ? $metadata['textdomain'] : 'secure-custom-fields';
 	$i18n_schema       = get_block_metadata_i18n_schema();
@@ -675,8 +679,11 @@ function acf_rendered_block( $attributes, $content = '', $is_preview = false, $p
 			 * If we're in preloaded preview, we need to get the validation state for a preview too.
 			 * Because the block render resets meta once it's finished to not pollute $post_id, we need to redo that process here.
 			 */
-			$block = acf_prepare_block( $attributes );
-			$block = acf_add_block_meta_values( $block, $post_id );
+			$block                = acf_prepare_block( $attributes );
+			$block                = acf_add_block_meta_values( $block, $post_id );
+			$block_toolbar_fields = acf_process_block_toolbar_fields( apply_filters( 'acf/blocks/top_toolbar_fields', array(), $block, $content, $is_preview, $post_id, $wp_block, $context ) );
+			$fields               = acf_get_block_fields( $block );
+
 			acf_setup_meta( $block['data'], $block['id'], true );
 			if ( ! empty( $block['validate'] ) ) {
 				$validation = acf_get_block_validation_state( $block, false, false, true );
@@ -715,6 +722,15 @@ function acf_rendered_block( $attributes, $content = '', $is_preview = false, $p
 		// If we're in the preview, also store the validation status in the block cache.
 		$block_cache['validation'] = $validation;
 	}
+
+	if ( isset( $block_toolbar_fields ) ) {
+		$block_cache['blockToolbarFields'] = $block_toolbar_fields;
+	}
+
+	if ( isset( $fields ) ) {
+		$block_cache['fields'] = $fields;
+	}
+
 
 	// Store in cache for preloading if we're in the backend.
 	acf_get_store( 'block-cache' )->set(
@@ -805,7 +821,17 @@ function acf_block_render_template( $block, $content, $is_preview, $post_id, $wp
 
 	// Include template.
 	if ( file_exists( $path ) ) {
-		include $path;
+		if ( $is_preview && ! empty( $block['auto_inline_editing'] ) ) {
+			$result = apply_inline_editing_attributes_to_render_template( $path, $block, $is_preview );
+
+			// In order to allow block render templates to support any html tags,
+			// we must assume that escaping has already been properly handled by the block render template here.
+			// Typically we'd use something like wp_kses here, but that would limit the HTML tags that can be used.
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $result;
+		} else {
+			include $path;
+		}
 	} elseif ( $is_preview ) {
 		echo acf_esc_html( apply_filters( 'acf/blocks/template_not_found_message', '<p>' . __( 'The render template for this ACF Block was not found', 'secure-custom-fields' ) . '</p>' ) );
 	}
@@ -912,6 +938,22 @@ function acf_enqueue_block_assets() {
 		);
 	}
 }
+
+
+/**
+ * Enqueues scripts and styles to load inside the block editor iframe.
+ * This allows us to do things like style contenteditable, and other inline editing elements.
+ *
+ * @since ACF 6.7
+ */
+function acf_enqueue_in_iframe_styles() {
+	if ( is_admin() ) {
+		$min      = defined( 'ACF_DEVELOPMENT_MODE' ) && ACF_DEVELOPMENT_MODE ? '' : '.min';
+		$css_path = acf_get_url( "assets/build/css/pro/acf-styles-in-iframe-for-blocks{$min}.css" );
+		wp_enqueue_style( 'acf-inline-editing-styles', $css_path, ACF_VERSION, true );
+	}
+}
+add_action( 'enqueue_block_assets', 'acf_enqueue_in_iframe_styles' );
 
 /**
  * Enqueues scripts and styles for a specific block type.
@@ -1068,6 +1110,8 @@ function acf_ajax_fetch_block() {
 		acf_prefix_fields( $fields, "acf-{$block['id']}" );
 
 		if ( $fields ) {
+			$response['fields'] = $fields;
+
 			// Start Capture.
 			ob_start();
 
@@ -1093,6 +1137,8 @@ function acf_ajax_fetch_block() {
 		// Render and store HTML.
 		$response['preview'] = acf_rendered_block( $block, $content, $is_preview, $post_id, null, $context, true );
 	}
+
+	$response['blockToolbarFields'] = acf_process_block_toolbar_fields( apply_filters( 'acf/blocks/top_toolbar_fields', array(), $block, $content, $is_preview, $post_id, null, $context ) );
 
 	// Send response.
 	wp_send_json_success( $response );
@@ -1588,3 +1634,205 @@ function acf_get_block_meta_values_to_save( $content = '' ) {
 
 	return $meta_values;
 }
+
+
+/**
+ * Helper function that returns the HTML attributes required for toolbar inline editing as a string, escaped and ready for output.
+ *
+ * @param array $fields Array {
+ * Required. A list of the fields, each of which which will be displayed in the popup toolbar.
+ *
+ * Each field can be passed as:
+ *
+ * - A string (e.g. `'my_field_name'`)
+ * - An associative array with specific keys:
+ * @type string $field_name  The name of the field to display in the toolbar.
+ * @type string $field_icon  An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
+ * @type string $field_label A string to use as the label for the button in the toolbar.
+ * }
+ *
+ * @param array $args   Array {
+ * Optional. An array of additional args which can control how the toolbar is displayed and used.
+ *
+ * @type string $toolbar_icon  Optional. An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
+ * @type string $toolbar_title Optional. A string to be used as the toolbar title. If not passed, the name of the first field will be used.
+ * @type string $uid           Optional. A unique identifier that isn't used by any other inline fields in this block. Pass if you have 2 elements that conflict.
+ * @type string $render        Optional. True if it should return the output, false if it should return an empty string.
+ * }
+ *
+ * @return string A string containing the attributes.
+ */
+function acf_inline_toolbar_editing_attrs( $fields, $args = array() ): string {
+
+	if ( empty( $fields ) ) {
+		return '';
+	}
+
+	$default_args = array(
+		'toolbar_icon'  => null,
+		'toolbar_title' => null,
+		'uid'           => null,
+		'render'        => null,
+	);
+
+	$args = wp_parse_args( $args, $default_args );
+
+	if ( $args['render'] === null ) {
+		$render = acf_get_data( 'acf_doing_block_preview' );
+	}
+
+	if ( ! $render ) {
+		return '';
+	}
+
+	// Get the block id.
+	$meta_instance = acf_get_instance( 'ACF_Local_Meta' );
+	$block_id      = $meta_instance->post_id;
+
+	if ( empty( $block_id ) || ! str_starts_with( $block_id, 'block_' ) ) {
+		return '';
+	}
+
+	// Prefix the generated uid with the blockid.
+	$generated_uid = $block_id;
+
+	$fields_processed = array();
+
+	foreach ( $fields as $field ) {
+		if ( is_array( $field ) ) {
+			$generated_uid     .= $field['field_name'];
+			$fields_processed[] = array(
+				'fieldName'  => $field['field_name'],
+				// Base64 allows us to embed html in an attribute without causing issues with quotes, etc.
+				'fieldIcon'  => base64_encode( $field['field_icon'] ), // phpcs:ignore
+				'fieldLabel' => $field['field_label'],
+			);
+		} else {
+			$fields_processed[] = $field;
+			$generated_uid     .= $field;
+		}
+	}
+
+	if ( empty( $args['uid'] ) ) {
+		$args['uid'] = $generated_uid;
+	}
+
+	if ( ! empty( $args['toolbar_icon'] ) ) {
+		$args['toolbar_icon'] = 'data-acf-toolbar-icon="' . esc_attr( $args['toolbar_icon'] ) . '" ';
+	}
+
+	if ( ! empty( $args['toolbar_title'] ) ) {
+		$args['toolbar_title'] = 'data-acf-toolbar-title="' . esc_attr( $args['toolbar_title'] ) . '" ';
+	}
+
+	return 'data-acf-inline-fields-uid="' . esc_attr( $args['uid'] ) . '" data-acf-inline-fields="' . esc_attr( wp_json_encode( $fields_processed ) ) . '" ' . $args['toolbar_icon'] . $args['toolbar_title'] . 'role="button" tabindex="0"';
+}
+
+/**
+ * Helper function that returns the HTML attributes required for inline text editing as a string, escaped and ready for output.
+ *
+ * @param string $field_name A string which is the name of the field to update when the user types into the HTML element.
+ *
+ * @param array  $args       Array {
+ * Optional. An array of additional args which can control how the popover identifier is displayed.
+ *
+ * @type string $toolbar_icon  Optional. An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
+ * @type string $toolbar_title Optional. A string to be used as the toolbar title. If not passed, the name of the first field will be used.
+ * @type string $placeholder   Optional. Optional. A string which will be used as the placeholder in the typable text area.
+ * @type string $render        Optional. True if it should return the output, false if it should return an empty string.
+ * }
+ *
+ * @return string A string containing the attributes.
+ */
+function acf_inline_text_editing_attrs( $field_name, $args = array() ): string {
+
+	if ( empty( $field_name ) ) {
+		return '';
+	}
+
+	$default_args = array(
+		'toolbar_icon'  => null,
+		'toolbar_title' => null,
+		'placeholder'   => null,
+		'render'        => null,
+	);
+
+	$args = wp_parse_args( $args, $default_args );
+
+	if ( $args['render'] === null ) {
+		$args['render'] = acf_get_data( 'acf_doing_block_preview' );
+	}
+
+	if ( ! $args['render'] ) {
+		return '';
+	}
+
+	if ( ! empty( $args['toolbar_icon'] ) ) {
+		$args['toolbar_icon'] = 'data-acf-toolbar-icon="' . esc_attr( $args['toolbar_icon'] ) . '" ';
+	}
+
+	if ( ! empty( $args['toolbar_title'] ) ) {
+		$args['toolbar_title'] = 'data-acf-toolbar-title="' . esc_attr( $args['toolbar_title'] ) . '" ';
+	}
+
+	if ( ! $args['placeholder'] ) {
+		$args['placeholder'] = __( 'Type to edit...', 'secure-custom-fields' );
+	}
+
+	return 'data-acf-inline-contenteditable="1" data-acf-inline-contenteditable-field-slug="' . esc_attr( $field_name ) . '" data-acf-placeholder="' . esc_attr( $args['placeholder'] ) . '" ' . $args['toolbar_icon'] . $args['toolbar_title'];
+}
+
+/**
+ * This function prepares a fields array for being localized and used on the frontend as block toolbar fields.
+ *
+ * @param array $fields Array {
+ * Required. A list of the fields, each of which which will be displayed in the popup toolbar.
+ *
+ * Each field can be passed as:
+ *
+ * - A string (e.g. `'my_field_name'`)
+ * - An associative array with specific keys:
+ * @type string $field_name  The name of the field to display in the toolbar.
+ * @type string $field_icon  An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
+ * @type string $field_label A string to use as the label for the button in the toolbar.
+ * }
+ *
+ * @return array The array of fields, prepared for JS localization.
+ */
+function acf_process_block_toolbar_fields( $fields ) {
+	$fields_processed = array();
+
+	foreach ( $fields as $index => $field ) {
+		if ( is_array( $field ) ) {
+			$fields_processed[] = array(
+				'fieldName'  => ! empty( $field['field_name'] ) ? $field['field_name'] : $index,
+				// Base64 allows us to embed html in an attribute without causing issues with quotes, etc.
+				'fieldIcon'  => ! empty( $field['field_icon'] ) ? base64_encode( $field['field_icon'] ) : null, // phpcs:ignore
+				'fieldLabel' => ! empty( $field['field_label'] ) ? $field['field_label'] : null,
+			);
+		} else {
+			$fields_processed[] = $field;
+		}
+	}
+
+	return $fields_processed;
+}
+
+/**
+ * Helper function for block render templates to check if an acf field has a value.
+ * This is relevant when autoInlineEditing is enabled for a block, because empty fields
+ * will have acf_auto_inline_editing_field_name_ + field_name as their value if they are empty.
+ *
+ * @param  string $field_name True if the field is empty, false if it has a value.
+ * @return boolean True if the field is empty, false if it has a value.
+ */
+function acf_inline_editing_field_is_empty( $field_name ) {
+	$field_value = get_field( $field_name );
+
+	if ( empty( $field_value ) || $field_value === 'acf_auto_inline_editing_field_name_' . $field_name ) {
+		return true;
+	}
+
+	return false;
+}
+

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -1304,7 +1304,7 @@ function acf_get_block_id( $attributes, $context = array(), $force = false ) {
  * @return string A prefixed block ID.
  */
 function acf_ensure_block_id_prefix( $block_id ) {
-	if ( substr( $block_id, 0, 6 ) === 'block_' ) {
+	if ( 'block_' === substr( $block_id, 0, 6 ) ) {
 		return $block_id;
 	}
 	return 'block_' . $block_id;
@@ -1639,27 +1639,24 @@ function acf_get_block_meta_values_to_save( $content = '' ) {
 /**
  * Helper function that returns the HTML attributes required for toolbar inline editing as a string, escaped and ready for output.
  *
- * @param array $fields Array {
- * Required. A list of the fields, each of which which will be displayed in the popup toolbar.
- *
- * Each field can be passed as:
+ * Required. A list of the fields, each of which will be displayed in the popup toolbar.
+ * Each field can be passed as one of the following.
  *
  * - A string (e.g. `'my_field_name'`)
  * - An associative array with specific keys:
+ *
  * @type string  $field_name  The name of the field to display in the toolbar.
  * @type string  $field_icon  An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
  * @type string  $field_label A string to use as the label for the button in the toolbar.
  * @type boolean $use_expanded_editor Default is false, which opens the field in the popover. Set to true to open in the expanded editor.
  * @type string  $popover_min_width Enter the CSS width value to use for the popover. Default is "300px".
- * }
  *
- * @param array $args   Array {
- * Optional. An array of additional args which can control how the toolbar is displayed and used.
+ * @param array $fields List of fields.
+ * @param array $args   Additional options controlling toolbar display and behavior.
  *
  * @type string $toolbar_icon  Optional. An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
  * @type string $toolbar_title Optional. A string to be used as the toolbar title. If not passed, the name of the first field will be used.
  * @type string $uid           Optional. A unique identifier that isn't used by any other inline fields in this block. Pass if you have 2 elements that conflict.
- * }
  *
  * @return string A string containing the attributes.
  */
@@ -1835,17 +1832,17 @@ function acf_inline_text_editing_attrs( $field_name, $args = array() ): string {
 /**
  * This function prepares a fields array for being localized and used on the frontend as block toolbar fields.
  *
- * @param array $fields Array {
- * Required. A list of the fields, each of which which will be displayed in the popup toolbar.
- *
- * Each field can be passed as:
+ * Required. A list of the fields, each of which will be displayed in the popup toolbar.
+ * Each field can be passed as one of the following.
  *
  * - A string (e.g. `'my_field_name'`)
  * - An associative array with specific keys:
+ *
  * @type string $field_name  The name of the field to display in the toolbar.
  * @type string $field_icon  An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
  * @type string $field_label A string to use as the label for the button in the toolbar.
- * }
+ *
+ * @param array $fields List of fields.
  *
  * @return array The array of fields, prepared for JS localization.
  */
@@ -1873,13 +1870,13 @@ function acf_process_block_toolbar_fields( $fields ) {
  * This is relevant when autoInlineEditing is enabled for a block, because empty fields
  * will have acf_auto_inline_editing_field_name_ + field_name as their value if they are empty.
  *
- * @param  string $field_name True if the field is empty, false if it has a value.
+ * @param string $field_name Field name.
  * @return boolean True if the field is empty, false if it has a value.
  */
 function acf_inline_editing_field_is_empty( $field_name ) {
 	$field_value = get_field( $field_name );
 
-	if ( empty( $field_value ) || $field_value === 'acf_auto_inline_editing_field_name_' . $field_name ) {
+	if ( empty( $field_value ) || 'acf_auto_inline_editing_field_name_' . $field_name === $field_value ) {
 		return true;
 	}
 

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -951,7 +951,7 @@ function acf_enqueue_in_iframe_styles() {
 	if ( is_admin() ) {
 		$min      = defined( 'ACF_DEVELOPMENT_MODE' ) && ACF_DEVELOPMENT_MODE ? '' : '.min';
 		$css_path = acf_get_url( "assets/build/css/pro/acf-styles-in-iframe-for-blocks{$min}.css" );
-		wp_enqueue_style( 'acf-inline-editing-styles', $css_path, ACF_VERSION, true );
+		wp_enqueue_style( 'acf-inline-editing-styles', $css_path, array(), ACF_VERSION, 'all' );
 	}
 }
 add_action( 'enqueue_block_assets', 'acf_enqueue_in_iframe_styles' );

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -1804,11 +1804,11 @@ function acf_inline_text_editing_attrs( $field_name, $args = array() ): string {
 		'toolbar_icon'  => null,
 		'toolbar_title' => null,
 		'placeholder'   => null,
-		'render'        => null,
 	);
 
-	$args           = wp_parse_args( $args, $default_args );
-	$args['render'] = acf_get_data( 'acf_doing_block_preview' );
+	$args = wp_parse_args( $args, $default_args );
+
+	$render = acf_get_data( 'acf_doing_block_preview' );
 
 	if ( ! $render ) {
 		return '';

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -8,7 +8,7 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
-require_once 'blocks-auto-inline-editing.php';
+require_once dirname( __DIR__ ) . '/pro/blocks-auto-inline-editing.php';
 use function SCF\Blocks\AutoInlineEditing\apply_inline_editing_attributes_to_render_template;
 
 // Register store.
@@ -731,7 +731,6 @@ function acf_rendered_block( $attributes, $content = '', $is_preview = false, $p
 		$block_cache['fields'] = $fields;
 	}
 
-
 	// Store in cache for preloading if we're in the backend.
 	acf_get_store( 'block-cache' )->set(
 		$attributes['id'],
@@ -894,6 +893,7 @@ function acf_enqueue_block_assets() {
 			'Open Expanded Editor'      => __( 'Open Expanded Editor', 'secure-custom-fields' ),
 			'Error previewing block v3' => __( 'The preview for this block couldn’t be loaded. Review its content or settings for issues.', 'secure-custom-fields' ),
 			'ACF Block'                 => __( 'ACF Block', 'secure-custom-fields' ),
+			'Done'                      => __( 'Done', 'secure-custom-fields' ),
 			/* translators: %s: Block type title */
 			'%s settings'               => __( '%s settings', 'secure-custom-fields' ),
 		)
@@ -931,6 +931,7 @@ function acf_enqueue_block_assets() {
 	// Retrieve any cached block HTML and include this in the localized data.
 	if ( acf_get_setting( 'preload_blocks' ) ) {
 		$preloaded_blocks = acf_get_store( 'block-cache' )->get_data();
+
 		acf_localize_data(
 			array(
 				'preloadedBlocks' => $preloaded_blocks,
@@ -1136,10 +1137,9 @@ function acf_ajax_fetch_block() {
 
 		// Render and store HTML.
 		$response['preview'] = acf_rendered_block( $block, $content, $is_preview, $post_id, null, $context, true );
+
+		$response['blockToolbarFields'] = acf_process_block_toolbar_fields( apply_filters( 'acf/blocks/top_toolbar_fields', array(), $block, $content, $is_preview, $post_id, null, $context ) );
 	}
-
-	$response['blockToolbarFields'] = acf_process_block_toolbar_fields( apply_filters( 'acf/blocks/top_toolbar_fields', array(), $block, $content, $is_preview, $post_id, null, $context ) );
-
 	// Send response.
 	wp_send_json_success( $response );
 }
@@ -1646,9 +1646,11 @@ function acf_get_block_meta_values_to_save( $content = '' ) {
  *
  * - A string (e.g. `'my_field_name'`)
  * - An associative array with specific keys:
- * @type string $field_name  The name of the field to display in the toolbar.
- * @type string $field_icon  An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
- * @type string $field_label A string to use as the label for the button in the toolbar.
+ * @type string  $field_name  The name of the field to display in the toolbar.
+ * @type string  $field_icon  An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
+ * @type string  $field_label A string to use as the label for the button in the toolbar.
+ * @type boolean $use_expanded_editor Default is false, which opens the field in the popover. Set to true to open in the expanded editor.
+ * @type string  $popover_min_width Enter the CSS width value to use for the popover. Default is "300px".
  * }
  *
  * @param array $args   Array {
@@ -1657,7 +1659,6 @@ function acf_get_block_meta_values_to_save( $content = '' ) {
  * @type string $toolbar_icon  Optional. An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
  * @type string $toolbar_title Optional. A string to be used as the toolbar title. If not passed, the name of the first field will be used.
  * @type string $uid           Optional. A unique identifier that isn't used by any other inline fields in this block. Pass if you have 2 elements that conflict.
- * @type string $render        Optional. True if it should return the output, false if it should return an empty string.
  * }
  *
  * @return string A string containing the attributes.
@@ -1672,14 +1673,11 @@ function acf_inline_toolbar_editing_attrs( $fields, $args = array() ): string {
 		'toolbar_icon'  => null,
 		'toolbar_title' => null,
 		'uid'           => null,
-		'render'        => null,
 	);
 
 	$args = wp_parse_args( $args, $default_args );
 
-	if ( $args['render'] === null ) {
-		$render = acf_get_data( 'acf_doing_block_preview' );
-	}
+	$render = acf_get_data( 'acf_doing_block_preview' );
 
 	if ( ! $render ) {
 		return '';
@@ -1698,18 +1696,74 @@ function acf_inline_toolbar_editing_attrs( $fields, $args = array() ): string {
 
 	$fields_processed = array();
 
+	/**
+	 * Filters the field types that should open in the expanded editor by default.
+	 *
+	 * @since ACF 6.7.0
+	 *
+	 * @param array $field_types An array of field type names.
+	 * @return array
+	 */
+	$fields_to_open_in_expanded_editor = apply_filters(
+		'acf/blocks/fields_to_open_in_expanded_editor',
+		array(
+			'repeater',
+			'flexible_content',
+		)
+	);
+
+	/**
+	 * Filters the field types that require a wider popover for inline editing.
+	 *
+	 * @since ACF 6.7.0
+	 *
+	 * @param array $field_types An array of field type names.
+	 * @return array
+	 */
+	$fields_needing_wide_popover = apply_filters(
+		'acf/blocks/fields_needing_wide_popover',
+		array(
+			'gallery',
+			'relationship',
+			'wysiwyg',
+			'google_map',
+		)
+	);
+
+	$popover_min_width_normal = '300px';
+	$popover_min_width_wide   = '600px';
+
 	foreach ( $fields as $field ) {
 		if ( is_array( $field ) ) {
-			$generated_uid     .= $field['field_name'];
-			$fields_processed[] = array(
-				'fieldName'  => $field['field_name'],
-				// Base64 allows us to embed html in an attribute without causing issues with quotes, etc.
-				'fieldIcon'  => base64_encode( $field['field_icon'] ), // phpcs:ignore
-				'fieldLabel' => $field['field_label'],
-			);
+			$full_field_data = acf_get_field( $field['field_name'] );
+			if ( $full_field_data ) {
+				$use_expanded_editor_default = in_array( $full_field_data['type'], $fields_to_open_in_expanded_editor, true ) ? true : false;
+				$popover_min_width_default   = in_array( $full_field_data['type'], $fields_needing_wide_popover, true ) ? $popover_min_width_wide : $popover_min_width_normal;
+
+				$generated_uid     .= $field['field_name'];
+				$fields_processed[] = array(
+					'fieldName'         => $field['field_name'],
+					// Base64 allows us to embed html in an attribute without causing issues with quotes, etc.
+					'fieldIcon'         => ! empty( $field['field_icon'] ) ? base64_encode( $field['field_icon'] ) : null, // phpcs:ignore
+					'fieldLabel'        => ! empty( $field['field_label'] ) ? $field['field_label'] : $full_field_data['label'],
+					'useExpandedEditor' => ! empty( $field['use_expanded_editor'] ) ? $field['use_expanded_editor'] : $use_expanded_editor_default,
+					'popoverMinWidth'   => ! empty( $field['popover_min_width'] ) ? $field['popover_min_width'] : $popover_min_width_default,
+				);
+			}
 		} else {
-			$fields_processed[] = $field;
-			$generated_uid     .= $field;
+			$full_field_data = acf_get_field( $field );
+
+			if ( $full_field_data ) {
+				$fields_processed[] = array(
+					'fieldName'         => $field,
+					'fieldIcon'         => null,
+					'fieldLabel'        => $full_field_data['label'],
+					'useExpandedEditor' => in_array( $full_field_data['type'], $fields_to_open_in_expanded_editor, true ) ? true : false,
+					'popoverMinWidth'   => in_array( $full_field_data['type'], $fields_needing_wide_popover, true ) ? $popover_min_width_wide : $popover_min_width_normal,
+				);
+			}
+
+			$generated_uid .= $field;
 		}
 	}
 
@@ -1739,7 +1793,6 @@ function acf_inline_toolbar_editing_attrs( $fields, $args = array() ): string {
  * @type string $toolbar_icon  Optional. An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
  * @type string $toolbar_title Optional. A string to be used as the toolbar title. If not passed, the name of the first field will be used.
  * @type string $placeholder   Optional. Optional. A string which will be used as the placeholder in the typable text area.
- * @type string $render        Optional. True if it should return the output, false if it should return an empty string.
  * }
  *
  * @return string A string containing the attributes.
@@ -1757,13 +1810,10 @@ function acf_inline_text_editing_attrs( $field_name, $args = array() ): string {
 		'render'        => null,
 	);
 
-	$args = wp_parse_args( $args, $default_args );
+	$args           = wp_parse_args( $args, $default_args );
+	$args['render'] = acf_get_data( 'acf_doing_block_preview' );
 
-	if ( $args['render'] === null ) {
-		$args['render'] = acf_get_data( 'acf_doing_block_preview' );
-	}
-
-	if ( ! $args['render'] ) {
+	if ( ! $render ) {
 		return '';
 	}
 
@@ -1835,4 +1885,3 @@ function acf_inline_editing_field_is_empty( $field_name ) {
 
 	return false;
 }
-

--- a/includes/fields/class-acf-field-google-map.php
+++ b/includes/fields/class-acf-field-google-map.php
@@ -151,13 +151,14 @@ if ( ! class_exists( 'acf_field_google_map' ) ) :
 
 	<div class="title">
 
+		<input class="search" type="text" placeholder="<?php esc_attr_e( 'Search for address...', 'secure-custom-fields' ); ?>" value="<?php echo esc_attr( $search ); ?>" />
+
 		<div class="acf-actions -hover">
-			<a href="#" data-name="search" class="acf-icon -search grey" title="<?php esc_attr_e( 'Search', 'secure-custom-fields' ); ?>"></a>
-			<a href="#" data-name="clear" class="acf-icon -cancel grey" title="<?php esc_attr_e( 'Clear location', 'secure-custom-fields' ); ?>"></a>
-			<a href="#" data-name="locate" class="acf-icon -location grey" title="<?php esc_attr_e( 'Find current location', 'secure-custom-fields' ); ?>"></a>
+			<button type="button" data-name="search" class="acf-icon -search grey" aria-label="<?php esc_attr_e( 'Search', 'secure-custom-fields' ); ?>"></button>
+			<button type="button" data-name="clear" class="acf-icon -cancel grey" aria-label="<?php esc_attr_e( 'Clear location', 'secure-custom-fields' ); ?>"></button>
+			<button type="button" data-name="locate" class="acf-icon -location grey" aria-label="<?php esc_attr_e( 'Find current location', 'secure-custom-fields' ); ?>"></button>
 		</div>
 
-		<input class="search" type="text" placeholder="<?php esc_attr_e( 'Search for address...', 'secure-custom-fields' ); ?>" value="<?php echo esc_attr( $search ); ?>" />
 		<i class="acf-loading"></i>
 
 	</div>

--- a/pro/blocks-auto-inline-editing.php
+++ b/pro/blocks-auto-inline-editing.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * @package wordpress/secure-custom-fields
+ *
+ */
+
+/**
+ * Applying auto inline editing to SCF blocks.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+namespace SCF\Blocks\AutoInlineEditing;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Returns an array of field type names which support contenteditable (allows typing text) attribute.
+ *
+ * @return array
+ */
+function get_allowed_contenteditable_fields(): array {
+	return array( 'text', 'textarea' );
+}
+
+/**
+ * Returns an array of field type names will be ignored by the automatic application of inline editing attributes.
+ *
+ * @return array
+ */
+function get_non_auto_inline_editing_fields(): array {
+	return array( 'repeater', 'flexible-content' );
+}
+
+/**
+ * This function populates a global variable called acf_fields_used_in_block_render_template, which is an array
+ * where each key is the value entered for the field, and the value is the field data, including the current value.
+ *
+ * @param mixed  $field_value The field_value.
+ * @param string $post_id     The post ID for this value.
+ * @param array  $field       The field array.
+ *
+ * @return mixed
+ */
+function populate_auto_inline_editing_values( $field_value, $post_id, $field ) {
+
+	global $acf_fields_used_in_block_render_template, $acf_blocks_doing_auto_inline_editing;
+
+	if ( ! $acf_blocks_doing_auto_inline_editing || ! empty( $field['parent_repeater'] ) ) {
+		return $field_value;
+	}
+
+	// Add this field and its value to the global variable so we can grab it when rendering later in apply_inline_editing_attributes_to_render_template.
+	if ( ! is_array( $field_value ) ) {
+		if ( empty( $field_value ) ) {
+			$field_value = 'acf_auto_inline_editing_field_name_' . $field['name'];
+		}
+
+		$field['value'] = $field_value;
+
+		// Note: If 2 fields happen to have the exact same value it's most-likely fine, but there are edge cases.
+		// Because in the DOM they get applied top-to-bottom, we also check top-to-bottom when pulling them from this array.
+		//
+		// A small, known edge case exists here if someone calls $a = get_field('a') and $b = get_field('b'), but then renders $b before $a.
+		// If BOTH field $a and field $b have the exact same value AND are rendered in a different order than they were called, you would end up
+		// with a scenario where editing the inline value of $a actually edits the value for $b.
+		// Regardless, it would likely be obvious to the block developer because you would see it,
+		// both in the field value in the block sidebar, and also inline/preview, wherever field a/b are used.
+		$acf_fields_used_in_block_render_template[] = $field;
+	}
+
+	return $field_value;
+}
+add_filter( 'acf/format_value', __NAMESPACE__ . '\populate_auto_inline_editing_values', 10, 3 );
+
+/**
+ * Applies inline editing attributes to dom elements if they contain field values.
+ *
+ * @param string  $path       The path to the render template for this block.
+ * @param array   $block      The block data.
+ * @param boolean $is_preview Whether we are in the block editor or not.
+ * @return string
+ */
+function apply_inline_editing_attributes_to_render_template( $path, $block, $is_preview ): string {
+	global $acf_fields_used_in_block_render_template, $acf_blocks_doing_auto_inline_editing;
+
+	// Don't apply autoInlineEditing if the current PHP doesn't include DOMDocument or DOMXPath.
+	if ( ! class_exists( 'DOMDocument' ) || ! class_exists( 'DOMXPath' ) ) {
+		ob_start();
+		include $path;
+		return ob_get_clean();
+	}
+
+	$allowed_contenteditable_field_types = get_allowed_contenteditable_fields();
+	$non_auto_inline_editing_fields      = get_non_auto_inline_editing_fields();
+
+	$acf_fields_used_in_block_render_template = array();
+
+	$acf_blocks_doing_auto_inline_editing = true;
+
+	ob_start();
+	include $path;
+	$html = '<!DOCTYPE html><html><head><meta charset="UTF-8"></head>' . ob_get_clean();
+
+	$acf_blocks_doing_auto_inline_editing = false;
+
+	// Load the HTML into DOMDocument
+	$dom = new \DOMDocument();
+	libxml_use_internal_errors( true ); // Suppress warnings for invalid HTML
+	$dom->loadHTML( $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+	libxml_clear_errors();
+
+	// Get all elements
+	$xpath    = new \DOMXPath( $dom );
+	$elements = $xpath->query( '//*' );
+
+	// Iterate over elements and modify based on text content
+	foreach ( $elements as $element ) {
+		$field_names_for_popover = array();
+
+		$top_level_text = '';
+
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName
+		if ( empty( $element->childNodes ) ) {
+			continue;
+		}
+
+		// Loop through the child nodes of the current element
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName
+		foreach ( $element->childNodes as $child ) {
+			// Check if the child node is a text node
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName
+			if ( $child->nodeType === XML_TEXT_NODE ) {
+				// phpcs:ignore WordPress.NamingConventions.ValidVariableName
+				$top_level_text .= $child->nodeValue;
+			}
+		}
+
+		$top_level_text = trim( $top_level_text );
+
+		if ( ! empty( $top_level_text ) ) {
+			$acf_field_found = false;
+
+			// Loop through each field used in this render template.
+			foreach ( $acf_fields_used_in_block_render_template as $key => $field_data ) {
+				if ( ! $field_data['name'] ) {
+					continue;
+				}
+
+				// If the value for this field matches the text in the dom, apply the inline editing attributes.
+				if ( $field_data['value'] === $top_level_text ) {
+					$acf_field_found        = true;
+					$field_slug             = $field_data['name'];
+					$field_value            = $field_data['value'];
+					$field_type             = $field_data['type'];
+					$field_placeholder_text = ! empty( $field_data['placeholder'] ) ? $field_data['placeholder'] : __( 'Type to edit...', 'secure-custom-fields' );
+
+					if ( ! in_array( $field_type, $non_auto_inline_editing_fields, true ) ) {
+						if ( in_array( $field_type, $allowed_contenteditable_field_types, true ) ) {
+							// Add the contenteditable things.
+							if ( ! $element->getAttribute( 'data-acf-inline-contenteditable' ) ) {
+								$element->setAttribute( 'role', 'button' );
+								$element->setAttribute( 'data-acf-inline-contenteditable', true );
+
+								$element->setAttribute( 'data-acf-inline-contenteditable-field-slug', str_replace( 'acf_auto_inline_editing_field_name_', '', $field_slug ) );
+								$element->setAttribute( 'data-acf-placeholder', $field_placeholder_text );
+							}
+
+							// phpcs:ignore WordPress.NamingConventions.ValidVariableName
+							if ( $field_value !== 'acf_auto_inline_editing_field_name_' . $field_slug ) {
+								// phpcs:ignore WordPress.NamingConventions.ValidVariableName
+								$element->nodeValue = $field_value;
+							} else {
+								// phpcs:ignore WordPress.NamingConventions.ValidVariableName
+								$element->nodeValue = '';
+							}
+						} else {
+							// Make the field popover instead of contenteditable.
+							$field_names_for_popover[] = str_replace( 'acf_auto_inline_editing_field_name_', '', $field_slug );
+						}
+					}
+
+					// We found a matching field so we can stop looping.
+					break;
+				}
+			}
+
+			if ( ! $acf_field_found ) {
+				foreach ( $acf_fields_used_in_block_render_template as $key => $field_data ) {
+					// Remove the acf_auto_inline_editing_field_name_ placeholder from the text node.
+					if ( strpos( $top_level_text, 'acf_auto_inline_editing_field_name_' . $field_data['name'] ) !== false ) {
+						// phpcs:ignore WordPress.NamingConventions.ValidVariableName
+						$element->nodeValue = str_replace( 'acf_auto_inline_editing_field_name_' . $field_data['name'], '', $top_level_text );
+					}
+				}
+			}
+		}
+
+		// If the value for this field matches the field slug, remove it.
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName
+		if ( str_starts_with( $top_level_text, 'acf_auto_inline_editing_field_name_' ) ) {
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName
+			$element->textContent = '';
+		}
+
+		// Loop over each attribute. If an attribute comes from acf, make it popup when parent is selected.
+		foreach ( $element->attributes as $attribute ) {
+			if ( $attribute->name === 'data-acf-inline-contenteditable-field-slug' ) {
+				continue;
+			}
+			$attribute_value = trim( $attribute->value );
+
+			foreach ( $acf_fields_used_in_block_render_template as $field_data ) {
+				if ( empty( $field_data['name'] ) ) {
+					continue;
+				}
+
+				$field_slug  = $field_data['name'];
+				$field_value = $field_data['value'];
+
+				if ( ! is_array( $field_value ) && $attribute_value === $field_value ) {
+					$field_names_for_popover[] = str_replace( 'acf_auto_inline_editing_field_name_', '', $field_slug );
+				}
+
+				if ( strpos( $attribute_value, 'acf_auto_inline_editing_field_name_' ) !== false ) {
+					$attribute_value = str_replace( 'acf_auto_inline_editing_field_name_' . $field_slug, '', $attribute_value );
+					$element->setAttribute( $attribute->name, $attribute_value );
+				}
+			}
+		}
+
+		$field_names_for_popover = array_unique( $field_names_for_popover );
+
+		// Don't add popover fields to the top level element unless it has text content (as opposed to html/non-text content, which is what most top level elements contain).
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName
+		$is_top_level = isset( $element->parentNode->tagName ) && $element->parentNode->tagName === 'body';
+
+		if ( ! $is_top_level && ! empty( $field_names_for_popover ) ) {
+			$preexisting_inline_fields_uid = $element->getAttribute( 'data-acf-inline-fields-uid' );
+			if ( ! $preexisting_inline_fields_uid ) {
+				$element->setAttribute( 'data-acf-inline-fields-uid', implode( '__', $field_names_for_popover ) . '__' . $block['id'] );
+				$element->setAttribute(
+					'data-acf-inline-fields',
+					wp_json_encode( $field_names_for_popover ),
+				);
+			}
+		}
+	}
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName
+	$dom->preserveWhiteSpace = true;
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName
+	$dom->formatOutput = false;
+
+	return str_replace( '<meta charset="UTF-8">', '', $dom->saveHTML() );
+}

--- a/pro/blocks-auto-inline-editing.php
+++ b/pro/blocks-auto-inline-editing.php
@@ -88,6 +88,9 @@ add_filter( 'acf/format_value', __NAMESPACE__ . '\populate_auto_inline_editing_v
 function apply_inline_editing_attributes_to_render_template( $path, $block, $is_preview ): string {
 	global $acf_fields_used_in_block_render_template, $acf_blocks_doing_auto_inline_editing;
 
+	// Suppress unused variable warning - parameter is part of the function signature for consistency.
+	unset( $is_preview );
+
 	// Don't apply autoInlineEditing if the current PHP doesn't include DOMDocument or DOMXPath.
 	if ( ! class_exists( 'DOMDocument' ) || ! class_exists( 'DOMXPath' ) ) {
 		ob_start();

--- a/pro/blocks-auto-inline-editing.php
+++ b/pro/blocks-auto-inline-editing.php
@@ -3,6 +3,8 @@
  * Applying auto inline editing to SCF blocks.
  *
  * @package wordpress/secure-custom-fields
+ *
+ * phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.Found
  */
 
 /**

--- a/pro/blocks-auto-inline-editing.php
+++ b/pro/blocks-auto-inline-editing.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @package wordpress/secure-custom-fields
+ * Applying auto inline editing to SCF blocks.
  *
+ * @package wordpress/secure-custom-fields
  */
 
 /**
@@ -131,7 +132,7 @@ function apply_inline_editing_attributes_to_render_template( $path, $block, $is_
 		foreach ( $element->childNodes as $child ) {
 			// Check if the child node is a text node
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName
-			if ( $child->nodeType === XML_TEXT_NODE ) {
+			if ( XML_TEXT_NODE === $child->nodeType ) {
 				// phpcs:ignore WordPress.NamingConventions.ValidVariableName
 				$top_level_text .= $child->nodeValue;
 			}
@@ -168,7 +169,7 @@ function apply_inline_editing_attributes_to_render_template( $path, $block, $is_
 							}
 
 							// phpcs:ignore WordPress.NamingConventions.ValidVariableName
-							if ( $field_value !== 'acf_auto_inline_editing_field_name_' . $field_slug ) {
+							if ( 'acf_auto_inline_editing_field_name_' . $field_slug !== $field_value ) {
 								// phpcs:ignore WordPress.NamingConventions.ValidVariableName
 								$element->nodeValue = $field_value;
 							} else {
@@ -206,7 +207,7 @@ function apply_inline_editing_attributes_to_render_template( $path, $block, $is_
 
 		// Loop over each attribute. If an attribute comes from acf, make it popup when parent is selected.
 		foreach ( $element->attributes as $attribute ) {
-			if ( $attribute->name === 'data-acf-inline-contenteditable-field-slug' ) {
+			if ( 'data-acf-inline-contenteditable-field-slug' === $attribute->name ) {
 				continue;
 			}
 			$attribute_value = trim( $attribute->value );
@@ -234,7 +235,7 @@ function apply_inline_editing_attributes_to_render_template( $path, $block, $is_
 
 		// Don't add popover fields to the top level element unless it has text content (as opposed to html/non-text content, which is what most top level elements contain).
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName
-		$is_top_level = isset( $element->parentNode->tagName ) && $element->parentNode->tagName === 'body';
+		$is_top_level = isset( $element->parentNode->tagName ) && 'body' === $element->parentNode->tagName;
 
 		if ( ! $is_top_level && ! empty( $field_names_for_popover ) ) {
 			$preexisting_inline_fields_uid = $element->getAttribute( 'data-acf-inline-fields-uid' );

--- a/tests/e2e/block-testimonial.spec.ts
+++ b/tests/e2e/block-testimonial.spec.ts
@@ -158,20 +158,9 @@ test.describe( 'SCF Block > Testimonial', () => {
 		const publishButton = page.locator( '.editor-post-publish-panel .editor-post-publish-button' );
 		await publishButton.click();
 
-		// Wait for validation to fully appear
-		await page.waitForTimeout( 1000 );
+		// Wait for the error notice to appear at the top of the editor
+		const errorNotice = page.locator( '.components-notice.is-error .components-notice__content' );
+		await expect( errorNotice ).toBeVisible( { timeout: 1000 } );
 
-		// Check that the field has error class
-		const quoteFieldWithError = page.locator(
-			'.acf-field[data-name="quote"].acf-error'
-		);
-		await expect( quoteFieldWithError ).toBeVisible();
-
-		// Check for the error message within the field
-		const errorMessage = page.locator(
-			'.acf-field[data-name="quote"] .acf-notice.-error'
-		);
-		await expect( errorMessage ).toBeVisible();
-		await expect( errorMessage ).toContainText( 'required' );
 	} );
 } );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,8 @@ const commonConfig = {
 		'css/pro/acf-pro-field-group':
 			'./assets/src/sass/pro/acf-pro-field-group.scss',
 		'css/pro/acf-pro-input': './assets/src/sass/pro/acf-pro-input.scss',
+		'css/pro/acf-styles-in-iframe-for-blocks':
+			'./assets/src/sass/pro/acf-styles-in-iframe-for-blocks.scss',
 	},
 	output: {
 		path: path.resolve( __dirname, 'assets/build/' ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,7 +49,7 @@ const commonConfig = {
 				use: {
 					loader: 'babel-loader',
 					options: {
-						presets: [ '@babel/preset-react' ],
+						presets: [ [ '@babel/preset-react', { runtime: 'automatic' } ] ],
 						plugins: process.env.COVERAGE_ENABLED
 							? [ 'istanbul' ]
 							: [],


### PR DESCRIPTION
## What

Backports from 6.7.0.

As uncompiling 6.7.0.2 with inline editing is being harder than expected. And not working 100% like it should. This version puts the compiled version into pro blocks in order to work as the main source.

I'm thinking about a better approach, less React intense based for inline editing that I will experiment in future PRs, but we cannot stall this version much longer.