### PR TITLE
Abilities support: Add abilities for Field Groups

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -38,3 +38,4 @@ ignore:
     - 'vendor'
     # Individual file exclusions
     - 'includes/abilities/class-scf-ui-options-page-abilities.php' # Thin wrapper - logic tested via base class
+    - 'includes/abilities/class-scf-field-group-abilities.php' # Thin wrapper - logic tested via base class

--- a/includes/abilities/class-scf-abilities-integration.php
+++ b/includes/abilities/class-scf-abilities-integration.php
@@ -43,6 +43,7 @@ if ( ! class_exists( 'SCF_Abilities_Integration' ) ) {
 			acf_include( 'includes/abilities/class-scf-post-type-abilities.php' );
 			acf_include( 'includes/abilities/class-scf-taxonomy-abilities.php' );
 			acf_include( 'includes/abilities/class-scf-ui-options-page-abilities.php' );
+			acf_include( 'includes/abilities/class-scf-field-group-abilities.php' );
 		}
 
 		/**

--- a/includes/abilities/class-scf-field-group-abilities.php
+++ b/includes/abilities/class-scf-field-group-abilities.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * SCF Field Group Abilities
+ *
+ * Handles WordPress Abilities API registration for SCF field group management.
+ *
+ * @package wordpress/secure-custom-fields
+ * @since 6.8.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'SCF_Field_Group_Abilities' ) ) :
+
+	/**
+	 * SCF Field Group Abilities class.
+	 *
+	 * Registers and handles all field group management abilities for the
+	 * WordPress Abilities API integration. Provides programmatic access
+	 * to SCF field group operations.
+	 *
+	 * @since 6.8.0
+	 */
+	class SCF_Field_Group_Abilities extends SCF_Internal_Post_Type_Abilities {
+
+		/**
+		 * The internal post type identifier.
+		 *
+		 * @var string
+		 */
+		protected $internal_post_type = 'acf-field-group';
+	}
+
+	// Initialize abilities instance.
+	acf_new_instance( 'SCF_Field_Group_Abilities' );
+
+endif; // class_exists check.

--- a/includes/abilities/class-scf-field-group-abilities.php
+++ b/includes/abilities/class-scf-field-group-abilities.php
@@ -32,6 +32,33 @@ if ( ! class_exists( 'SCF_Field_Group_Abilities' ) ) :
 		 * @var string
 		 */
 		protected $internal_post_type = 'acf-field-group';
+
+		/**
+		 * Handles the list ability callback.
+		 *
+		 * Overrides parent to ignore location rules. Field groups use location rules
+		 * to determine which edit screens they appear on - this is a UX feature for
+		 * showing contextually relevant field groups, not access control.
+		 *
+		 * The abilities API should return all field groups regardless of location
+		 * rules, so we bypass that filtering while preserving other filters like
+		 * active status.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param array $input The input parameters.
+		 * @return array List of field groups.
+		 */
+		public function list_callback( $input ) {
+			// Ensure filter is an array (REST API may pass empty string for empty filter).
+			$filter = isset( $input['filter'] ) && is_array( $input['filter'] ) ? $input['filter'] : array();
+
+			// Location rules are a UX feature for edit screens, not access control.
+			$filter['ignore_location_rules'] = true;
+
+			$instance = acf_get_internal_post_type_instance( $this->internal_post_type );
+			return $instance->filter_posts( $instance->get_posts(), $filter );
+		}
 	}
 
 	// Initialize abilities instance.

