### PR TITLE
JSON schemas polish: extract common properties and fix inconsistencies

### DIFF
--- a/includes/class-scf-json-schema-validator.php
+++ b/includes/class-scf-json-schema-validator.php
@@ -26,7 +26,7 @@ if ( ! class_exists( 'SCF_JSON_Schema_Validator' ) ) :
 		 *
 		 * @var array
 		 */
-		public const REQUIRED_SCHEMAS = array( 'post-type', 'taxonomy', 'ui-options-page', 'internal-fields', 'scf-identifier' );
+		public const REQUIRED_SCHEMAS = array( 'post-type', 'taxonomy', 'ui-options-page', 'field-group', 'internal-fields', 'scf-identifier' );
 
 		/**
 		 * The last validation errors.

--- a/schemas/common.schema.json
+++ b/schemas/common.schema.json
@@ -2,8 +2,46 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "https://raw.githubusercontent.com/WordPress/secure-custom-fields/trunk/schemas/common.schema.json",
 	"title": "SCF Common Definitions",
-	"description": "Shared definitions for SCF schemas",
+	"description": "Shared definitions for SCF schemas including common entity properties and reserved terms",
 	"definitions": {
+		"title": {
+			"type": "string",
+			"minLength": 1,
+			"maxLength": 255,
+			"description": "The title/name of this entity"
+		},
+		"menu_order": {
+			"type": "integer",
+			"minimum": 0,
+			"default": 0,
+			"description": "The order of this entity in the admin menu"
+		},
+
+		"active": {
+			"type": "boolean",
+			"default": true,
+			"description": "[SCF] Whether this entity is active"
+		},
+		"advanced_configuration": {
+			"type": [ "boolean", "integer" ],
+			"default": false,
+			"description": "[SCF] Whether advanced configuration options are enabled. Accepts boolean or integer (0/1)."
+		},
+
+		"modified": {
+			"type": "integer",
+			"minimum": 0,
+			"description": "[SCF Export Only] Unix timestamp of last modification"
+		},
+		"import_source": {
+			"type": "string",
+			"description": "[SCF Export Only] Source of import if this entity was imported"
+		},
+		"import_date": {
+			"type": "string",
+			"description": "[SCF Export Only] Date when this entity was imported"
+		},
+
 		"wordpressReservedTerms": {
 			"description": "WordPress reserved terms that cannot be used as post type or taxonomy slugs. Using these terms will cause conflicts with WordPress core functionality.",
 			"enum": [

--- a/schemas/field-group.schema.json
+++ b/schemas/field-group.schema.json
@@ -27,26 +27,19 @@
 					"minLength": 1,
 					"description": "Unique identifier for the field group with group_ prefix (e.g. 'group_abc123')"
 				},
-				"title": {
-					"type": "string",
-					"minLength": 1,
-					"maxLength": 255,
-					"description": "The title/name of the field group"
-				},
+				"title": { "$ref": "file://common.schema.json#/definitions/title" },
 				"fields": {
 					"type": "array",
 					"items": { "$ref": "#/definitions/field" },
 					"description": "Array of field definitions. If empty array, field group appears but contains no fields."
 				},
+				"menu_order": { "$ref": "file://common.schema.json#/definitions/menu_order" },
+				"active": { "$ref": "file://common.schema.json#/definitions/active" },
+				"modified": { "$ref": "file://common.schema.json#/definitions/modified" },
 				"location": {
 					"type": "array",
 					"items": { "$ref": "#/definitions/locationGroup" },
 					"description": "Location rules determining where this field group appears. Array of rule groups (OR logic between groups, AND logic within groups). If omitted or empty, field group won't appear on any edit screens."
-				},
-				"menu_order": {
-					"type": "integer",
-					"default": 0,
-					"description": "Order in which the field group appears"
 				},
 				"position": {
 					"type": "string",
@@ -97,11 +90,6 @@
 					"uniqueItems": true,
 					"description": "Screen elements to hide when this field group is displayed"
 				},
-				"active": {
-					"type": "boolean",
-					"default": true,
-					"description": "[SCF] Whether the field group is active"
-				},
 				"description": {
 					"type": "string",
 					"description": "Description of the field group"
@@ -114,10 +102,6 @@
 				"display_title": {
 					"type": "string",
 					"description": "Alternative display title for the field group"
-				},
-				"modified": {
-					"type": "integer",
-					"description": "[SCF Export Only] Unix timestamp of last modification"
 				}
 			}
 		},

--- a/schemas/field-group.schema.json
+++ b/schemas/field-group.schema.json
@@ -98,9 +98,9 @@
 					"description": "Screen elements to hide when this field group is displayed"
 				},
 				"active": {
-					"type": [ "boolean", "integer" ],
+					"type": "boolean",
 					"default": true,
-					"description": "Whether the field group is active"
+					"description": "[SCF] Whether the field group is active"
 				},
 				"description": {
 					"type": "string",

--- a/schemas/internal-fields.schema.json
+++ b/schemas/internal-fields.schema.json
@@ -24,7 +24,7 @@
 				},
 				"not_registered": {
 					"type": "boolean",
-					"description": "Flag indicating that this post entity could not be registered because another one with the same key already exists. Present only when registration was skipped."
+					"description": "Flag indicating that this entity could not be registered because another one with the same key already exists. Present only when registration was skipped."
 				}
 			},
 			"additionalProperties": false

--- a/schemas/post-type.schema.json
+++ b/schemas/post-type.schema.json
@@ -52,7 +52,7 @@
 				"advanced_configuration": {
 					"type": [ "boolean", "integer" ],
 					"default": false,
-					"description": "[SCF Export Only] Whether advanced configuration options are enabled. Accepts boolean or integer (0/1)."
+					"description": "[SCF] Whether advanced configuration options are enabled. Accepts boolean or integer (0/1)."
 				},
 				"import_source": {
 					"type": "string",
@@ -246,7 +246,7 @@
 					"type": "integer",
 					"minimum": 0,
 					"default": 0,
-					"description": "[SCF Export Only] The order of this post type in the admin menu"
+					"description": "The order of this post type in the admin menu"
 				},
 				"menu_position": {
 					"type": [ "integer", "string", "null" ],

--- a/schemas/post-type.schema.json
+++ b/schemas/post-type.schema.json
@@ -27,12 +27,7 @@
 					"minLength": 1,
 					"description": "Unique identifier for the post type with post_type_ prefix (e.g. 'post_type_book')"
 				},
-				"title": {
-					"type": "string",
-					"minLength": 1,
-					"maxLength": 255,
-					"description": "The title/name of the post type"
-				},
+				"title": { "$ref": "file://common.schema.json#/definitions/title" },
 				"post_type": {
 					"type": "string",
 					"pattern": "^[a-z0-9_-]+$",
@@ -43,30 +38,12 @@
 					},
 					"description": "The post type key passed to register_post_type() (e.g. 'book', 'product'). Max 20 characters, lowercase letters/numbers/underscores/dashes only, cannot be WordPress reserved terms."
 				},
-
-				"active": {
-					"type": "boolean",
-					"default": true,
-					"description": "[SCF] Whether this post type is active"
-				},
-				"advanced_configuration": {
-					"type": [ "boolean", "integer" ],
-					"default": false,
-					"description": "[SCF] Whether advanced configuration options are enabled. Accepts boolean or integer (0/1)."
-				},
-				"import_source": {
-					"type": "string",
-					"description": "[SCF Export Only] Source of import if this post type was imported"
-				},
-				"import_date": {
-					"type": "string",
-					"description": "[SCF Export Only] Date when this post type was imported"
-				},
-				"modified": {
-					"type": "integer",
-					"minimum": 0,
-					"description": "[SCF Export Only] Unix timestamp of last modification"
-				},
+				"menu_order": { "$ref": "file://common.schema.json#/definitions/menu_order" },
+				"active": { "$ref": "file://common.schema.json#/definitions/active" },
+				"advanced_configuration": { "$ref": "file://common.schema.json#/definitions/advanced_configuration" },
+				"modified": { "$ref": "file://common.schema.json#/definitions/modified" },
+				"import_source": { "$ref": "file://common.schema.json#/definitions/import_source" },
+				"import_date": { "$ref": "file://common.schema.json#/definitions/import_date" },
 
 				"labels": {
 					"type": "object",
@@ -241,12 +218,6 @@
 				"show_in_menu": {
 					"type": "boolean",
 					"description": "Where to show the post type in the admin menu"
-				},
-				"menu_order": {
-					"type": "integer",
-					"minimum": 0,
-					"default": 0,
-					"description": "The order of this post type in the admin menu"
 				},
 				"menu_position": {
 					"type": [ "integer", "string", "null" ],

--- a/schemas/scf-identifier.schema.json
+++ b/schemas/scf-identifier.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "scf-identifier.schema.json",
+	"$id": "https://raw.githubusercontent.com/WordPress/secure-custom-fields/trunk/schemas/scf-identifier.schema.json",
 	"title": "SCF Identifier",
 	"description": "Schema for SCF entity identifiers (post types, field groups, fields, taxonomies, etc.)",
 	"type": ["string", "integer"],
@@ -9,6 +9,6 @@
 		"group_abc123",
 		"post_type_products",
 		"taxonomy_product_categories",
-		"options_page_theme_settings"
+		"ui_options_page_theme_settings"
 	]
 }

--- a/schemas/taxonomy.schema.json
+++ b/schemas/taxonomy.schema.json
@@ -27,12 +27,7 @@
 					"minLength": 1,
 					"description": "Unique identifier for the taxonomy with taxonomy_ prefix (e.g. 'taxonomy_genre')"
 				},
-				"title": {
-					"type": "string",
-					"minLength": 1,
-					"maxLength": 255,
-					"description": "The title/name of the taxonomy"
-				},
+				"title": { "$ref": "file://common.schema.json#/definitions/title" },
 				"taxonomy": {
 					"type": "string",
 					"pattern": "^[a-z0-9_-]*$",
@@ -44,35 +39,12 @@
 					"description": "The taxonomy key passed to register_taxonomy() (e.g. 'genre', 'product_tag'). Max 32 characters, lowercase letters/numbers/underscores/dashes only, cannot be WordPress reserved terms."
 				},
 
-				"active": {
-					"type": "boolean",
-					"default": true,
-					"description": "[SCF] Whether this taxonomy is active"
-				},
-				"advanced_configuration": {
-					"type": [ "boolean", "integer" ],
-					"default": false,
-					"description": "[SCF] Whether advanced configuration options are enabled. Accepts boolean or integer (0/1)."
-				},
-				"import_source": {
-					"type": "string",
-					"description": "[SCF Export Only] Source of import if this taxonomy was imported"
-				},
-				"import_date": {
-					"type": "string",
-					"description": "[SCF Export Only] Date when this taxonomy was imported"
-				},
-				"modified": {
-					"type": "integer",
-					"minimum": 0,
-					"description": "[SCF Export Only] Unix timestamp of last modification"
-				},
-				"menu_order": {
-					"type": "integer",
-					"minimum": 0,
-					"default": 0,
-					"description": "The order of this taxonomy in the admin menu"
-				},
+				"menu_order": { "$ref": "file://common.schema.json#/definitions/menu_order" },
+				"active": { "$ref": "file://common.schema.json#/definitions/active" },
+				"advanced_configuration": { "$ref": "file://common.schema.json#/definitions/advanced_configuration" },
+				"modified": { "$ref": "file://common.schema.json#/definitions/modified" },
+				"import_source": { "$ref": "file://common.schema.json#/definitions/import_source" },
+				"import_date": { "$ref": "file://common.schema.json#/definitions/import_date" },
 
 				"object_type": {
 					"type": "array",

--- a/schemas/taxonomy.schema.json
+++ b/schemas/taxonomy.schema.json
@@ -52,7 +52,7 @@
 				"advanced_configuration": {
 					"type": [ "boolean", "integer" ],
 					"default": false,
-					"description": "[SCF Export Only] Whether advanced configuration options are enabled. Accepts boolean or integer (0/1)."
+					"description": "[SCF] Whether advanced configuration options are enabled. Accepts boolean or integer (0/1)."
 				},
 				"import_source": {
 					"type": "string",
@@ -71,7 +71,7 @@
 					"type": "integer",
 					"minimum": 0,
 					"default": 0,
-					"description": "[SCF Export Only] The order of this taxonomy in the admin menu"
+					"description": "The order of this taxonomy in the admin menu"
 				},
 
 				"object_type": {

--- a/schemas/ui-options-page.schema.json
+++ b/schemas/ui-options-page.schema.json
@@ -61,7 +61,7 @@
 				"advanced_configuration": {
 					"type": [ "boolean", "integer" ],
 					"default": false,
-					"description": "[SCF Export Only] Whether advanced configuration options are enabled. Accepts boolean or integer (0/1)."
+					"description": "[SCF] Whether advanced configuration options are enabled. Accepts boolean or integer (0/1)."
 				},
 				"import_source": {
 					"type": "string",
@@ -80,7 +80,7 @@
 					"type": "integer",
 					"minimum": 0,
 					"default": 0,
-					"description": "[SCF Export Only] The order of this options page in the admin menu"
+					"description": "The order of this options page in the admin menu"
 				},
 
 				"icon_url": {

--- a/schemas/ui-options-page.schema.json
+++ b/schemas/ui-options-page.schema.json
@@ -27,18 +27,19 @@
 					"minLength": 1,
 					"description": "Unique identifier for the options page with ui_options_page_ prefix (e.g. 'ui_options_page_site_settings')"
 				},
-				"title": {
-					"type": "string",
-					"minLength": 1,
-					"maxLength": 255,
-					"description": "The title/name of the options page"
-				},
+				"title": { "$ref": "file://common.schema.json#/definitions/title" },
 				"menu_slug": {
 					"type": "string",
 					"pattern": "^[a-z0-9_-]+$",
 					"minLength": 1,
 					"description": "The menu slug used in the admin URL (e.g. 'site-settings'). Lowercase letters, numbers, underscores, and dashes only."
 				},
+				"menu_order": { "$ref": "file://common.schema.json#/definitions/menu_order" },
+				"active": { "$ref": "file://common.schema.json#/definitions/active" },
+				"advanced_configuration": { "$ref": "file://common.schema.json#/definitions/advanced_configuration" },
+				"modified": { "$ref": "file://common.schema.json#/definitions/modified" },
+				"import_source": { "$ref": "file://common.schema.json#/definitions/import_source" },
+				"import_date": { "$ref": "file://common.schema.json#/definitions/import_date" },
 
 				"page_title": {
 					"type": "string",
@@ -51,36 +52,6 @@
 				"menu_title": {
 					"type": "string",
 					"description": "The title displayed in the admin menu. If omitted, falls back to 'title'."
-				},
-
-				"active": {
-					"type": "boolean",
-					"default": true,
-					"description": "[SCF] Whether this options page is active"
-				},
-				"advanced_configuration": {
-					"type": [ "boolean", "integer" ],
-					"default": false,
-					"description": "[SCF] Whether advanced configuration options are enabled. Accepts boolean or integer (0/1)."
-				},
-				"import_source": {
-					"type": "string",
-					"description": "[SCF Export Only] Source of import if this options page was imported"
-				},
-				"import_date": {
-					"type": "string",
-					"description": "[SCF Export Only] Date when this options page was imported"
-				},
-				"modified": {
-					"type": "integer",
-					"minimum": 0,
-					"description": "[SCF Export Only] Unix timestamp of last modification"
-				},
-				"menu_order": {
-					"type": "integer",
-					"minimum": 0,
-					"default": 0,
-					"description": "The order of this options page in the admin menu"
 				},
 
 				"icon_url": {

--- a/tests/php/schemas/FieldGroupSchemaTest.php
+++ b/tests/php/schemas/FieldGroupSchemaTest.php
@@ -192,15 +192,6 @@ class FieldGroupSchemaTest extends BaseSchemaTestCase {
 				),
 				'Field group with active as boolean should be valid',
 			),
-			'active as integer'             => array(
-				array(
-					'key'    => 'group_active_int',
-					'title'  => 'Active Integer',
-					'fields' => array(),
-					'active' => 1,
-				),
-				'Field group with active as integer should be valid',
-			),
 			'show_in_rest boolean'          => array(
 				array(
 					'key'          => 'group_rest_bool',


### PR DESCRIPTION
## What
Refactors JSON schemas to extract shared properties and fixes some schema inconsistencies.

## Why
Reduces duplication across entity schemas and ensures consistent property definitions.

## How
Extracting common properties to `common.schema.json` and updated entity schemas to reference them via `$ref`.

## Testing Instructions
Run `vendor/bin/phpunit tests/php/schemas/` to verify all schema tests pass
