### PR TITLE
Validate `new_post_id` parameter in duplicate ability

### DIFF
--- a/includes/abilities/class-scf-internal-post-type-abilities.php
+++ b/includes/abilities/class-scf-internal-post-type-abilities.php
@@ -756,7 +756,21 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 			}
 
 			$new_post_id = isset( $input['new_post_id'] ) ? $input['new_post_id'] : 0;
-			$duplicated  = $this->instance()->duplicate_post( $input['identifier'], $new_post_id );
+
+			// Validate that new_post_id references an existing WordPress post.
+			if ( $new_post_id && ! get_post( $new_post_id ) ) {
+				return new WP_Error(
+					'invalid_new_post_id',
+					sprintf(
+						/* translators: %d: Invalid post ID */
+						__( 'Invalid new_post_id: %d does not exist.', 'secure-custom-fields' ),
+						$new_post_id
+					),
+					array( 'status' => 400 )
+				);
+			}
+
+			$duplicated = $this->instance()->duplicate_post( $input['identifier'], $new_post_id );
 
 			if ( ! $duplicated ) {
 				return new WP_Error(

--- a/tests/php/includes/abilities/test-scf-internal-post-type-abilities.php
+++ b/tests/php/includes/abilities/test-scf-internal-post-type-abilities.php
@@ -846,6 +846,31 @@ class Test_SCF_Internal_Post_Type_Abilities extends BaseTestCase {
 	}
 
 	/**
+	 * Test duplicate_callback returns error when new_post_id is provided but doesn't exist
+	 */
+	public function test_duplicate_callback_returns_error_for_invalid_new_post_id() {
+		$this->inject_mock_instance(
+			array(
+				'get_post' => array(
+					'ID'  => 123,
+					'key' => 'test_key',
+				),
+			)
+		);
+
+		$result = $this->abilities->duplicate_callback(
+			array(
+				'identifier'  => 123,
+				'new_post_id' => 99999, // Non-existent WordPress post.
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'invalid_new_post_id', $result->get_error_code() );
+		$this->assertEquals( 400, $result->get_error_data()['status'] );
+	}
+
+	/**
 	 * Test export_callback succeeds when entity exists
 	 */
 	public function test_export_callback_success() {


### PR DESCRIPTION
## What
Adds input validation for the `new_post_id` parameter in the `duplicate` ability callback.

## Why
The `new_post_id` parameter accepts an integer to overwrite an existing post with the duplicate, but the ability did not validate that the referenced post actually exists.

## How
- Adding a validation check before calling `duplicate_post()` that verifies `new_post_id` exists
- Returning `WP_Error` with code `invalid_new_post_id` and HTTP 400 status when validation fails

## Testing Instructions
1. Call the duplicate ability with a valid entity identifier but an invalid `new_post_id`
2. Verify you receive a 400 error with code `invalid_new_post_id`
3. Call with a valid `new_post_id` or no `new_post_id` to confirm normal operation still works