### PR TITLE
Add `SCF_Field_Manager` adapter class for Field operations

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -37,5 +37,6 @@ ignore:
     - 'tests'
     - 'vendor'
     # Individual file exclusions
+    - 'secure-custom-fields.php' # Bootstrap/initialization code
     - 'includes/abilities/class-scf-ui-options-page-abilities.php' # Thin wrapper - logic tested via base class
     - 'includes/abilities/class-scf-field-group-abilities.php' # Thin wrapper - logic tested via base class

--- a/includes/post-types/class-scf-field-manager.php
+++ b/includes/post-types/class-scf-field-manager.php
@@ -2,9 +2,7 @@
 /**
  * SCF Field Manager
  *
- * Adapter class that wraps ACF field functions to provide the same interface
- * as ACF_Internal_Post_Type. This enables Field abilities to reuse the base
- * SCF_Internal_Post_Type_Abilities class.
+ * Manages field operations by wrapping ACF field functions.
  *
  * @package wordpress/secure-custom-fields
  * @since 6.8.0
@@ -19,10 +17,6 @@ if ( ! class_exists( 'SCF_Field_Manager' ) ) :
 
 	/**
 	 * SCF Field Manager class.
-	 *
-	 * Provides an interface compatible with ACF_Internal_Post_Type for field
-	 * operations, allowing the abilities system to treat fields like other
-	 * internal post types.
 	 *
 	 * @since 6.8.0
 	 */

