### PR TITLE
Improve abilities and JSON attribute descriptions

### DIFF
--- a/includes/abilities/class-scf-internal-post-type-abilities.php
+++ b/includes/abilities/class-scf-internal-post-type-abilities.php
@@ -300,7 +300,7 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 					),
 					'description'         => sprintf(
 						/* translators: %s: Entity type plural */
-						__( 'Retrieves a list of SCF %s with optional filtering.', 'secure-custom-fields' ),
+						__( 'Retrieves a list of SCF %s. Returns all if no filter provided.', 'secure-custom-fields' ),
 						$this->entity_name_plural()
 					),
 					'category'            => $this->ability_category(),
@@ -397,7 +397,7 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 					),
 					'description'         => sprintf(
 						/* translators: %s: Entity type */
-						__( 'Creates a new instance of SCF %s with provided configuration.', 'secure-custom-fields' ),
+						__( 'Creates a new instance of SCF %s with provided configuration. Omitted optional fields use schema defaults.', 'secure-custom-fields' ),
 						$this->entity_name()
 					),
 					'category'            => $this->ability_category(),
@@ -437,7 +437,7 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 					),
 					'description'         => sprintf(
 						/* translators: %s: Entity type */
-						__( 'Updates an existing instance of SCF %s with new configuration.', 'secure-custom-fields' ),
+						__( 'Updates an existing instance of SCF %s. Properties not provided are preserved (merge behavior).', 'secure-custom-fields' ),
 						$this->entity_name()
 					),
 					'category'            => $this->ability_category(),
@@ -524,7 +524,7 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 					),
 					'description'         => sprintf(
 						/* translators: %s: Entity type */
-						__( 'Creates a copy of SCF %s. Duplicate receives a new unique key.', 'secure-custom-fields' ),
+						__( 'Creates a copy of SCF %s with a new ID and unique key. Title gets (copy) appended. Active status is inherited from source.', 'secure-custom-fields' ),
 						$this->entity_name()
 					),
 					'category'            => $this->ability_category(),
@@ -545,7 +545,7 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 							'identifier'  => $this->get_scf_identifier_schema(),
 							'new_post_id' => array(
 								'type'        => 'integer',
-								'description' => __( 'Optional post ID for duplicate.', 'secure-custom-fields' ),
+								'description' => __( 'Optional ID of an existing post to overwrite. Used for import/sync operations.', 'secure-custom-fields' ),
 							),
 						),
 						'required'   => array( 'identifier' ),
@@ -571,7 +571,7 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 					),
 					'description'         => sprintf(
 						/* translators: %s: Entity type */
-						__( 'Exports an instance of SCF %s as JSON for backup or transfer.', 'secure-custom-fields' ),
+						__( 'Exports an instance of SCF %s as JSON for backup or transfer. Internal fields (ID, local, _valid) are stripped.', 'secure-custom-fields' ),
 						$this->entity_name()
 					),
 					'category'            => $this->ability_category(),
@@ -614,7 +614,7 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 					),
 					'description'         => sprintf(
 						/* translators: %s: Entity type */
-						__( 'Imports an instance of SCF %s from JSON data.', 'secure-custom-fields' ),
+						__( 'Imports an instance of SCF %s from JSON data. If ID is provided, updates existing; otherwise creates new with schema defaults for omitted fields.', 'secure-custom-fields' ),
 						$this->entity_name()
 					),
 					'category'            => $this->ability_category(),

