### PR TITLE
Fix filtering by `active` status when listing internal post types

### DIFF
--- a/includes/class-acf-internal-post-type.php
+++ b/includes/class-acf-internal-post-type.php
@@ -443,11 +443,12 @@ if ( ! class_exists( 'ACF_Internal_Post_Type' ) ) {
 		 * @return array
 		 */
 		public function filter_posts( $posts, $args = array() ) {
-			if ( ! empty( $args['active'] ) ) {
-				$posts = array_filter(
+			if ( isset( $args['active'] ) ) {
+				$active_filter = $args['active'];
+				$posts         = array_filter(
 					$posts,
-					function ( $post ) {
-						return $post['active'];
+					function ( $post ) use ( $active_filter ) {
+						return $post['active'] === $active_filter;
 					}
 				);
 			}

--- a/tests/php/includes/test-class-acf-internal-post-type.php
+++ b/tests/php/includes/test-class-acf-internal-post-type.php
@@ -172,6 +172,111 @@ class Test_ACF_Internal_Post_Type extends BaseTestCase {
 	}
 
 	/**
+	 * Test filter_posts returns only active posts when active filter is true.
+	 *
+	 * Uses ignore_location_rules to test the parent's filter_posts method directly,
+	 * which is the code path used by the abilities API.
+	 */
+	public function test_filter_posts_with_active_true_returns_only_active() {
+		$posts = array(
+			array(
+				'key'    => 'group_active_1',
+				'title'  => 'Active Group 1',
+				'active' => true,
+			),
+			array(
+				'key'    => 'group_inactive_1',
+				'title'  => 'Inactive Group 1',
+				'active' => false,
+			),
+			array(
+				'key'    => 'group_active_2',
+				'title'  => 'Active Group 2',
+				'active' => true,
+			),
+		);
+
+		$filtered = $this->field_group->filter_posts(
+			$posts,
+			array(
+				'active'                => true,
+				'ignore_location_rules' => true,
+			)
+		);
+
+		$this->assertCount( 2, $filtered, 'Should return only active posts' );
+		foreach ( $filtered as $post ) {
+			$this->assertTrue( $post['active'], 'All filtered posts should be active' );
+		}
+	}
+
+	/**
+	 * Test filter_posts returns only inactive posts when active filter is false.
+	 *
+	 * This tests the bug where !empty(false) returns false, so the filter never runs.
+	 * Uses ignore_location_rules to test the parent's filter_posts method directly.
+	 */
+	public function test_filter_posts_with_active_false_returns_only_inactive() {
+		$posts = array(
+			array(
+				'key'    => 'group_active_1',
+				'title'  => 'Active Group 1',
+				'active' => true,
+			),
+			array(
+				'key'    => 'group_inactive_1',
+				'title'  => 'Inactive Group 1',
+				'active' => false,
+			),
+			array(
+				'key'    => 'group_active_2',
+				'title'  => 'Active Group 2',
+				'active' => true,
+			),
+		);
+
+		$filtered = $this->field_group->filter_posts(
+			$posts,
+			array(
+				'active'                => false,
+				'ignore_location_rules' => true,
+			)
+		);
+
+		$this->assertCount( 1, $filtered, 'Should return only inactive posts' );
+		foreach ( $filtered as $post ) {
+			$this->assertFalse( $post['active'], 'All filtered posts should be inactive' );
+		}
+	}
+
+	/**
+	 * Test filter_posts returns all posts when no active filter is provided.
+	 *
+	 * Uses ignore_location_rules to test the parent's filter_posts method directly.
+	 */
+	public function test_filter_posts_without_active_filter_returns_all() {
+		$posts = array(
+			array(
+				'key'    => 'group_active_1',
+				'title'  => 'Active Group 1',
+				'active' => true,
+			),
+			array(
+				'key'    => 'group_inactive_1',
+				'title'  => 'Inactive Group 1',
+				'active' => false,
+			),
+		);
+
+		$filtered = $this->field_group->filter_posts(
+			$posts,
+			array( 'ignore_location_rules' => true )
+		);
+
+		$this->assertCount( 2, $filtered, 'Should return all posts when no filter is applied' );
+	}
+
+	/**
 	 * Test post type duplication uses correct prefix (not group_).
 	 *
 	 * Post types should use 'post_type_' prefix, not the 'group_' prefix used by field groups.


### PR DESCRIPTION
## What
Fix filtering internal post types by `active: false`.

## Why
In the `filter_posts()` method, the filter was never applied when requesting inactive entities. This caused the abilities API to return all entities instead of only inactive ones when filtering by active: false

This path was never used in the codebase until the Abilities API, since rendering active/inactive items in the UI is done through queries.

## How
- Added strict comparison to filter by both true and false values
- Added unit tests

## Testing Instructions
1. Create two post types, one active and another inactive
2. Ask your AI agent to list all inactive ones. Before this fix, it returned all results, and the agent filtered locally; now it returns only one result.