### PR TITLE
JSON Schemas: Add schema for field groups

### DIFF
--- a/schemas/field-group.schema.json
+++ b/schemas/field-group.schema.json
@@ -1,0 +1,305 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://raw.githubusercontent.com/WordPress/secure-custom-fields/trunk/schemas/field-group.schema.json",
+	"title": "SCF Field Group(s)",
+	"description": "Schema for Secure Custom Fields field group definitions - accepts single object or array. Validates field group structure and base field properties. Type-specific field properties are allowed but not strictly validated.",
+	"oneOf": [
+		{
+			"description": "Single field group object",
+			"$ref": "#/definitions/fieldGroup"
+		},
+		{
+			"description": "Array of field group objects (export format)",
+			"type": "array",
+			"items": { "$ref": "#/definitions/fieldGroup" },
+			"minItems": 1
+		}
+	],
+	"definitions": {
+		"fieldGroup": {
+			"type": "object",
+			"required": ["key", "title", "fields"],
+			"additionalProperties": false,
+			"properties": {
+				"key": {
+					"type": "string",
+					"pattern": "^group_.+$",
+					"minLength": 1,
+					"description": "Unique identifier for the field group with group_ prefix (e.g. 'group_abc123')"
+				},
+				"title": {
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 255,
+					"description": "The title/name of the field group"
+				},
+				"fields": {
+					"type": "array",
+					"items": { "$ref": "#/definitions/field" },
+					"description": "Array of field definitions"
+				},
+				"location": {
+					"type": "array",
+					"items": { "$ref": "#/definitions/locationGroup" },
+					"description": "Location rules determining where this field group appears. Array of rule groups (OR logic between groups, AND logic within groups)."
+				},
+				"menu_order": {
+					"type": "integer",
+					"default": 0,
+					"description": "Order in which the field group appears"
+				},
+				"position": {
+					"type": "string",
+					"enum": ["normal", "side", "acf_after_title"],
+					"default": "normal",
+					"description": "Position of the field group on the edit screen"
+				},
+				"style": {
+					"type": "string",
+					"enum": ["default", "seamless"],
+					"default": "default",
+					"description": "Visual style of the field group metabox"
+				},
+				"label_placement": {
+					"type": "string",
+					"enum": ["top", "left"],
+					"default": "top",
+					"description": "Placement of field labels relative to fields"
+				},
+				"instruction_placement": {
+					"type": "string",
+					"enum": ["label", "field"],
+					"default": "label",
+					"description": "Placement of field instructions"
+				},
+				"hide_on_screen": {
+					"type": "array",
+					"items": {
+						"type": "string",
+						"enum": [
+							"permalink",
+							"the_content",
+							"excerpt",
+							"custom_fields",
+							"discussion",
+							"comments",
+							"revisions",
+							"slug",
+							"author",
+							"format",
+							"page_attributes",
+							"featured_image",
+							"categories",
+							"tags",
+							"send-trackbacks"
+						]
+					},
+					"uniqueItems": true,
+					"description": "Screen elements to hide when this field group is displayed"
+				},
+				"active": {
+					"type": [ "boolean", "integer" ],
+					"default": true,
+					"description": "Whether the field group is active"
+				},
+				"description": {
+					"type": "string",
+					"description": "Description of the field group"
+				},
+				"show_in_rest": {
+					"type": [ "boolean", "integer" ],
+					"default": false,
+					"description": "Whether to expose this field group's fields in the REST API"
+				},
+				"display_title": {
+					"type": "string",
+					"description": "Alternative display title for the field group"
+				},
+				"modified": {
+					"type": "integer",
+					"description": "[SCF Export Only] Unix timestamp of last modification"
+				}
+			}
+		},
+		"field": {
+			"type": "object",
+			"required": ["key", "label", "name", "type"],
+			"additionalProperties": true,
+			"properties": {
+				"key": {
+					"type": "string",
+					"pattern": "^field_.+$",
+					"minLength": 1,
+					"description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+				},
+				"label": {
+					"type": "string",
+					"minLength": 1,
+					"description": "The label displayed for this field"
+				},
+				"name": {
+					"type": "string",
+					"pattern": "^[a-zA-Z0-9_-]*$",
+					"description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+				},
+				"aria-label": {
+					"type": "string",
+					"description": "Accessible label for screen readers"
+				},
+				"type": {
+					"type": "string",
+					"enum": [
+						"text",
+						"textarea",
+						"number",
+						"range",
+						"email",
+						"url",
+						"password",
+						"image",
+						"file",
+						"wysiwyg",
+						"oembed",
+						"gallery",
+						"select",
+						"checkbox",
+						"radio",
+						"button_group",
+						"true_false",
+						"link",
+						"post_object",
+						"page_link",
+						"relationship",
+						"taxonomy",
+						"user",
+						"google_map",
+						"date_picker",
+						"date_time_picker",
+						"time_picker",
+						"color_picker",
+						"icon_picker",
+						"message",
+						"accordion",
+						"tab",
+						"group",
+						"repeater",
+						"flexible_content",
+						"clone",
+						"nav_menu",
+						"separator",
+						"output"
+					],
+					"description": "The type of field"
+				},
+				"instructions": {
+					"type": "string",
+					"description": "Instructions for content editors"
+				},
+				"required": {
+					"type": [ "boolean", "integer" ],
+					"default": false,
+					"description": "Whether the field is required"
+				},
+				"conditional_logic": {
+					"oneOf": [
+						{ "type": "boolean", "enum": [false] },
+						{ "type": "integer", "enum": [0] },
+						{
+							"type": "array",
+							"items": { "$ref": "#/definitions/conditionalLogicGroup" }
+						}
+					],
+					"description": "Conditional logic rules for field visibility"
+				},
+				"wrapper": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"width": {
+							"type": "string",
+							"description": "Width of the field wrapper (e.g. '50' for 50%)"
+						},
+						"class": {
+							"type": "string",
+							"description": "CSS class(es) for the field wrapper"
+						},
+						"id": {
+							"type": "string",
+							"description": "HTML ID for the field wrapper"
+						}
+					},
+					"description": "Wrapper element settings"
+				},
+				"menu_order": {
+					"type": "integer",
+					"description": "Order of the field within its parent"
+				},
+				"parent": {
+					"oneOf": [
+						{ "type": "string" },
+						{ "type": "integer" }
+					],
+					"description": "Parent field or field group key/ID"
+				},
+				"parent_layout": {
+					"type": "string",
+					"description": "Parent layout key for flexible content sub-fields"
+				}
+			}
+		},
+		"locationGroup": {
+			"type": "array",
+			"items": { "$ref": "#/definitions/locationRule" },
+			"minItems": 1,
+			"description": "Group of location rules (AND logic within group)"
+		},
+		"locationRule": {
+			"type": "object",
+			"required": ["param", "operator", "value"],
+			"additionalProperties": true,
+			"properties": {
+				"param": {
+					"type": "string",
+					"minLength": 1,
+					"description": "The parameter to compare (e.g. 'post_type', 'page_template', 'user_role')"
+				},
+				"operator": {
+					"type": "string",
+					"enum": ["==", "!="],
+					"description": "Comparison operator"
+				},
+				"value": {
+					"type": "string",
+					"description": "Value to compare against"
+				}
+			}
+		},
+		"conditionalLogicGroup": {
+			"type": "array",
+			"items": { "$ref": "#/definitions/conditionalLogicRule" },
+			"minItems": 1,
+			"description": "Group of conditional logic rules (AND logic within group)"
+		},
+		"conditionalLogicRule": {
+			"type": "object",
+			"required": ["field", "operator"],
+			"additionalProperties": false,
+			"properties": {
+				"field": {
+					"type": "string",
+					"pattern": "^field_.+$",
+					"description": "Field key to check"
+				},
+				"operator": {
+					"type": "string",
+					"enum": ["==", "!=", "!==", "==empty", "!=empty", "==pattern", "==contains", "!=contains", "<", ">"],
+					"description": "Comparison operator"
+				},
+				"value": {
+					"type": "string",
+					"description": "Value to compare against (not required for ==empty and !=empty operators)"
+				}
+			}
+		}
+	}
+}

