### PR TITLE
Docs: Claim repositoty in`context7`

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/wordpress/secure-custom-fields",
+  "public_key": "pk_n7NUnQwBc18T22RI8ReVk"
+}


### PR DESCRIPTION
[Context7](https://context7.com/) is a documentation tool that pulls up-to-date, version-specific documentation and code examples directly from the source, tailored explicitly for LLMs and offering MCP support.

To be able to manage the repository in Context7, we need to add this file t the project root to claim ownership, and it can be removed later