--- a/includes/post-types/class-scf-field-manager.php
+++ b/includes/post-types/class-scf-field-manager.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * SCF Field Manager
+ *
+ * Adapter class that wraps ACF field functions to provide the same interface
+ * as ACF_Internal_Post_Type. This enables Field abilities to reuse the base
+ * SCF_Internal_Post_Type_Abilities class.
+ *
+ * @package wordpress/secure-custom-fields
+ * @since 6.8.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'SCF_Field_Manager' ) ) :
+
+	/**
+	 * SCF Field Manager class.
+	 *
+	 * Provides an interface compatible with ACF_Internal_Post_Type for field
+	 * operations, allowing the abilities system to treat fields like other
+	 * internal post types.
+	 *
+	 * @since 6.8.0
+	 */
+	class SCF_Field_Manager {
+
+		/**
+		 * The post type for fields.
+		 *
+		 * @var string
+		 */
+		public $post_type = 'acf-field';
+
+		/**
+		 * The key prefix for fields.
+		 *
+		 * @var string
+		 */
+		public $post_key_prefix = 'field_';
+
+		/**
+		 * Gets a field by ID or key.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param int|string $id The field ID or key.
+		 * @return array|false The field array or false if not found.
+		 */
+		public function get_post( $id = 0 ) {
+			return acf_get_field( $id );
+		}
+
+		/**
+		 * Gets all fields across all field groups.
+		 *
+		 * Unlike internal post types which are top-level, fields are children
+		 * of field groups. This method aggregates fields from all field groups.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @return array Array of all fields.
+		 */
+		public function get_posts() {
+			$all_fields   = array();
+			$field_groups = acf_get_field_groups();
+
+			foreach ( $field_groups as $field_group ) {
+				$fields = acf_get_fields( $field_group );
+				if ( $fields ) {
+					$all_fields = array_merge( $all_fields, $fields );
+				}
+			}
+
+			return $all_fields;
+		}
+
+		/**
+		 * Filters fields based on provided arguments.
+		 *
+		 * Supports filtering by:
+		 * - parent: Field group ID or key
+		 * - type: Field type (text, image, etc.)
+		 * - name: Field name
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param array $posts Array of fields to filter.
+		 * @param array $args  Filter arguments.
+		 * @return array Filtered fields.
+		 */
+		public function filter_posts( $posts, $args = array() ) {
+			if ( isset( $args['parent'] ) ) {
+				$parent_filter = $args['parent'];
+				$posts         = array_filter(
+					$posts,
+					function ( $post ) use ( $parent_filter ) {
+						return $post['parent'] === $parent_filter;
+					}
+				);
+			}
+
+			if ( isset( $args['type'] ) ) {
+				$type_filter = $args['type'];
+				$posts       = array_filter(
+					$posts,
+					function ( $post ) use ( $type_filter ) {
+						return $post['type'] === $type_filter;
+					}
+				);
+			}
+
+			if ( isset( $args['name'] ) ) {
+				$name_filter = $args['name'];
+				$posts       = array_filter(
+					$posts,
+					function ( $post ) use ( $name_filter ) {
+						return $post['name'] === $name_filter;
+					}
+				);
+			}
+
+			return array_values( $posts );
+		}
+
+		/**
+		 * Updates or creates a field.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param array $field The field data.
+		 * @return array|false The updated field or false on failure.
+		 */
+		public function update_post( $field ) {
+			return acf_update_field( $field );
+		}
+
+		/**
+		 * Permanently deletes a field.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param int|string $id The field ID or key.
+		 * @return bool True on success, false on failure.
+		 */
+		public function delete_post( $id = 0 ) {
+			return acf_delete_field( $id );
+		}
+
+		/**
+		 * Moves a field to trash.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param int|string $id The field ID or key.
+		 * @return bool True on success, false on failure.
+		 */
+		public function trash_post( $id = 0 ) {
+			return acf_trash_field( $id );
+		}
+
+		/**
+		 * Restores a field from trash.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param int|string $id The field ID or key.
+		 * @return bool True on success, false on failure.
+		 */
+		public function untrash_post( $id = 0 ) {
+			return acf_untrash_field( $id );
+		}
+
+		/**
+		 * Duplicates a field.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param int|string $id          The field ID or key to duplicate.
+		 * @param int        $new_post_id Optional parent ID for the duplicate.
+		 * @return array|false The duplicated field or false on failure.
+		 */
+		public function duplicate_post( $id = 0, $new_post_id = 0 ) {
+			$field = $this->get_post( $id );
+			if ( ! $field ) {
+				return false;
+			}
+
+			$parent_id = $new_post_id ? $new_post_id : $field['parent'];
+			return acf_duplicate_field( $field['ID'], $parent_id );
+		}
+
+		/**
+		 * Prepares a field for export.
+		 *
+		 * Strips internal fields (ID, local, _valid) that shouldn't be exported.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param array $field The field to prepare.
+		 * @return array The prepared field.
+		 */
+		public function prepare_post_for_export( $field = array() ) {
+			acf_extract_vars( $field, array( 'ID', 'local', '_valid', '_name', 'prefix', 'value', 'id', 'class' ) );
+
+			/** This filter is documented in includes/acf-field-group-functions.php */
+			return apply_filters( 'acf/prepare_field_for_export', $field );
+		}
+
+		/**
+		 * Imports a field.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param array $field The field data to import.
+		 * @return array|false The imported field or false on failure.
+		 */
+		public function import_post( $field ) {
+			$filters = acf_disable_filters();
+			$field   = acf_validate_field( $field );
+			$field   = acf_update_field( $field );
+			acf_enable_filters( $filters );
+
+			/** This action is documented in includes/acf-field-group-functions.php */
+			do_action( 'acf/import_field', $field );
+
+			return $field;
+		}
+	}
+
+endif;