--- a/includes/post-types/class-acf-field-group.php
+++ b/includes/post-types/class-acf-field-group.php
@@ -150,13 +150,34 @@ if ( ! class_exists( 'ACF_Field_Group' ) ) {
 		/**
 		 * Filter the posts returned by $this->get_posts().
 		 *
+		 * By default, field groups are filtered based on their location rules. This
+		 * determines which field groups appear on specific edit screens (e.g., a
+		 * "Product" field group only shows when editing WooCommerce products).
+		 *
+		 * IMPORTANT: Location rule filtering is a UX feature, not a security mechanism.
+		 * It controls which field groups are contextually relevant to display, not
+		 * who can access them. Access control is handled by WordPress capabilities.
+		 *
+		 * Pass 'ignore_location_rules' => true to bypass location-based filtering and
+		 * return all field groups. Use this for admin listings, REST/abilities APIs,
+		 * and other programmatic contexts where all field groups should be listed
+		 * regardless of their location rules.
+		 *
 		 * @since ACF 6.1
 		 *
 		 * @param array $posts An array of posts to filter.
 		 * @param array $args  An array of args to filter by.
+		 *                     - 'ignore_location_rules': Bypass location filtering when true.
+		 *                     - 'active': Filter by active status (handled by parent).
 		 * @return array
 		 */
 		public function filter_posts( $posts, $args = array() ) {
+			// If ignore_location_rules is set, bypass location-based filtering
+			// and use parent's filter (which only filters by active status).
+			if ( ! empty( $args['ignore_location_rules'] ) ) {
+				return parent::filter_posts( $posts, $args );
+			}
+
 			// Loop over field groups and check visibility.
 			$filtered = array();
 			if ( $posts ) {

--- a/tests/e2e/abilities-internal-post-types.spec.ts
+++ b/tests/e2e/abilities-internal-post-types.spec.ts
@@ -476,10 +476,20 @@ for ( const entityType of ENTITY_TYPES ) {
 
 				expect( result ).toHaveProperty( 'key' );
 				expect( result ).toHaveProperty( identifierKey );
+
+				// When duplicating, the internal `key` always changes to a new unique value.
 				expect( result.key ).not.toBe( testEntity.key );
-				expect( result[ identifierKey ] ).toBe(
-					testEntity[ identifierKey ]
-				);
+
+				// For Post Types, Taxonomies, and Options Pages, the user-facing identifier
+				// (post_type, taxonomy, menu_slug) is preserved when duplicating.
+				// For Field Groups, the `key` IS the identifier - there's no separate
+				// user-facing identifier, so this assertion doesn't apply.
+				if ( identifierKey !== 'key' ) {
+					expect( result[ identifierKey ] ).toBe(
+						testEntity[ identifierKey ]
+					);
+				}
+
 				expect( result.title ).toContain( '(copy)' );
 			} );
 

--- a/tests/e2e/abilities-internal-post-types.spec.ts
+++ b/tests/e2e/abilities-internal-post-types.spec.ts
@@ -54,6 +54,17 @@ const ENTITY_TYPES = [
 			menu_slug: 'e2e-test-options',
 		},
 	},
+	{
+		name: 'Field Group',
+		slug: 'field-group',
+		slugPlural: 'field-groups',
+		identifierKey: 'key',
+		testEntity: {
+			key: 'group_e2e_test',
+			title: 'E2E Test Field Group',
+			fields: [],
+		},
+	},
 ];
 
 // Shared helper functions