--- a/schemas/field-group.schema.json
+++ b/schemas/field-group.schema.json
@@ -18,7 +18,7 @@
 	"definitions": {
 		"fieldGroup": {
 			"type": "object",
-			"required": ["key", "title", "fields"],
+			"required": [ "key", "title", "fields" ],
 			"additionalProperties": false,
 			"properties": {
 				"key": {
@@ -50,25 +50,25 @@
 				},
 				"position": {
 					"type": "string",
-					"enum": ["normal", "side", "acf_after_title"],
+					"enum": [ "normal", "side", "acf_after_title" ],
 					"default": "normal",
 					"description": "Position of the field group on the edit screen"
 				},
 				"style": {
 					"type": "string",
-					"enum": ["default", "seamless"],
+					"enum": [ "default", "seamless" ],
 					"default": "default",
 					"description": "Visual style of the field group metabox"
 				},
 				"label_placement": {
 					"type": "string",
-					"enum": ["top", "left"],
+					"enum": [ "top", "left" ],
 					"default": "top",
 					"description": "Placement of field labels relative to fields"
 				},
 				"instruction_placement": {
 					"type": "string",
-					"enum": ["label", "field"],
+					"enum": [ "label", "field" ],
 					"default": "label",
 					"description": "Placement of field instructions"
 				},
@@ -123,7 +123,7 @@
 		},
 		"field": {
 			"type": "object",
-			"required": ["key", "label", "name", "type"],
+			"required": [ "key", "label", "name", "type" ],
 			"additionalProperties": true,
 			"properties": {
 				"key": {
@@ -202,11 +202,13 @@
 				},
 				"conditional_logic": {
 					"oneOf": [
-						{ "type": "boolean", "enum": [false] },
-						{ "type": "integer", "enum": [0] },
+						{ "type": "boolean", "enum": [ false ] },
+						{ "type": "integer", "enum": [ 0 ] },
 						{
 							"type": "array",
-							"items": { "$ref": "#/definitions/conditionalLogicGroup" }
+							"items": {
+								"$ref": "#/definitions/conditionalLogicGroup"
+							}
 						}
 					],
 					"description": "Conditional logic rules for field visibility"
@@ -235,10 +237,7 @@
 					"description": "Order of the field within its parent"
 				},
 				"parent": {
-					"oneOf": [
-						{ "type": "string" },
-						{ "type": "integer" }
-					],
+					"oneOf": [ { "type": "string" }, { "type": "integer" } ],
 					"description": "Parent field or field group key/ID"
 				},
 				"parent_layout": {
@@ -255,7 +254,7 @@
 		},
 		"locationRule": {
 			"type": "object",
-			"required": ["param", "operator", "value"],
+			"required": [ "param", "operator", "value" ],
 			"additionalProperties": true,
 			"properties": {
 				"param": {
@@ -265,7 +264,7 @@
 				},
 				"operator": {
 					"type": "string",
-					"enum": ["==", "!="],
+					"enum": [ "==", "!=" ],
 					"description": "Comparison operator"
 				},
 				"value": {
@@ -282,7 +281,7 @@
 		},
 		"conditionalLogicRule": {
 			"type": "object",
-			"required": ["field", "operator"],
+			"required": [ "field", "operator" ],
 			"additionalProperties": false,
 			"properties": {
 				"field": {
@@ -292,7 +291,18 @@
 				},
 				"operator": {
 					"type": "string",
-					"enum": ["==", "!=", "!==", "==empty", "!=empty", "==pattern", "==contains", "!=contains", "<", ">"],
+					"enum": [
+						"==",
+						"!=",
+						"!==",
+						"==empty",
+						"!=empty",
+						"==pattern",
+						"==contains",
+						"!=contains",
+						"<",
+						">"
+					],
 					"description": "Comparison operator"
 				},
 				"value": {

--- a/tests/php/fixtures/schemas/field-groups/invalid/field-group-wrong-format.json
+++ b/tests/php/fixtures/schemas/field-groups/invalid/field-group-wrong-format.json
@@ -1,0 +1,210 @@
+{
+	"key": "group_site_settings",
+	"title": "Site Settings",
+	"location": [
+		[
+			{
+				"param": "options_page",
+				"operator": "==",
+				"value": "theme-settings"
+			}
+		]
+	],
+	"menu_order": 0,
+	"position": "normal",
+	"style": "default",
+	"label_placement": "top",
+	"instruction_placement": "label",
+	"hide_on_screen": "",
+	"active": true,
+	"description": "Example field group with many field types",
+	"fields": [
+		{
+			"key": "field_site_title",
+			"label": "Site Title",
+			"name": "site_title",
+			"type": "text",
+			"instructions": "Main title for the site",
+			"required": 0
+		},
+		{
+			"key": "field_site_tagline",
+			"label": "Tagline",
+			"name": "site_tagline",
+			"type": "textarea",
+			"instructions": "Short description used in SEO and headers",
+			"required": 0,
+			"rows": 3,
+			"new_lines": ""
+		},
+		{
+			"key": "field_items_per_page",
+			"label": "Items Per Page",
+			"name": "items_per_page",
+			"type": "number",
+			"instructions": "Default number of items to list",
+			"required": 0,
+			"min": 1,
+			"max": 100,
+			"step": 1
+		},
+		{
+			"key": "field_contact_email",
+			"label": "Contact Email",
+			"name": "contact_email",
+			"type": "email",
+			"required": 0
+		},
+		{
+			"key": "field_primary_url",
+			"label": "Primary URL",
+			"name": "primary_url",
+			"type": "url",
+			"required": 0
+		},
+		{
+			"key": "field_logo",
+			"label": "Logo",
+			"name": "logo",
+			"type": "image",
+			"return_format": "array",
+			"preview_size": "medium",
+			"library": "all"
+		},
+		{
+			"key": "field_download_file",
+			"label": "Download File",
+			"name": "download_file",
+			"type": "file",
+			"return_format": "array",
+			"library": "all"
+		},
+		{
+			"key": "field_enable_feature",
+			"label": "Enable Feature",
+			"name": "enable_feature",
+			"type": "true_false",
+			"ui": 1,
+			"ui_on_text": "Enabled",
+			"ui_off_text": "Disabled"
+		},
+		{
+			"key": "field_color_scheme",
+			"label": "Color Scheme",
+			"name": "color_scheme",
+			"type": "select",
+			"choices": {
+				"light": "Light",
+				"dark": "Dark",
+				"auto": "Auto"
+			},
+			"default_value": "auto",
+			"ui": 1,
+			"return_format": "value",
+			"ajax": 0,
+			"multiple": 0,
+			"allow_null": 0,
+			"placeholder": ""
+		},
+		{
+			"key": "field_display_elements",
+			"label": "Display Elements",
+			"name": "display_elements",
+			"type": "checkbox",
+			"choices": {
+				"search": "Search Box",
+				"breadcrumbs": "Breadcrumbs",
+				"footer_widgets": "Footer Widgets"
+			},
+			"default_value": [],
+			"layout": "vertical",
+			"return_format": "value"
+		},
+		{
+			"key": "field_layout_style",
+			"label": "Layout Style",
+			"name": "layout_style",
+			"type": "radio",
+			"choices": {
+				"boxed": "Boxed",
+				"full": "Full Width"
+			},
+			"layout": "horizontal",
+			"return_format": "value"
+		},
+		{
+			"key": "field_launch_date",
+			"label": "Launch Date",
+			"name": "launch_date",
+			"type": "date_picker",
+			"display_format": "Y-m-d",
+			"return_format": "Y-m-d",
+			"first_day": 1
+		},
+		{
+			"key": "field_social_links",
+			"label": "Social Links",
+			"name": "social_links",
+			"type": "repeater",
+			"instructions": "Add social media profiles",
+			"min": 0,
+			"max": 0,
+			"layout": "row",
+			"button_label": "Add Social Link",
+			"sub_fields": [
+				{
+					"key": "field_social_network",
+					"label": "Network",
+					"name": "network",
+					"type": "select",
+					"choices": {
+						"facebook": "Facebook",
+						"twitter": "X / Twitter",
+						"instagram": "Instagram",
+						"linkedin": "LinkedIn"
+					},
+					"ui": 1,
+					"return_format": "value"
+				},
+				{
+					"key": "field_social_url",
+					"label": "Profile URL",
+					"name": "url",
+					"type": "url"
+				}
+			]
+		},
+		{
+			"key": "field_seo_group",
+			"label": "SEO Settings",
+			"name": "seo_settings",
+			"type": "group",
+			"layout": "block",
+			"sub_fields": [
+				{
+					"key": "field_seo_title",
+					"label": "SEO Title",
+					"name": "seo_title",
+					"type": "text"
+				},
+				{
+					"key": "field_seo_description",
+					"label": "SEO Description",
+					"name": "seo_description",
+					"type": "textarea",
+					"rows": 3
+				},
+				{
+					"key": "field_seo_index",
+					"label": "Allow Indexing",
+					"name": "seo_index",
+					"type": "true_false",
+					"ui": 1,
+					"ui_on_text": "Index",
+					"ui_off_text": "Noindex"
+				}
+			]
+		}
+	],
+	"modified": 1700000000
+}

--- a/tests/php/fixtures/schemas/field-groups/valid/comprehensive-export.json
+++ b/tests/php/fixtures/schemas/field-groups/valid/comprehensive-export.json
@@ -1,0 +1,536 @@
+{
+	"key": "group_comprehensive_export",
+	"title": "Comprehensive Export Test",
+	"fields": [
+		{
+			"key": "field_text_001",
+			"label": "Text Field",
+			"name": "text_field",
+			"aria-label": "",
+			"type": "text",
+			"instructions": "Enter some text",
+			"required": 0,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"default_value": "",
+			"placeholder": "Type here...",
+			"maxlength": 100,
+			"prepend": "",
+			"append": ""
+		},
+		{
+			"key": "field_textarea_001",
+			"label": "Textarea Field",
+			"name": "textarea_field",
+			"aria-label": "",
+			"type": "textarea",
+			"instructions": "Enter multi-line text",
+			"required": 1,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"rows": 4,
+			"new_lines": "br",
+			"default_value": "",
+			"maxlength": "",
+			"placeholder": ""
+		},
+		{
+			"key": "field_number_001",
+			"label": "Number Field",
+			"name": "number_field",
+			"aria-label": "",
+			"type": "number",
+			"instructions": "",
+			"required": false,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"min": 0,
+			"max": 100,
+			"step": 1,
+			"default_value": "",
+			"placeholder": "",
+			"prepend": "",
+			"append": ""
+		},
+		{
+			"key": "field_email_001",
+			"label": "Email Field",
+			"name": "email_field",
+			"aria-label": "",
+			"type": "email",
+			"instructions": "",
+			"required": false,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"default_value": "",
+			"placeholder": "",
+			"prepend": "",
+			"append": ""
+		},
+		{
+			"key": "field_url_001",
+			"label": "URL Field",
+			"name": "url_field",
+			"aria-label": "",
+			"type": "url",
+			"instructions": "",
+			"required": false,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"default_value": "",
+			"placeholder": ""
+		},
+		{
+			"key": "field_password_001",
+			"label": "Password Field",
+			"name": "password_field",
+			"aria-label": "",
+			"type": "password",
+			"instructions": "",
+			"required": false,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"placeholder": "",
+			"prepend": "",
+			"append": ""
+		},
+		{
+			"key": "field_wysiwyg_001",
+			"label": "WYSIWYG Editor",
+			"name": "wysiwyg_field",
+			"aria-label": "",
+			"type": "wysiwyg",
+			"instructions": "",
+			"required": false,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"tabs": "all",
+			"toolbar": "full",
+			"media_upload": 1,
+			"default_value": "",
+			"delay": 0
+		},
+		{
+			"key": "field_select_001",
+			"label": "Select Field",
+			"name": "select_field",
+			"aria-label": "",
+			"type": "select",
+			"instructions": "",
+			"required": false,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"choices": {
+				"option1": "Option 1",
+				"option2": "Option 2",
+				"option3": "Option 3"
+			},
+			"default_value": "option1",
+			"allow_null": 0,
+			"multiple": 0,
+			"ui": 1,
+			"return_format": "value",
+			"ajax": 0,
+			"placeholder": "",
+			"create_options": 0,
+			"save_options": 0
+		},
+		{
+			"key": "field_checkbox_001",
+			"label": "Checkbox Field",
+			"name": "checkbox_field",
+			"aria-label": "",
+			"type": "checkbox",
+			"instructions": "",
+			"required": false,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"choices": {
+				"check1": "Check 1",
+				"check2": "Check 2"
+			},
+			"layout": "vertical",
+			"return_format": "value",
+			"default_value": [],
+			"allow_custom": 0,
+			"save_custom": 0,
+			"toggle": 0,
+			"custom_choice_button_text": "Add new choice"
+		},
+		{
+			"key": "field_radio_001",
+			"label": "Radio Field",
+			"name": "radio_field",
+			"aria-label": "",
+			"type": "radio",
+			"instructions": "",
+			"required": false,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"choices": {
+				"radio1": "Radio 1",
+				"radio2": "Radio 2"
+			},
+			"layout": "horizontal",
+			"return_format": "value",
+			"default_value": "",
+			"other_choice": 0,
+			"save_other_choice": 0,
+			"allow_null": 0
+		},
+		{
+			"key": "field_true_false_001",
+			"label": "True False Field",
+			"name": "true_false_field",
+			"aria-label": "",
+			"type": "true_false",
+			"instructions": "",
+			"required": false,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"ui": 1,
+			"ui_on_text": "Yes",
+			"ui_off_text": "No",
+			"default_value": 0,
+			"message": ""
+		},
+		{
+			"key": "field_image_001",
+			"label": "Image Field",
+			"name": "image_field",
+			"aria-label": "",
+			"type": "image",
+			"instructions": "",
+			"required": false,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"return_format": "array",
+			"preview_size": "medium",
+			"library": "all",
+			"min_width": 0,
+			"min_height": 0,
+			"min_size": 0,
+			"max_width": 0,
+			"max_height": 0,
+			"max_size": 0,
+			"mime_types": ""
+		},
+		{
+			"key": "field_file_001",
+			"label": "File Field",
+			"name": "file_field",
+			"aria-label": "",
+			"type": "file",
+			"instructions": "",
+			"required": false,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"return_format": "array",
+			"library": "all",
+			"min_size": 0,
+			"max_size": 0,
+			"mime_types": ""
+		},
+		{
+			"key": "field_tab_001",
+			"label": "Settings Tab",
+			"name": "",
+			"aria-label": "",
+			"type": "tab",
+			"instructions": "",
+			"required": 0,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"placement": "top",
+			"endpoint": 0,
+			"selected": 0
+		},
+		{
+			"key": "field_date_picker_001",
+			"label": "Date Picker",
+			"name": "date_picker_field",
+			"aria-label": "",
+			"type": "date_picker",
+			"instructions": "",
+			"required": false,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"display_format": "F j, Y",
+			"return_format": "Y-m-d",
+			"first_day": 1,
+			"default_to_current_date": 0
+		},
+		{
+			"key": "field_color_picker_001",
+			"label": "Color Picker",
+			"name": "color_picker_field",
+			"aria-label": "",
+			"type": "color_picker",
+			"instructions": "",
+			"required": false,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"enable_opacity": 1,
+			"return_format": "string",
+			"default_value": "",
+			"custom_palette_source": "",
+			"palette_colors": "",
+			"show_color_wheel": true
+		},
+		{
+			"key": "field_message_001",
+			"label": "Message",
+			"name": "",
+			"aria-label": "",
+			"type": "message",
+			"instructions": "",
+			"required": 0,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"message": "This is an informational message.",
+			"new_lines": "wpautop",
+			"esc_html": 0
+		},
+		{
+			"key": "field_range_001",
+			"label": "Range Field",
+			"name": "range_field",
+			"aria-label": "",
+			"type": "range",
+			"instructions": "",
+			"required": false,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"min": 0,
+			"max": 100,
+			"step": 5,
+			"default_value": "",
+			"prepend": "",
+			"append": ""
+		},
+		{
+			"key": "field_group_001",
+			"label": "Group Field",
+			"name": "group_field",
+			"aria-label": "",
+			"type": "group",
+			"instructions": "",
+			"required": false,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"layout": "block",
+			"sub_fields": [
+				{
+					"key": "field_group_sub_text",
+					"label": "Sub Text",
+					"name": "sub_text",
+					"aria-label": "",
+					"type": "text",
+					"instructions": "",
+					"required": false,
+					"conditional_logic": false,
+					"wrapper": {
+						"width": "",
+						"class": "",
+						"id": ""
+					},
+					"default_value": "",
+					"maxlength": "",
+					"placeholder": "",
+					"prepend": "",
+					"append": ""
+				},
+				{
+					"key": "field_group_sub_number",
+					"label": "Sub Number",
+					"name": "sub_number",
+					"aria-label": "",
+					"type": "number",
+					"instructions": "",
+					"required": false,
+					"conditional_logic": false,
+					"wrapper": {
+						"width": "",
+						"class": "",
+						"id": ""
+					},
+					"default_value": "",
+					"min": "",
+					"max": "",
+					"step": "",
+					"placeholder": "",
+					"prepend": "",
+					"append": ""
+				}
+			]
+		},
+		{
+			"key": "field_repeater_001",
+			"label": "Repeater Field",
+			"name": "repeater_field",
+			"aria-label": "",
+			"type": "repeater",
+			"instructions": "",
+			"required": false,
+			"conditional_logic": false,
+			"wrapper": {
+				"width": "",
+				"class": "",
+				"id": ""
+			},
+			"min": 0,
+			"max": 10,
+			"layout": "row",
+			"button_label": "Add Row",
+			"rows_per_page": 20,
+			"collapsed": "",
+			"sub_fields": [
+				{
+					"key": "field_repeater_sub_text",
+					"label": "Item Text",
+					"name": "item_text",
+					"aria-label": "",
+					"type": "text",
+					"instructions": "",
+					"required": false,
+					"conditional_logic": false,
+					"wrapper": {
+						"width": "",
+						"class": "",
+						"id": ""
+					},
+					"default_value": "",
+					"maxlength": "",
+					"placeholder": "",
+					"prepend": "",
+					"append": "",
+					"parent_repeater": "field_repeater_001"
+				},
+				{
+					"key": "field_repeater_sub_image",
+					"label": "Item Image",
+					"name": "item_image",
+					"aria-label": "",
+					"type": "image",
+					"instructions": "",
+					"required": false,
+					"conditional_logic": false,
+					"wrapper": {
+						"width": "",
+						"class": "",
+						"id": ""
+					},
+					"return_format": "id",
+					"preview_size": "medium",
+					"library": "all",
+					"min_width": 0,
+					"min_height": 0,
+					"min_size": 0,
+					"max_width": 0,
+					"max_height": 0,
+					"max_size": 0,
+					"mime_types": "",
+					"parent_repeater": "field_repeater_001"
+				}
+			]
+		}
+	],
+	"location": [
+		[
+			{
+				"param": "post_type",
+				"operator": "==",
+				"value": "post"
+			}
+		]
+	],
+	"menu_order": 0,
+	"position": "normal",
+	"style": "default",
+	"label_placement": "top",
+	"instruction_placement": "label",
+	"hide_on_screen": [
+		"the_content",
+		"excerpt"
+	],
+	"active": true,
+	"description": "A comprehensive field group for testing all field types",
+	"show_in_rest": false,
+	"display_title": ""
+}

--- a/tests/php/fixtures/schemas/field-groups/valid/field-group-minimal.json
+++ b/tests/php/fixtures/schemas/field-groups/valid/field-group-minimal.json
@@ -1,0 +1,5 @@
+{
+	"key": "group_minimal_test",
+	"title": "Minimal Test Field Group",
+	"fields": []
+}

--- a/tests/php/fixtures/schemas/field-groups/valid/full-export.json
+++ b/tests/php/fixtures/schemas/field-groups/valid/full-export.json
@@ -525,10 +525,7 @@
 	"style": "default",
 	"label_placement": "top",
 	"instruction_placement": "label",
-	"hide_on_screen": [
-		"the_content",
-		"excerpt"
-	],
+	"hide_on_screen": [ "the_content", "excerpt" ],
 	"active": true,
 	"description": "A comprehensive field group for testing all field types",
 	"show_in_rest": false,

--- a/tests/php/schemas/FieldGroupSchemaTest.php
+++ b/tests/php/schemas/FieldGroupSchemaTest.php
@@ -1,0 +1,476 @@
+<?php
+/**
+ * Tests for the SCF Field Group JSON Schema validation.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once 'BaseSchemaTestCase.php';
+
+/**
+ * Class FieldGroupSchemaTest
+ *
+ * Tests JSON Schema validation for SCF field groups.
+ */
+class FieldGroupSchemaTest extends BaseSchemaTestCase {
+
+	/**
+	 * Get the schema type to test.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_type(): string {
+		return 'field-group';
+	}
+
+	/**
+	 * Get the path to the fixtures directory.
+	 *
+	 * @return string
+	 */
+	protected function get_fixtures_path(): string {
+		return dirname( __DIR__ ) . '/fixtures/schemas/field-groups/';
+	}
+
+	/**
+	 * Get the definition name in the schema.
+	 *
+	 * @return string
+	 */
+	protected function get_definition_name(): string {
+		return 'fieldGroup';
+	}
+
+	/**
+	 * Get the required fields for this schema.
+	 *
+	 * @return array
+	 */
+	protected function get_required_fields(): array {
+		return array( 'key', 'title', 'fields' );
+	}
+
+	/**
+	 * Data provider for valid field groups.
+	 *
+	 * @return array
+	 */
+	public function validEntitiesProvider(): array {
+		return array(
+			'basic valid'                   => array(
+				array(
+					'key'    => 'group_test123',
+					'title'  => 'Test Field Group',
+					'fields' => array(),
+				),
+				'Basic field group should validate successfully',
+			),
+			'array with two items'          => array(
+				array(
+					array(
+						'key'    => 'group_test123',
+						'title'  => 'Test Field Group',
+						'fields' => array(),
+					),
+					array(
+						'key'    => 'group_another456',
+						'title'  => 'Another Field Group',
+						'fields' => array(),
+					),
+				),
+				'Array of two field groups should validate successfully',
+			),
+			'with location rules'           => array(
+				array(
+					'key'      => 'group_with_location',
+					'title'    => 'Field Group with Location',
+					'fields'   => array(),
+					'location' => array(
+						array(
+							array(
+								'param'    => 'post_type',
+								'operator' => '==',
+								'value'    => 'post',
+							),
+						),
+					),
+				),
+				'Field group with location rules should be valid',
+			),
+			'with multiple location groups' => array(
+				array(
+					'key'      => 'group_multi_location',
+					'title'    => 'Multi Location Group',
+					'fields'   => array(),
+					'location' => array(
+						array(
+							array(
+								'param'    => 'post_type',
+								'operator' => '==',
+								'value'    => 'post',
+							),
+						),
+						array(
+							array(
+								'param'    => 'post_type',
+								'operator' => '==',
+								'value'    => 'page',
+							),
+						),
+					),
+				),
+				'Field group with OR location logic should be valid',
+			),
+			'with field'                    => array(
+				array(
+					'key'    => 'group_with_field',
+					'title'  => 'Field Group with Field',
+					'fields' => array(
+						array(
+							'key'   => 'field_text_abc',
+							'label' => 'Text Field',
+							'name'  => 'text_field',
+							'type'  => 'text',
+						),
+					),
+				),
+				'Field group with a text field should be valid',
+			),
+			'with all positions'            => array(
+				array(
+					'key'      => 'group_position_normal',
+					'title'    => 'Normal Position',
+					'fields'   => array(),
+					'position' => 'normal',
+				),
+				'Field group with normal position should be valid',
+			),
+			'position side'                 => array(
+				array(
+					'key'      => 'group_position_side',
+					'title'    => 'Side Position',
+					'fields'   => array(),
+					'position' => 'side',
+				),
+				'Field group with side position should be valid',
+			),
+			'position after title'          => array(
+				array(
+					'key'      => 'group_position_after',
+					'title'    => 'After Title Position',
+					'fields'   => array(),
+					'position' => 'acf_after_title',
+				),
+				'Field group with acf_after_title position should be valid',
+			),
+			'style default'                 => array(
+				array(
+					'key'    => 'group_style_default',
+					'title'  => 'Default Style',
+					'fields' => array(),
+					'style'  => 'default',
+				),
+				'Field group with default style should be valid',
+			),
+			'style seamless'                => array(
+				array(
+					'key'    => 'group_style_seamless',
+					'title'  => 'Seamless Style',
+					'fields' => array(),
+					'style'  => 'seamless',
+				),
+				'Field group with seamless style should be valid',
+			),
+			'active as boolean'             => array(
+				array(
+					'key'    => 'group_active_bool',
+					'title'  => 'Active Boolean',
+					'fields' => array(),
+					'active' => true,
+				),
+				'Field group with active as boolean should be valid',
+			),
+			'active as integer'             => array(
+				array(
+					'key'    => 'group_active_int',
+					'title'  => 'Active Integer',
+					'fields' => array(),
+					'active' => 1,
+				),
+				'Field group with active as integer should be valid',
+			),
+			'show_in_rest boolean'          => array(
+				array(
+					'key'          => 'group_rest_bool',
+					'title'        => 'REST Boolean',
+					'fields'       => array(),
+					'show_in_rest' => true,
+				),
+				'Field group with show_in_rest as boolean should be valid',
+			),
+			'show_in_rest integer'          => array(
+				array(
+					'key'          => 'group_rest_int',
+					'title'        => 'REST Integer',
+					'fields'       => array(),
+					'show_in_rest' => 0,
+				),
+				'Field group with show_in_rest as integer should be valid',
+			),
+			'hide_on_screen items'          => array(
+				array(
+					'key'            => 'group_hide_screen',
+					'title'          => 'Hide Screen Elements',
+					'fields'         => array(),
+					'hide_on_screen' => array( 'the_content', 'excerpt', 'comments' ),
+				),
+				'Field group with hide_on_screen should be valid',
+			),
+			'full export format'            => array(
+				array(
+					'key'                   => 'group_full_export',
+					'title'                 => 'Full Export Format',
+					'fields'                => array(),
+					'location'              => array(),
+					'menu_order'            => 5,
+					'position'              => 'normal',
+					'style'                 => 'default',
+					'label_placement'       => 'top',
+					'instruction_placement' => 'label',
+					'hide_on_screen'        => array(),
+					'active'                => true,
+					'description'           => 'A test field group',
+					'show_in_rest'          => false,
+					'display_title'         => 'Custom Title',
+					'modified'              => 1700000000,
+				),
+				'Complete field group with all properties should be valid',
+			),
+			'field with conditional_logic'  => array(
+				array(
+					'key'    => 'group_conditional',
+					'title'  => 'Conditional Group',
+					'fields' => array(
+						array(
+							'key'               => 'field_toggle',
+							'label'             => 'Toggle',
+							'name'              => 'toggle',
+							'type'              => 'true_false',
+							'conditional_logic' => 0,
+						),
+						array(
+							'key'               => 'field_dependent',
+							'label'             => 'Dependent',
+							'name'              => 'dependent',
+							'type'              => 'text',
+							'conditional_logic' => array(
+								array(
+									array(
+										'field'    => 'field_toggle',
+										'operator' => '==',
+										'value'    => '1',
+									),
+								),
+							),
+						),
+					),
+				),
+				'Field group with conditional logic should be valid',
+			),
+			'field required as boolean'     => array(
+				array(
+					'key'    => 'group_req_bool',
+					'title'  => 'Required Boolean',
+					'fields' => array(
+						array(
+							'key'      => 'field_req_bool',
+							'label'    => 'Required Field',
+							'name'     => 'required_field',
+							'type'     => 'text',
+							'required' => true,
+						),
+					),
+				),
+				'Field with required as boolean should be valid',
+			),
+			'field required as integer'     => array(
+				array(
+					'key'    => 'group_req_int',
+					'title'  => 'Required Integer',
+					'fields' => array(
+						array(
+							'key'      => 'field_req_int',
+							'label'    => 'Required Field',
+							'name'     => 'required_field',
+							'type'     => 'text',
+							'required' => 1,
+						),
+					),
+				),
+				'Field with required as integer should be valid',
+			),
+		);
+	}
+
+	/**
+	 * Data provider for invalid field groups.
+	 *
+	 * @return array
+	 */
+	public function invalidEntitiesProvider(): array {
+		return array(
+			'missing key'               => array(
+				array(
+					'title'  => 'Missing Key',
+					'fields' => array(),
+				),
+				'Field group missing key should fail validation',
+			),
+			'missing title'             => array(
+				array(
+					'key'    => 'group_missing_title',
+					'fields' => array(),
+				),
+				'Field group missing title should fail validation',
+			),
+			'missing fields'            => array(
+				array(
+					'key'   => 'group_missing_fields',
+					'title' => 'Missing Fields',
+				),
+				'Field group missing fields should fail validation',
+			),
+			'empty key'                 => array(
+				array(
+					'key'    => '',
+					'title'  => 'Empty Key',
+					'fields' => array(),
+				),
+				'Field group with empty key should fail validation',
+			),
+			'invalid key pattern'       => array(
+				array(
+					'key'    => 'invalid_key_without_prefix',
+					'title'  => 'Invalid Key',
+					'fields' => array(),
+				),
+				'Field group without group_ prefix should fail validation',
+			),
+			'additional properties'     => array(
+				array(
+					'key'              => 'group_extra_props',
+					'title'            => 'Extra Properties',
+					'fields'           => array(),
+					'invalid_property' => 'some value',
+				),
+				'Field group with additional properties should fail validation',
+			),
+			'invalid position'          => array(
+				array(
+					'key'      => 'group_bad_position',
+					'title'    => 'Bad Position',
+					'fields'   => array(),
+					'position' => 'invalid_position',
+				),
+				'Field group with invalid position should fail validation',
+			),
+			'invalid style'             => array(
+				array(
+					'key'    => 'group_bad_style',
+					'title'  => 'Bad Style',
+					'fields' => array(),
+					'style'  => 'invalid_style',
+				),
+				'Field group with invalid style should fail validation',
+			),
+			'field missing key'         => array(
+				array(
+					'key'    => 'group_field_no_key',
+					'title'  => 'Field Missing Key',
+					'fields' => array(
+						array(
+							'label' => 'No Key Field',
+							'name'  => 'no_key',
+							'type'  => 'text',
+						),
+					),
+				),
+				'Field without key should fail validation',
+			),
+			'field invalid key'         => array(
+				array(
+					'key'    => 'group_field_bad_key',
+					'title'  => 'Field Bad Key',
+					'fields' => array(
+						array(
+							'key'   => 'invalid_field_key',
+							'label' => 'Bad Key Field',
+							'name'  => 'bad_key',
+							'type'  => 'text',
+						),
+					),
+				),
+				'Field without field_ prefix should fail validation',
+			),
+			'field invalid type'        => array(
+				array(
+					'key'    => 'group_field_bad_type',
+					'title'  => 'Field Bad Type',
+					'fields' => array(
+						array(
+							'key'   => 'field_bad_type',
+							'label' => 'Bad Type Field',
+							'name'  => 'bad_type',
+							'type'  => 'nonexistent_type',
+						),
+					),
+				),
+				'Field with invalid type should fail validation',
+			),
+			'invalid hide_on_screen'    => array(
+				array(
+					'key'            => 'group_bad_hide',
+					'title'          => 'Bad Hide Screen',
+					'fields'         => array(),
+					'hide_on_screen' => array( 'invalid_element' ),
+				),
+				'Field group with invalid hide_on_screen value should fail validation',
+			),
+			'location missing param'    => array(
+				array(
+					'key'      => 'group_loc_no_param',
+					'title'    => 'Location No Param',
+					'fields'   => array(),
+					'location' => array(
+						array(
+							array(
+								'operator' => '==',
+								'value'    => 'post',
+							),
+						),
+					),
+				),
+				'Location rule missing param should fail validation',
+			),
+			'location invalid operator' => array(
+				array(
+					'key'      => 'group_loc_bad_op',
+					'title'    => 'Location Bad Operator',
+					'fields'   => array(),
+					'location' => array(
+						array(
+							array(
+								'param'    => 'post_type',
+								'operator' => '===',
+								'value'    => 'post',
+							),
+						),
+					),
+				),
+				'Location rule with invalid operator should fail validation',
+			),
+		);
+	}
+}


### PR DESCRIPTION
## What
Part of https://github.com/WordPress/secure-custom-fields/issues/162; adds JSON Schemas for SCF Field Groups, continuing the schema implementation work from Post Types,  Taxonomies, and Options Pages.

## Why
Already explained, but it will provide validation before import and when using the Abilities API.

## How
- Added a field group schema that validates all 39 field types, conditional logic operators, and location rules.
- Added PHPUnit tests covering valid and invalid scenarios

Note that this PR validates the field group structure and common field properties. Field-type-specific properties (e.g., `choices` for select fields, `min`/`max` for number fields) use `additionalProperties: true` to allow flexibility, but are not validated yet.

Follow-up PRs will add category-based field subschemas, mirroring the SCF field categories (basic, content, choice, etc.).

## Testing Instructions
1. Run `vendor/bin/phpunit tests/php/schemas/FieldGroupSchemaTest.php`