### PR TITLE
Abilities: Add `trash` and `untrash` abilities for internal post types

### DIFF
--- a/includes/abilities/class-scf-internal-post-type-abilities.php
+++ b/includes/abilities/class-scf-internal-post-type-abilities.php
@@ -282,6 +282,8 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 			$this->register_duplicate_ability();
 			$this->register_export_ability();
 			$this->register_import_ability();
+			$this->register_trash_ability();
+			$this->register_untrash_ability();
 		}
 
 		/**
@@ -830,6 +832,122 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 				);
 			}
 			return $imported;
+		}
+
+		/**
+		 * Registers the trash ability.
+		 *
+		 * @return void
+		 */
+		private function register_trash_ability() {
+			wp_register_ability(
+				$this->ability_name( 'trash' ),
+				array(
+					'label'               => __( 'Trash', 'secure-custom-fields' ),
+					'description'         => __( 'Moves the item to trash. The item can be restored later using untrash.', 'secure-custom-fields' ),
+					'category'            => $this->ability_category(),
+					'execute_callback'    => array( $this, 'trash_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array( 'public' => true ),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => true,
+						),
+					),
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'identifier' => $this->get_scf_identifier_schema(),
+						),
+						'required'   => array( 'identifier' ),
+					),
+					'output_schema'       => array(
+						'type'        => 'boolean',
+						'description' => __( 'True if the item was trashed successfully.', 'secure-custom-fields' ),
+					),
+				)
+			);
+		}
+
+		/**
+		 * Handles the trash ability callback.
+		 *
+		 * @param array $input The input parameters.
+		 * @return bool|WP_Error True on success or error on failure.
+		 */
+		public function trash_callback( $input ) {
+			if ( ! $this->instance()->get_post( $input['identifier'] ) ) {
+				return $this->not_found_error();
+			}
+
+			if ( ! $this->instance()->trash_post( $input['identifier'] ) ) {
+				return new WP_Error(
+					'trash_failed',
+					__( 'Failed to trash the item.', 'secure-custom-fields' )
+				);
+			}
+			return true;
+		}
+
+		/**
+		 * Registers the untrash ability.
+		 *
+		 * @return void
+		 */
+		private function register_untrash_ability() {
+			wp_register_ability(
+				$this->ability_name( 'untrash' ),
+				array(
+					'label'               => __( 'Restore', 'secure-custom-fields' ),
+					'description'         => __( 'Restores the item from trash to its previous status.', 'secure-custom-fields' ),
+					'category'            => $this->ability_category(),
+					'execute_callback'    => array( $this, 'untrash_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array( 'public' => true ),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => true,
+						),
+					),
+					'permission_callback' => 'scf_current_user_has_capability',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'identifier' => $this->get_scf_identifier_schema(),
+						),
+						'required'   => array( 'identifier' ),
+					),
+					'output_schema'       => array(
+						'type'        => 'boolean',
+						'description' => __( 'True if the item was restored successfully.', 'secure-custom-fields' ),
+					),
+				)
+			);
+		}
+
+		/**
+		 * Handles the untrash ability callback.
+		 *
+		 * @param array $input The input parameters.
+		 * @return bool|WP_Error True on success or error on failure.
+		 */
+		public function untrash_callback( $input ) {
+			if ( ! $this->instance()->get_post( $input['identifier'] ) ) {
+				return $this->not_found_error();
+			}
+
+			if ( ! $this->instance()->untrash_post( $input['identifier'] ) ) {
+				return new WP_Error(
+					'untrash_failed',
+					__( 'Failed to restore the item.', 'secure-custom-fields' )
+				);
+			}
+			return true;
 		}
 
 		/**

--- a/includes/abilities/class-scf-internal-post-type-abilities.php
+++ b/includes/abilities/class-scf-internal-post-type-abilities.php
@@ -844,7 +844,11 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 				$this->ability_name( 'trash' ),
 				array(
 					'label'               => __( 'Trash', 'secure-custom-fields' ),
-					'description'         => __( 'Moves the item to trash. The item can be restored later using untrash.', 'secure-custom-fields' ),
+					'description'         => sprintf(
+						/* translators: %s: Entity type */
+						__( 'Moves SCF %s to trash. Can be restored using untrash.', 'secure-custom-fields' ),
+						$this->entity_name()
+					),
 					'category'            => $this->ability_category(),
 					'execute_callback'    => array( $this, 'trash_callback' ),
 					'meta'                => array(
@@ -866,7 +870,7 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 					),
 					'output_schema'       => array(
 						'type'        => 'boolean',
-						'description' => __( 'True if the item was trashed successfully.', 'secure-custom-fields' ),
+						'description' => __( 'True on success.', 'secure-custom-fields' ),
 					),
 				)
 			);