--- a/schemas/common.schema.json
+++ b/schemas/common.schema.json
@@ -5,6 +5,7 @@
 	"description": "Shared definitions for SCF schemas",
 	"definitions": {
 		"wordpressReservedTerms": {
+			"description": "WordPress reserved terms that cannot be used as post type or taxonomy slugs. Using these terms will cause conflicts with WordPress core functionality.",
 			"enum": [
 				"action",
 				"attachment",

--- a/schemas/field-group.schema.json
+++ b/schemas/field-group.schema.json
@@ -36,12 +36,12 @@
 				"fields": {
 					"type": "array",
 					"items": { "$ref": "#/definitions/field" },
-					"description": "Array of field definitions"
+					"description": "Array of field definitions. If empty array, field group appears but contains no fields."
 				},
 				"location": {
 					"type": "array",
 					"items": { "$ref": "#/definitions/locationGroup" },
-					"description": "Location rules determining where this field group appears. Array of rule groups (OR logic between groups, AND logic within groups)."
+					"description": "Location rules determining where this field group appears. Array of rule groups (OR logic between groups, AND logic within groups). If omitted or empty, field group won't appear on any edit screens."
 				},
 				"menu_order": {
 					"type": "integer",

--- a/schemas/post-type.schema.json
+++ b/schemas/post-type.schema.json
@@ -70,7 +70,7 @@
 
 				"labels": {
 					"type": "object",
-					"description": "Labels for the post type in various contexts",
+					"description": "Labels for the post type in various contexts. If omitted, WordPress auto-generates labels from 'title'.",
 					"additionalProperties": false,
 					"properties": {
 						"name": {
@@ -250,7 +250,7 @@
 				},
 				"menu_position": {
 					"type": [ "integer", "string", "null" ],
-					"description": "The position in the menu order. SCF exports as empty string or null when not set, integer when set. Import accepts all types and casts to integer."
+					"description": "The position in the menu order. SCF exports as empty string or null when not set, integer when set. Import accepts all types and casts to integer. If omitted, appears below Comments in admin menu."
 				},
 				"menu_icon": {
 					"oneOf": [
@@ -276,7 +276,7 @@
 							"description": "[SCF] SCF icon object format: {\"type\": \"dashicons\", \"value\": \"dashicons-admin-post\"}"
 						}
 					],
-					"description": "The menu icon. Can be a string (URL or dashicon name) or SCF object format with type and value properties."
+					"description": "The menu icon. Can be a string (URL or dashicon name) or SCF object format with type and value properties. If omitted, uses default posts icon (dashicons-admin-post)."
 				},
 				"admin_menu_parent": {
 					"type": "string",
@@ -297,7 +297,7 @@
 					"type": "array",
 					"items": { "type": "string" },
 					"uniqueItems": true,
-					"description": "Core feature(s) the post type supports. Common values: 'title', 'editor', 'author', 'thumbnail', 'excerpt', 'trackbacks', 'custom-fields', 'comments', 'revisions', 'page-attributes', 'post-formats'. Custom supports are also allowed."
+					"description": "Core feature(s) the post type supports. Common values: 'title', 'editor', 'author', 'thumbnail', 'excerpt', 'trackbacks', 'custom-fields', 'comments', 'revisions', 'page-attributes', 'post-formats'. Custom supports are also allowed. If omitted, defaults to ['title', 'editor']."
 				},
 				"taxonomies": {
 					"anyOf": [

--- a/schemas/scf-identifier.schema.json
+++ b/schemas/scf-identifier.schema.json
@@ -6,7 +6,9 @@
 	"type": ["string", "integer"],
 	"examples": [
 		123,
+		"group_abc123",
 		"post_type_products",
-		"post_type_testimonials"
+		"taxonomy_product_categories",
+		"options_page_theme_settings"
 	]
 }

--- a/schemas/taxonomy.schema.json
+++ b/schemas/taxonomy.schema.json
@@ -79,12 +79,12 @@
 					"items": { "type": "string" },
 					"uniqueItems": true,
 					"default": [],
-					"description": "Post types to which this taxonomy should be attached (e.g. ['post', 'page', 'book'])"
+					"description": "Post types to which this taxonomy should be attached (e.g. ['post', 'page', 'book']). If empty, taxonomy exists but isn't usable from any post type."
 				},
 
 				"labels": {
 					"type": "object",
-					"description": "Labels for the taxonomy in various contexts",
+					"description": "Labels for the taxonomy in various contexts. If omitted, WordPress auto-generates labels from 'title'.",
 					"additionalProperties": false,
 					"properties": {
 						"name": {

--- a/schemas/ui-options-page.schema.json
+++ b/schemas/ui-options-page.schema.json
@@ -42,15 +42,15 @@
 
 				"page_title": {
 					"type": "string",
-					"description": "The page title displayed in the browser tab and page heading"
+					"description": "The page title displayed in the browser tab and page heading. If omitted, falls back to 'title'."
 				},
 				"parent_slug": {
 					"type": "string",
-					"description": "The parent menu slug. Use 'none' for top-level menu, or a WordPress admin menu slug (e.g. 'options-general.php') for submenu."
+					"description": "The parent menu slug. Use 'none' for top-level menu, or a WordPress admin menu slug (e.g. 'options-general.php') for submenu. If omitted, defaults to top-level menu."
 				},
 				"menu_title": {
 					"type": "string",
-					"description": "The title displayed in the admin menu"
+					"description": "The title displayed in the admin menu. If omitted, falls back to 'title'."
 				},
 
 				"active": {
@@ -112,11 +112,11 @@
 							"description": "Empty array representing unset/default state (no icon configured)."
 						}
 					],
-					"description": "The menu icon displayed in the admin menu. Accepts object format with type/value properties, or empty array when no icon is configured."
+					"description": "The menu icon displayed in the admin menu. Accepts object format with type/value properties, or empty array when no icon is configured. If omitted, uses default gear icon (dashicons-admin-generic)."
 				},
 				"position": {
 					"type": [ "integer", "string", "null" ],
-					"description": "The position in the menu where this page should appear. SCF exports as empty string or null when not set, integer when set."
+					"description": "The position in the menu where this page should appear. SCF exports as empty string or null when not set, integer when set. If omitted, appears at bottom of admin menu."
 				},
 				"redirect": {
 					"type": "boolean",


### PR DESCRIPTION
By playing with the MCP, I noticed the agent would usually not set options unless required in the input schema or asked by the user, sometimes resulting in valid yet suboptimal results, as LLM agents using the abilities API need clear descriptions to understand ability behavior and input options.

This PR fine-tunes some of the ability descriptions and expands JSON attribute descriptions, including being explicit about default results when omitted.