--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -247,8 +247,9 @@ if ( ! class_exists( 'ACF' ) ) {
 			acf_include( 'includes/blocks.php' );
 			acf_include( 'includes/class-acf-options-page.php' );
 
-			// Include field group class.
+			// Include field group and field manager classes.
 			acf_include( 'includes/post-types/class-acf-field-group.php' );
+			acf_include( 'includes/post-types/class-scf-field-manager.php' );
 
 			// Include ajax.
 			acf_include( 'includes/ajax/class-acf-ajax.php' );

--- a/tests/php/post-types/SCFFieldManagerTest.php
+++ b/tests/php/post-types/SCFFieldManagerTest.php
@@ -286,11 +286,36 @@ class SCFFieldManagerTest extends BaseTestCase {
 	}
 
 	/**
-	 * Test get_posts returns an array.
+	 * Test get_posts returns fields from all field groups.
 	 */
-	public function test_get_posts_returns_array() {
+	public function test_get_posts_returns_fields_from_field_groups() {
+		acf_add_local_field_group(
+			array(
+				'key'    => 'group_local_test',
+				'title'  => 'Local Test Group',
+				'fields' => array(
+					array(
+						'key'   => 'field_local_1',
+						'name'  => 'local_field_1',
+						'type'  => 'text',
+						'label' => 'Local Field 1',
+					),
+					array(
+						'key'   => 'field_local_2',
+						'name'  => 'local_field_2',
+						'type'  => 'text',
+						'label' => 'Local Field 2',
+					),
+				),
+			)
+		);
+
 		$result = $this->manager->get_posts();
+
 		$this->assertIsArray( $result );
+		$keys = array_column( $result, 'key' );
+		$this->assertContains( 'field_local_1', $keys );
+		$this->assertContains( 'field_local_2', $keys );
 	}
 
 	/**

--- a/tests/php/post-types/SCFFieldManagerTest.php
+++ b/tests/php/post-types/SCFFieldManagerTest.php
@@ -284,4 +284,104 @@ class SCFFieldManagerTest extends BaseTestCase {
 		$this->manager->untrash_post( $field['ID'] );
 		$this->assertTrue( $called );
 	}
+
+	/**
+	 * Test get_posts returns an array.
+	 */
+	public function test_get_posts_returns_array() {
+		$result = $this->manager->get_posts();
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Test duplicate_post duplicates a field.
+	 */
+	public function test_duplicate_post_duplicates_field() {
+		$group = acf_update_field_group(
+			array(
+				'key'    => 'group_dup_test',
+				'title'  => 'Dup Test Group',
+				'fields' => array(),
+			)
+		);
+
+		$field = acf_update_field(
+			array(
+				'key'    => 'field_to_dup',
+				'name'   => 'to_dup',
+				'type'   => 'text',
+				'label'  => 'To Duplicate',
+				'parent' => $group['key'],
+			)
+		);
+
+		$duplicate = $this->manager->duplicate_post( $field['ID'] );
+
+		$this->assertIsArray( $duplicate );
+		$this->assertNotEquals( $field['key'], $duplicate['key'] );
+		$this->assertEquals( 'to_dup', $duplicate['name'] );
+	}
+
+	/**
+	 * Test prepare_post_for_export strips internal fields.
+	 */
+	public function test_prepare_post_for_export_strips_internal_fields() {
+		$field = array(
+			'key'    => 'field_export_test',
+			'name'   => 'export_test',
+			'type'   => 'text',
+			'label'  => 'Export Test',
+			'ID'     => 123,
+			'local'  => true,
+			'_valid' => 1,
+			'_name'  => 'internal_name',
+			'prefix' => 'acf',
+			'value'  => 'some value',
+			'id'     => 'acf-field_export_test',
+			'class'  => 'acf-field',
+		);
+
+		$result = $this->manager->prepare_post_for_export( $field );
+
+		$this->assertArrayNotHasKey( 'ID', $result );
+		$this->assertArrayNotHasKey( 'local', $result );
+		$this->assertArrayNotHasKey( '_valid', $result );
+		$this->assertArrayHasKey( 'key', $result );
+		$this->assertArrayHasKey( 'name', $result );
+	}
+
+	/**
+	 * Test import_post imports a field.
+	 */
+	public function test_import_post_imports_field() {
+		$group = acf_update_field_group(
+			array(
+				'key'    => 'group_import_test',
+				'title'  => 'Import Test Group',
+				'fields' => array(),
+			)
+		);
+
+		$called = false;
+		add_action(
+			'acf/import_field',
+			function () use ( &$called ) {
+				$called = true;
+			}
+		);
+
+		$result = $this->manager->import_post(
+			array(
+				'key'    => 'field_imported',
+				'name'   => 'imported_field',
+				'type'   => 'text',
+				'label'  => 'Imported Field',
+				'parent' => $group['key'],
+			)
+		);
+
+		$this->assertTrue( $called );
+		$this->assertIsArray( $result );
+		$this->assertEquals( 'field_imported', $result['key'] );
+	}
 }

--- a/tests/php/post-types/SCFFieldManagerTest.php
+++ b/tests/php/post-types/SCFFieldManagerTest.php
@@ -1,0 +1,287 @@
+<?php
+/**
+ * Tests for SCF_Field_Manager class.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+require_once dirname( __DIR__, 3 ) . '/includes/post-types/class-scf-field-manager.php';
+
+/**
+ * SCF_Field_Manager test case.
+ */
+class SCFFieldManagerTest extends BaseTestCase {
+
+	/**
+	 * Manager instance.
+	 *
+	 * @var SCF_Field_Manager
+	 */
+	private $manager;
+
+	/**
+	 * Sample fields.
+	 *
+	 * @var array
+	 */
+	private $sample_fields;
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->manager       = new SCF_Field_Manager();
+		$this->sample_fields = array(
+			array(
+				'key'    => 'field_1',
+				'name'   => 'text_field',
+				'type'   => 'text',
+				'parent' => 'group_123',
+			),
+			array(
+				'key'    => 'field_2',
+				'name'   => 'image_field',
+				'type'   => 'image',
+				'parent' => 'group_123',
+			),
+			array(
+				'key'    => 'field_3',
+				'name'   => 'another_text',
+				'type'   => 'text',
+				'parent' => 'group_456',
+			),
+			array(
+				'key'    => 'field_4',
+				'name'   => 'email_field',
+				'type'   => 'email',
+				'parent' => 'group_456',
+			),
+		);
+	}
+
+	/**
+	 * Create a test field.
+	 *
+	 * @param string $key Field key suffix.
+	 * @return array
+	 */
+	private function create_test_field( $key ) {
+		return acf_update_field(
+			array(
+				'key'   => 'field_' . $key,
+				'name'  => $key,
+				'type'  => 'text',
+				'label' => ucfirst( $key ),
+			)
+		);
+	}
+
+	/**
+	 * Test filter_posts with no filters.
+	 */
+	public function test_filter_posts_no_filters() {
+		$result = $this->manager->filter_posts( $this->sample_fields );
+		$this->assertCount( 4, $result );
+	}
+
+	/**
+	 * Test filter_posts by parent.
+	 */
+	public function test_filter_posts_by_parent() {
+		$result = $this->manager->filter_posts( $this->sample_fields, array( 'parent' => 'group_123' ) );
+
+		$this->assertCount( 2, $result );
+		foreach ( $result as $field ) {
+			$this->assertEquals( 'group_123', $field['parent'] );
+		}
+	}
+
+	/**
+	 * Test filter_posts by type.
+	 */
+	public function test_filter_posts_by_type() {
+		$result = $this->manager->filter_posts( $this->sample_fields, array( 'type' => 'text' ) );
+
+		$this->assertCount( 2, $result );
+		foreach ( $result as $field ) {
+			$this->assertEquals( 'text', $field['type'] );
+		}
+	}
+
+	/**
+	 * Test filter_posts by name.
+	 */
+	public function test_filter_posts_by_name() {
+		$result = $this->manager->filter_posts( $this->sample_fields, array( 'name' => 'email_field' ) );
+
+		$this->assertCount( 1, $result );
+		$this->assertEquals( 'email_field', $result[0]['name'] );
+	}
+
+	/**
+	 * Test filter_posts with multiple filters.
+	 */
+	public function test_filter_posts_multiple_filters() {
+		$result = $this->manager->filter_posts(
+			$this->sample_fields,
+			array(
+				'parent' => 'group_123',
+				'type'   => 'text',
+			)
+		);
+
+		$this->assertCount( 1, $result );
+		$this->assertEquals( 'field_1', $result[0]['key'] );
+	}
+
+	/**
+	 * Test filter_posts with no matches.
+	 */
+	public function test_filter_posts_no_matches() {
+		$result = $this->manager->filter_posts( $this->sample_fields, array( 'type' => 'nonexistent' ) );
+		$this->assertCount( 0, $result );
+	}
+
+	/**
+	 * Test filter_posts reindexes keys.
+	 */
+	public function test_filter_posts_reindexes_keys() {
+		$result = $this->manager->filter_posts( $this->sample_fields, array( 'parent' => 'group_456' ) );
+
+		$this->assertArrayHasKey( 0, $result );
+		$this->assertArrayHasKey( 1, $result );
+		$this->assertArrayNotHasKey( 2, $result );
+	}
+
+	/**
+	 * Test filter_posts with empty input.
+	 */
+	public function test_filter_posts_empty_input() {
+		$result = $this->manager->filter_posts( array(), array( 'type' => 'text' ) );
+		$this->assertCount( 0, $result );
+	}
+
+	/**
+	 * Test post_type property.
+	 */
+	public function test_post_type_property() {
+		$this->assertEquals( 'acf-field', $this->manager->post_type );
+	}
+
+	/**
+	 * Test post_key_prefix property.
+	 */
+	public function test_post_key_prefix_property() {
+		$this->assertEquals( 'field_', $this->manager->post_key_prefix );
+	}
+
+	/**
+	 * Test duplicate_post returns false when field not found.
+	 */
+	public function test_duplicate_post_returns_false_when_field_not_found() {
+		$this->assertFalse( $this->manager->duplicate_post( 'nonexistent_field' ) );
+	}
+
+	/**
+	 * Test get_post calls acf_get_field.
+	 */
+	public function test_get_post_calls_acf_get_field() {
+		$field       = $this->create_test_field( 'get_test' );
+		$called_with = null;
+
+		add_filter(
+			'acf/load_field',
+			function ( $f ) use ( &$called_with ) {
+				$called_with = $f;
+				return $f;
+			}
+		);
+
+		$this->manager->get_post( $field['ID'] );
+		$this->assertEquals( 'field_get_test', $called_with['key'] );
+	}
+
+	/**
+	 * Test update_post calls acf_update_field.
+	 */
+	public function test_update_post_calls_acf_update_field() {
+		$called_with = null;
+
+		add_filter(
+			'acf/update_field',
+			function ( $field ) use ( &$called_with ) {
+				$called_with = $field;
+				return $field;
+			}
+		);
+
+		$this->manager->update_post(
+			array(
+				'key'   => 'field_update_test',
+				'name'  => 'update_test',
+				'type'  => 'text',
+				'label' => 'Update Test',
+			)
+		);
+
+		$this->assertEquals( 'field_update_test', $called_with['key'] );
+	}
+
+	/**
+	 * Test delete_post calls acf_delete_field.
+	 */
+	public function test_delete_post_calls_acf_delete_field() {
+		$field  = $this->create_test_field( 'delete_test' );
+		$called = false;
+
+		add_action(
+			'acf/delete_field',
+			function () use ( &$called ) {
+				$called = true;
+			}
+		);
+
+		$this->manager->delete_post( $field['ID'] );
+		$this->assertTrue( $called );
+	}
+
+	/**
+	 * Test trash_post calls acf_trash_field.
+	 */
+	public function test_trash_post_calls_acf_trash_field() {
+		$field  = $this->create_test_field( 'trash_test' );
+		$called = false;
+
+		add_action(
+			'acf/trash_field',
+			function () use ( &$called ) {
+				$called = true;
+			}
+		);
+
+		$this->manager->trash_post( $field['ID'] );
+		$this->assertTrue( $called );
+	}
+
+	/**
+	 * Test untrash_post calls acf_untrash_field.
+	 */
+	public function test_untrash_post_calls_acf_untrash_field() {
+		$field = $this->create_test_field( 'untrash_test' );
+		acf_trash_field( $field['ID'] );
+		$called = false;
+
+		add_action(
+			'acf/untrash_field',
+			function () use ( &$called ) {
+				$called = true;
+			}
+		);
+
+		$this->manager->untrash_post( $field['ID'] );
+		$this->assertTrue( $called );
+	}
+}


### PR DESCRIPTION
## What

Adds `SCF_Field_Manager`, an adapter class that provides a unified CRUD interface for field operations.

## Why

Although Fields are not internal post types, they need to participate in the abilities system just like field groups and other internal post types so that updating a Field can be done directly without interacting with the parent Field Group. This adapter allows fields to reuse the existing abilities infrastructure.

## How

Created `SCF_Field_Manager` class that wraps ACF field functions (`acf_get_field`, `acf_update_field`, etc.) with the same interface as `ACF_Internal_Post_Type`. The class aggregates fields from all field groups via `get_posts()` and supports filtering by parent, type, and name.

## Testing Instructions

1. Run `vendor/bin/phpunit tests/php/post-types/SCFFieldManagerTest.php`
2. All 20 tests should pass