@@ -886,7 +890,7 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 			if ( ! $this->instance()->trash_post( $input['identifier'] ) ) {
 				return new WP_Error(
 					'trash_failed',
-					__( 'Failed to trash the item.', 'secure-custom-fields' )
+					__( 'Trash operation failed.', 'secure-custom-fields' )
 				);
 			}
 			return true;
@@ -902,7 +906,11 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 				$this->ability_name( 'untrash' ),
 				array(
 					'label'               => __( 'Restore', 'secure-custom-fields' ),
-					'description'         => __( 'Restores the item from trash to its previous status.', 'secure-custom-fields' ),
+					'description'         => sprintf(
+						/* translators: %s: Entity type */
+						__( 'Restores SCF %s from trash to previous status.', 'secure-custom-fields' ),
+						$this->entity_name()
+					),
 					'category'            => $this->ability_category(),
 					'execute_callback'    => array( $this, 'untrash_callback' ),
 					'meta'                => array(
@@ -924,7 +932,7 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 					),
 					'output_schema'       => array(
 						'type'        => 'boolean',
-						'description' => __( 'True if the item was restored successfully.', 'secure-custom-fields' ),
+						'description' => __( 'True on success.', 'secure-custom-fields' ),
 					),
 				)
 			);
@@ -944,7 +952,7 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 			if ( ! $this->instance()->untrash_post( $input['identifier'] ) ) {
 				return new WP_Error(
 					'untrash_failed',
-					__( 'Failed to restore the item.', 'secure-custom-fields' )
+					__( 'Restore operation failed.', 'secure-custom-fields' )
 				);
 			}
 			return true;