--- a/tests/php/post-types/test-class-acf-field-group.php
+++ b/tests/php/post-types/test-class-acf-field-group.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Tests for ACF_Field_Group::filter_posts() and ignore_location_rules flag.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+acf_include( '/includes/class-acf-internal-post-type.php' );
+acf_include( '/includes/post-types/class-acf-field-group.php' );
+
+/**
+ * Test ACF_Field_Group functionality.
+ */
+class Test_ACF_Field_Group extends BaseTestCase {
+
+	/**
+	 * Field group manager instance.
+	 *
+	 * @var ACF_Field_Group
+	 */
+	private $field_group;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->field_group = new ACF_Field_Group();
+	}
+
+	/**
+	 * Helper to create an in-memory field group array.
+	 *
+	 * @param string $key      Unique key for the field group.
+	 * @param array  $location Location rules array.
+	 * @param bool   $active   Whether the field group is active.
+	 * @return array The field group data.
+	 */
+	private function make_field_group( $key, $location = array(), $active = true ) {
+		return array(
+			'key'      => $key,
+			'title'    => 'Test Field Group ' . $key,
+			'fields'   => array(),
+			'location' => $location,
+			'active'   => $active,
+		);
+	}
+
+	/**
+	 * Test that ignore_location_rules returns all field groups.
+	 *
+	 * Location rules are a UX feature for edit screens, not access control.
+	 * When ignore_location_rules is true, all field groups should be returned
+	 * regardless of their location rules.
+	 */
+	public function test_ignore_location_rules_returns_all_field_groups() {
+		$fg_posts = $this->make_field_group(
+			'group_posts',
+			array(
+				array(
+					array(
+						'param'    => 'post_type',
+						'operator' => '==',
+						'value'    => 'post',
+					),
+				),
+			)
+		);
+
+		$fg_pages = $this->make_field_group(
+			'group_pages',
+			array(
+				array(
+					array(
+						'param'    => 'post_type',
+						'operator' => '==',
+						'value'    => 'page',
+					),
+				),
+			)
+		);
+
+		$fg_no_location = $this->make_field_group( 'group_no_location', array() );
+
+		$all_groups = array( $fg_posts, $fg_pages, $fg_no_location );
+
+		$result = $this->field_group->filter_posts(
+			$all_groups,
+			array( 'ignore_location_rules' => true )
+		);
+
+		$this->assertCount(
+			3,
+			$result,
+			'All field groups should be returned when ignore_location_rules is true'
+		);
+	}
+
+	/**
+	 * Test that active filter still works with ignore_location_rules.
+	 *
+	 * Even when bypassing location rules, the active filter should still apply.
+	 */
+	public function test_ignore_location_rules_respects_active_filter() {
+		$fg_active   = $this->make_field_group( 'group_active', array(), true );
+		$fg_inactive = $this->make_field_group( 'group_inactive', array(), false );
+
+		$all_groups = array( $fg_active, $fg_inactive );
+
+		$result = $this->field_group->filter_posts(
+			$all_groups,
+			array(
+				'ignore_location_rules' => true,
+				'active'                => true,
+			)
+		);
+
+		$this->assertCount( 1, $result, 'Only active field groups should be returned' );
+		$this->assertEquals( 'group_active', array_values( $result )[0]['key'] );
+	}
+
+	/**
+	 * Test that without ignore_location_rules, empty context filters out field groups.
+	 *
+	 * By default, filter_posts checks visibility based on location rules.
+	 * With no context provided, field groups with location rules won't match.
+	 */
+	public function test_default_behavior_filters_by_location_rules() {
+		$fg_with_location = $this->make_field_group(
+			'group_with_loc',
+			array(
+				array(
+					array(
+						'param'    => 'post_type',
+						'operator' => '==',
+						'value'    => 'post',
+					),
+				),
+			)
+		);
+
+		// Without ignore_location_rules and no matching context, visibility check fails.
+		$result = $this->field_group->filter_posts( array( $fg_with_location ), array() );
+
+		$this->assertCount(
+			0,
+			$result,
+			'Field groups should be filtered out when location rules do not match context'
+		);
+	}
+}


### PR DESCRIPTION
## What
Part of https://github.com/WordPress/secure-custom-fields/issues/171

Adds WordPress Abilities API support for UI Field Groups, enabling AI assistants and external tools to manage options pages programmatically.

## Why
Enables AI-powered workflows to create, read, update, delete, duplicate, import, and export Field Groups, maintaining consistency with the existing abilities implementation pattern.

## How
Follows the same pattern as the other abilities
- Added `SCF_Field_Group_Abilities ` class extending the base internal post type abilities
- Registered options pages abilities in the abilities integration class
- Added E2E tests covering all CRUD operations for options pages
- Excluded the abilities class from codecov, as it is only settings and the real execution happens in the base class

More granular abilities for managing individual fields might be updated later.

## Testing Instructions
1. Activate the plugin and ensure WordPress 6.9 with Abilities API support
2. Install the [MCP Adapter plugin](https://github.com/WordPress/mcp-adapter)
3. Create an application password
4. Use your favorite agent to connect to your site using the application password
5. List abilities, create a Field Group, duplicate it, update it, etc. through MCP