--- a/tests/php/includes/abilities/test-scf-internal-post-type-abilities.php
+++ b/tests/php/includes/abilities/test-scf-internal-post-type-abilities.php
@@ -240,6 +240,8 @@ class Test_SCF_Internal_Post_Type_Abilities extends BaseTestCase {
 			'scf/duplicate-taxonomy',
 			'scf/export-taxonomy',
 			'scf/import-taxonomy',
+			'scf/trash-taxonomy',
+			'scf/untrash-taxonomy',
 		);
 
 		foreach ( $expected_abilities as $ability_name ) {
@@ -356,6 +358,72 @@ class Test_SCF_Internal_Post_Type_Abilities extends BaseTestCase {
 		$meta        = $ability['meta'] ?? array();
 		$annotations = $meta['annotations'] ?? array();
 		$this->assertTrue( $annotations['readonly'] ?? false, 'Get ability should be marked readonly' );
+	}
+
+	/**
+	 * Test trash ability is marked as idempotent but not destructive
+	 */
+	public function test_trash_ability_is_idempotent() {
+		global $mock_registered_abilities;
+		$mock_registered_abilities = array();
+
+		$this->abilities->register_abilities();
+
+		$this->assertArrayHasKey( 'scf/trash-taxonomy', $mock_registered_abilities );
+		$ability     = $mock_registered_abilities['scf/trash-taxonomy'];
+		$meta        = $ability['meta'] ?? array();
+		$annotations = $meta['annotations'] ?? array();
+		$this->assertTrue( $annotations['idempotent'] ?? false, 'Trash ability should be marked idempotent' );
+		$this->assertFalse( $annotations['destructive'] ?? true, 'Trash ability should not be marked destructive' );
+		$this->assertFalse( $annotations['readonly'] ?? true, 'Trash ability should not be marked readonly' );
+	}
+
+	/**
+	 * Test untrash ability is marked as idempotent but not destructive
+	 */
+	public function test_untrash_ability_is_idempotent() {
+		global $mock_registered_abilities;
+		$mock_registered_abilities = array();
+
+		$this->abilities->register_abilities();
+
+		$this->assertArrayHasKey( 'scf/untrash-taxonomy', $mock_registered_abilities );
+		$ability     = $mock_registered_abilities['scf/untrash-taxonomy'];
+		$meta        = $ability['meta'] ?? array();
+		$annotations = $meta['annotations'] ?? array();
+		$this->assertTrue( $annotations['idempotent'] ?? false, 'Untrash ability should be marked idempotent' );
+		$this->assertFalse( $annotations['destructive'] ?? true, 'Untrash ability should not be marked destructive' );
+		$this->assertFalse( $annotations['readonly'] ?? true, 'Untrash ability should not be marked readonly' );
+	}
+
+	/**
+	 * Test trash ability has boolean output schema
+	 */
+	public function test_trash_ability_has_boolean_output_schema() {
+		global $mock_registered_abilities;
+		$mock_registered_abilities = array();
+
+		$this->abilities->register_abilities();
+
+		$this->assertArrayHasKey( 'scf/trash-taxonomy', $mock_registered_abilities );
+		$ability = $mock_registered_abilities['scf/trash-taxonomy'];
+		$this->assertArrayHasKey( 'output_schema', $ability );
+		$this->assertEquals( 'boolean', $ability['output_schema']['type'] );
+	}
+
+	/**
+	 * Test untrash ability has boolean output schema
+	 */
+	public function test_untrash_ability_has_boolean_output_schema() {
+		global $mock_registered_abilities;
+		$mock_registered_abilities = array();
+
+		$this->abilities->register_abilities();
+
+		$this->assertArrayHasKey( 'scf/untrash-taxonomy', $mock_registered_abilities );
+		$ability = $mock_registered_abilities['scf/untrash-taxonomy'];
+		$this->assertArrayHasKey( 'output_schema', $ability );
+		$this->assertEquals( 'boolean', $ability['output_schema']['type'] );
 	}
 
 	/**
@@ -978,6 +1046,104 @@ class Test_SCF_Internal_Post_Type_Abilities extends BaseTestCase {
 			array( $this->abilities, 'import_callback' ),
 			array( 'key' => 'test_key' ),
 			'import_failed'
+		);
+	}
+
+	/**
+	 * Test trash_callback returns WP_Error for non-existent entity
+	 */
+	public function test_trash_callback_not_found_returns_error() {
+		$this->assert_callback_error(
+			array( 'get_post' => null ),
+			array( $this->abilities, 'trash_callback' ),
+			array( 'identifier' => 999999 ),
+			'not_found'
+		);
+	}
+
+	/**
+	 * Test trash_callback succeeds when entity exists
+	 */
+	public function test_trash_callback_success() {
+		$this->inject_mock_instance(
+			array(
+				'get_post'   => array(
+					'ID'  => 123,
+					'key' => 'test_key',
+				),
+				'trash_post' => true,
+			)
+		);
+
+		$result = $this->abilities->trash_callback( array( 'identifier' => 123 ) );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test trash_callback returns error when trashing fails
+	 */
+	public function test_trash_callback_returns_error_on_failure() {
+		$this->assert_callback_error(
+			array(
+				'get_post'   => array(
+					'ID'  => 123,
+					'key' => 'test_key',
+				),
+				'trash_post' => false,
+			),
+			array( $this->abilities, 'trash_callback' ),
+			array( 'identifier' => 123 ),
+			'trash_failed'
+		);
+	}
+
+	/**
+	 * Test untrash_callback returns WP_Error for non-existent entity
+	 */
+	public function test_untrash_callback_not_found_returns_error() {
+		$this->assert_callback_error(
+			array( 'get_post' => null ),
+			array( $this->abilities, 'untrash_callback' ),
+			array( 'identifier' => 999999 ),
+			'not_found'
+		);
+	}
+
+	/**
+	 * Test untrash_callback succeeds when entity exists
+	 */
+	public function test_untrash_callback_success() {
+		$this->inject_mock_instance(
+			array(
+				'get_post'     => array(
+					'ID'  => 123,
+					'key' => 'test_key',
+				),
+				'untrash_post' => true,
+			)
+		);
+
+		$result = $this->abilities->untrash_callback( array( 'identifier' => 123 ) );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test untrash_callback returns error when restoring fails
+	 */
+	public function test_untrash_callback_returns_error_on_failure() {
+		$this->assert_callback_error(
+			array(
+				'get_post'     => array(
+					'ID'  => 123,
+					'key' => 'test_key',
+				),
+				'untrash_post' => false,
+			),
+			array( $this->abilities, 'untrash_callback' ),
+			array( 'identifier' => 123 ),
+			'untrash_failed'
 		);
 	}
 


### PR DESCRIPTION
## What
Adds `trash` and `untrash` abilities to the WordPress Abilities API for SCF internal post types.

## Why
MCP clients need the ability to move SCF entities to trash and restore them,  providing a reversible alternative to permanent deletion.

## How
Adding `register_trash_ability()` and `register_untrash_ability()` methods to the base class that delegate to existing `trash_post()` and `untrash_post()` internal post type base class methods. Both abilities are marked as idempotent but not destructive since trash operations are reversible.