### PR TITLE
JSON Schemas: Make them draft-07 compliant with fully working `$ref`s

### DIFF
--- a/.github/workflows/verify-field-schema.yml
+++ b/.github/workflows/verify-field-schema.yml
@@ -1,0 +1,38 @@
+name: Verify Field Schema
+
+on:
+  push:
+    branches:
+      - trunk
+      - 'branch/*'
+    paths:
+      - 'schemas/field-fragments/**'
+      - 'schemas/field.schema.json'
+      - 'bin/generate-field-schema.php'
+      - 'includes/class-scf-schema-builder.php'
+  pull_request:
+    branches:
+      - trunk
+      - 'branch/*'
+    paths:
+      - 'schemas/field-fragments/**'
+      - 'schemas/field.schema.json'
+      - 'bin/generate-field-schema.php'
+      - 'includes/class-scf-schema-builder.php'
+
+jobs:
+  verify-schema:
+    name: Verify field.schema.json is in sync
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+
+      - name: Verify field.schema.json is in sync with fragments
+        run: php bin/generate-field-schema.php --check

--- a/bin/generate-field-schema.php
+++ b/bin/generate-field-schema.php
@@ -1,0 +1,78 @@
+#!/usr/bin/env php
+<?php
+// phpcs:ignoreFile -- CLI script runs outside WordPress, can't use WP functions.
+/**
+ * Generates the composed field.schema.json from fragments.
+ *
+ * This script reuses SCF_Schema_Builder::compose_field_schema() to ensure
+ * the generated schema matches runtime behavior exactly.
+ *
+ * Usage:
+ *   php bin/generate-field-schema.php          # Generate the schema
+ *   php bin/generate-field-schema.php --check  # Verify schema is in sync
+ *
+ * @package SCF
+ */
+
+$check_mode = in_array( '--check', $argv, true );
+
+// Bootstrap minimal SCF environment.
+define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+define( 'ACF_PATH', dirname( __DIR__ ) . '/' );
+
+// Load the Schema Builder (auto-initialization is skipped outside WordPress).
+require_once ACF_PATH . 'includes/class-scf-schema-builder.php';
+
+// Load base schema for structure and shared definitions.
+$base_path = ACF_PATH . 'schemas/field-fragments/field-base.schema.json';
+$base      = json_decode( file_get_contents( $base_path ), true );
+
+if ( ! $base ) {
+	fwrite( STDERR, "Error: Could not load base schema from {$base_path}\n" );
+	exit( 1 );
+}
+
+// Get composed field definition from builder.
+$builder            = new SCF_Schema_Builder();
+$composed_field_def = $builder->compose_field_schema();
+
+// Remove 'parent' from each variant's required array.
+// - Standalone fields (validated via top-level oneOf) require parent because
+// the UI always creates fields with a parent - you can't create orphan fields.
+// - Fields inside field groups (validated via #/definitions/field) don't need
+// parent in the JSON because it's implicit from the field group context.
+foreach ( $composed_field_def['oneOf'] as &$variant ) {
+	if ( isset( $variant['required'] ) ) {
+		$variant['required'] = array_values(
+			array_diff( $variant['required'], array( 'parent' ) )
+		);
+	}
+}
+unset( $variant );
+
+// Use base schema as wrapper, replacing definitions/field with composed version.
+$schema                         = $base;
+$schema['$id']                  = 'https://raw.githubusercontent.com/WordPress/secure-custom-fields/trunk/schemas/field.schema.json';
+$schema['title']                = 'SCF Field';
+$schema['description']          = 'Schema for Secure Custom Fields field definitions. Auto-generated from field-fragments/.';
+$schema['definitions']['field'] = $composed_field_def;
+
+// Remove the $comment from generated file (it's only relevant for the source).
+unset( $schema['$comment'] );
+
+$output      = json_encode( $schema, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n";
+$output_path = ACF_PATH . 'schemas/field.schema.json';
+
+if ( $check_mode ) {
+	$current = file_exists( $output_path ) ? file_get_contents( $output_path ) : '';
+	if ( $current !== $output ) {
+		fwrite( STDERR, "Error: field.schema.json is out of sync with fragments!\n" );
+		fwrite( STDERR, "Run: php bin/generate-field-schema.php\n" );
+		exit( 1 );
+	}
+	echo "field.schema.json is in sync.\n";
+	exit( 0 );
+}
+
+file_put_contents( $output_path, $output );
+echo "Generated: schemas/field.schema.json\n";

--- a/includes/abilities/class-scf-field-abilities.php
+++ b/includes/abilities/class-scf-field-abilities.php
@@ -106,9 +106,8 @@ if ( ! class_exists( 'SCF_Field_Abilities' ) ) :
 		/**
 		 * Gets the composed field schema with oneOf variants for each field type.
 		 *
-		 * Uses SCF_Schema_Builder to build a schema where each field type has
-		 * its own complete variant, allowing WordPress Abilities to validate
-		 * type-specific properties.
+		 * Loads the generated field.schema.json and resolves internal refs
+		 * (like conditionalLogicGroup) for WordPress Abilities API compatibility.
 		 *
 		 * @since 6.8.0
 		 *
@@ -116,8 +115,14 @@ if ( ! class_exists( 'SCF_Field_Abilities' ) ) :
 		 */
 		private function get_field_schema() {
 			if ( null === $this->field_schema ) {
+				$schema_path    = ACF_PATH . 'schemas/field.schema.json';
+				$schema_content = file_get_contents( $schema_path );
+				$schema         = json_decode( $schema_content, true );
+				$field_def      = $schema['definitions']['field'] ?? array();
+
+				// Resolve internal refs (conditionalLogicGroup, etc.) at runtime.
 				$builder            = acf_get_instance( 'SCF_Schema_Builder' );
-				$this->field_schema = $builder->compose_field_schema();
+				$this->field_schema = $builder->resolve_refs( $field_def, $schema );
 			}
 			return $this->field_schema;
 		}

--- a/includes/class-scf-json-schema-validator.php
+++ b/includes/class-scf-json-schema-validator.php
@@ -94,23 +94,27 @@ if ( ! class_exists( 'SCF_JSON_Schema_Validator' ) ) :
 				$data = json_decode( wp_json_encode( $data ) );
 			}
 
-			// Create schema storage and register schemas for $ref support
+			// Create schema storage and register schemas for $ref support.
+			// Use full file:// URIs so relative refs resolve correctly within the schemas directory.
 			$schema_storage = new JsonSchema\SchemaStorage();
 
-			// Register common schema
+			// Build base URI for the schemas directory.
+			$schemas_base_uri = 'file://' . realpath( $this->schema_path ) . '/';
+
+			// Register common schema (referenced by post-type, taxonomy, ui-options-page, field-group).
 			$common_schema_path    = $this->schema_path . 'common.schema.json';
 			$common_schema_content = wp_json_file_decode( $common_schema_path );
-			$schema_storage->addSchema( 'file://common.schema.json', $common_schema_content );
+			$schema_storage->addSchema( $schemas_base_uri . 'common.schema.json', $common_schema_content );
 
-			// Register field schema (needed for field-group schema $ref)
+			// Register field schema (referenced by field-group).
 			$field_schema_path    = $this->schema_path . 'field.schema.json';
 			$field_schema_content = wp_json_file_decode( $field_schema_path );
 			if ( $field_schema_content ) {
-				$schema_storage->addSchema( 'file://field.schema.json', $field_schema_content );
+				$schema_storage->addSchema( $schemas_base_uri . 'field.schema.json', $field_schema_content );
 			}
 
-			// Register main schema
-			$main_schema_uri = 'file://' . $schema_name . '.schema.json';
+			// Register main schema with full path so relative refs resolve to sibling schemas.
+			$main_schema_uri = $schemas_base_uri . $schema_name . '.schema.json';
 			$schema_storage->addSchema( $main_schema_uri, $schema );
 
 			$validator = new JsonSchema\Validator( new JsonSchema\Constraints\Factory( $schema_storage ) );

--- a/includes/class-scf-schema-builder.php
+++ b/includes/class-scf-schema-builder.php
@@ -55,7 +55,7 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 		 * Recursively resolves $ref references in a JSON schema.
 		 *
 		 * WordPress internal validation doesn't understand JSON Schema $ref,
-		 * so we need to inline referenced definitions.
+		 * so we inline referenced definitions before passing schemas to WP.
 		 *
 		 * @since 6.8.0
 		 *
@@ -64,44 +64,21 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 		 * @return array The resolved schema.
 		 */
 		public function resolve_refs( array $schema, ?array $root_schema = null ): array {
-			// Use the schema itself as root if not provided (first call).
-			if ( null === $root_schema ) {
-				$root_schema = $schema;
-			}
-
+			$root_schema = $root_schema ?? $schema;
 			$definitions = $root_schema['definitions'] ?? array();
 
-			// If this is a $ref, resolve it.
-			if ( isset( $schema['$ref'] ) ) {
-				$ref = $schema['$ref'];
-				// Extract definition name from "#/definitions/name".
-				if ( preg_match( '~^#/definitions/(.+)$~', $ref, $matches ) ) {
-					$def_name = $matches[1];
-					if ( isset( $definitions[ $def_name ] ) ) {
-						// Recursively resolve refs in the referenced definition.
-						$resolved = $this->resolve_refs( $definitions[ $def_name ], $root_schema );
-						// Merge any additional properties from the original schema.
-						unset( $schema['$ref'] );
-						return array_merge( $resolved, $schema );
-					}
+			if ( isset( $schema['$ref'] ) && preg_match( '~^#/definitions/(.+)$~', $schema['$ref'], $matches ) ) {
+				$resolved = $definitions;
+				foreach ( explode( '/', $matches[1] ) as $part ) {
+					$resolved = $resolved[ $part ] ?? null;
 				}
 
-				// Log warning for unresolvable $ref.
-				_doing_it_wrong(
-					__METHOD__,
-					esc_html(
-						sprintf(
-							/* translators: %s: The unresolvable JSON Schema $ref value */
-							__( 'Could not resolve schema $ref: %s', 'secure-custom-fields' ),
-							$ref
-						)
-					),
-					'6.8.0'
-				);
-				return $schema;
+				if ( is_array( $resolved ) ) {
+					unset( $schema['$ref'] );
+					return array_merge( $this->resolve_refs( $resolved, $root_schema ), $schema );
+				}
 			}
 
-			// Recursively process all array elements.
 			foreach ( $schema as $key => $value ) {
 				if ( is_array( $value ) ) {
 					$schema[ $key ] = $this->resolve_refs( $value, $root_schema );

--- a/includes/class-scf-schema-builder.php
+++ b/includes/class-scf-schema-builder.php
@@ -57,31 +57,59 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 		 * WordPress internal validation doesn't understand JSON Schema $ref,
 		 * so we inline referenced definitions before passing schemas to WP.
 		 *
+		 * Supports two ref formats:
+		 * - Internal refs: #/definitions/foo (resolved from root_schema)
+		 * - Relative file refs: file.schema.json#/definitions/foo (loaded from base_path)
+		 *
 		 * @since 6.8.0
 		 *
-		 * @param array      $schema      The schema to resolve.
-		 * @param array|null $root_schema The root schema containing definitions. If null, uses $schema.
+		 * @param array       $schema      The schema to resolve.
+		 * @param array|null  $root_schema The root schema containing definitions. If null, uses $schema.
+		 * @param string|null $base_path   Base path for loading external schema files. Defaults to schemas/.
 		 * @return array The resolved schema.
 		 */
-		public function resolve_refs( array $schema, ?array $root_schema = null ): array {
+		public function resolve_refs( array $schema, ?array $root_schema = null, ?string $base_path = null ): array {
 			$root_schema = $root_schema ?? $schema;
 			$definitions = $root_schema['definitions'] ?? array();
+			$base_path   = $base_path ?? acf_get_path( 'schemas/' );
 
-			if ( isset( $schema['$ref'] ) && preg_match( '~^#/definitions/(.+)$~', $schema['$ref'], $matches ) ) {
-				$resolved = $definitions;
-				foreach ( explode( '/', $matches[1] ) as $part ) {
-					$resolved = $resolved[ $part ] ?? null;
+			if ( isset( $schema['$ref'] ) ) {
+				$ref      = $schema['$ref'];
+				$resolved = null;
+
+				// Internal ref: #/definitions/path/to/def
+				if ( preg_match( '~^#/definitions/(.+)$~', $ref, $matches ) ) {
+					$resolved = $definitions;
+					foreach ( explode( '/', $matches[1] ) as $part ) {
+						$resolved = $resolved[ $part ] ?? null;
+					}
+				} elseif ( preg_match( '~^([^#]+)#/definitions/(.+)$~', $ref, $matches ) ) {
+					// Relative file ref: file.schema.json#/definitions/path/to/def
+					$file_path = $base_path . $matches[1];
+					$def_path  = $matches[2];
+
+					if ( file_exists( $file_path ) ) {
+						$external_content = file_get_contents( $file_path );
+						$external_schema  = json_decode( $external_content, true );
+
+						if ( is_array( $external_schema ) ) {
+							$resolved = $external_schema['definitions'] ?? array();
+							foreach ( explode( '/', $def_path ) as $part ) {
+								$resolved = $resolved[ $part ] ?? null;
+							}
+						}
+					}
 				}
 
 				if ( is_array( $resolved ) ) {
 					unset( $schema['$ref'] );
-					return array_merge( $this->resolve_refs( $resolved, $root_schema ), $schema );
+					return array_merge( $this->resolve_refs( $resolved, $root_schema, $base_path ), $schema );
 				}
 			}
 
 			foreach ( $schema as $key => $value ) {
 				if ( is_array( $value ) ) {
-					$schema[ $key ] = $this->resolve_refs( $value, $root_schema );
+					$schema[ $key ] = $this->resolve_refs( $value, $root_schema, $base_path );
 				}
 			}
 

--- a/includes/class-scf-schema-builder.php
+++ b/includes/class-scf-schema-builder.php
@@ -30,8 +30,8 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 	 * - Fallback variant allows unknown types until all 35 field types have schemas
 	 *
 	 * Schema structure:
-	 * - schemas/field.schema.json: Base properties shared by all types
-	 * - schemas/fields/{category}/{type}.schema.json: Type-specific properties
+	 * - schemas/field-fragments/field-base.schema.json: Base properties shared by all types
+	 * - schemas/field-fragments/{category}/{type}.schema.json: Type-specific properties
 	 *
 	 * @since 6.8.0
 	 */
@@ -151,17 +151,19 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 		}
 
 		/**
-		 * Loads and resolves the base field schema.
+		 * Loads the base field schema without resolving refs.
+		 *
+		 * Refs are kept intact so the generated field.schema.json stays compact.
+		 * Consumers (like Field Abilities) resolve refs at runtime when needed.
 		 *
 		 * @since 6.8.0
 		 *
-		 * @return array The base field schema with refs resolved.
+		 * @return array The base field schema with refs intact.
 		 */
 		private function load_base_field_schema(): array {
 			if ( null === $this->base_schema ) {
-				$schema_path       = ACF_PATH . 'schemas/field.schema.json';
+				$schema_path       = ACF_PATH . 'schemas/field-fragments/field-base.schema.json';
 				$this->base_schema = json_decode( file_get_contents( $schema_path ), true );
-				$this->base_schema = $this->resolve_refs( $this->base_schema );
 			}
 
 			return $this->base_schema;
@@ -170,7 +172,7 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 		/**
 		 * Loads all type-specific field schemas from category directories.
 		 *
-		 * Scans schemas/fields/{category}/ directories for type schema files.
+		 * Scans schemas/field-fragments/{category}/ directories for type schema files.
 		 *
 		 * @since 6.8.0
 		 *
@@ -178,7 +180,7 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 		 */
 		private function load_type_schemas(): array {
 			$schemas     = array();
-			$fields_path = ACF_PATH . 'schemas/fields/';
+			$fields_path = ACF_PATH . 'schemas/field-fragments/';
 
 			if ( ! is_dir( $fields_path ) || ! is_readable( $fields_path ) ) {
 				return $schemas;
@@ -220,7 +222,9 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 		}
 	}
 
-	// Initialize builder instance.
-	acf_new_instance( 'SCF_Schema_Builder' );
+	// Initialize only in WordPress context, not in the CLI.
+	if ( function_exists( 'acf_new_instance' ) ) {
+		acf_new_instance( 'SCF_Schema_Builder' );
+	}
 
 endif;

--- a/includes/class-scf-schema-builder.php
+++ b/includes/class-scf-schema-builder.php
@@ -179,15 +179,10 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 		 * @return array Associative array of type => schema data.
 		 */
 		private function load_type_schemas(): array {
-			$schemas     = array();
-			$fields_path = ACF_PATH . 'schemas/field-fragments/';
-
-			if ( ! is_dir( $fields_path ) || ! is_readable( $fields_path ) ) {
-				return $schemas;
-			}
-
-			// Get category directories using glob (safer than scandir).
+			$schemas       = array();
+			$fields_path   = ACF_PATH . 'schemas/field-fragments/';
 			$category_dirs = glob( $fields_path . '*', GLOB_ONLYDIR );
+
 			if ( ! is_array( $category_dirs ) ) {
 				return $schemas;
 			}

--- a/schemas/field-fragments/basic/text.schema.json
+++ b/schemas/field-fragments/basic/text.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://raw.githubusercontent.com/WordPress/secure-custom-fields/trunk/schemas/fields/basic/text.schema.json",
+	"$id": "https://raw.githubusercontent.com/WordPress/secure-custom-fields/trunk/schemas/field-fragments/basic/text.schema.json",
 	"title": "SCF Text Field",
 	"description": "Type-specific properties for text fields",
 	"type": "object",

--- a/schemas/field-fragments/field-base.schema.json
+++ b/schemas/field-fragments/field-base.schema.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://raw.githubusercontent.com/WordPress/secure-custom-fields/trunk/schemas/field.schema.json",
-	"title": "SCF Field",
-	"description": "Schema for Secure Custom Fields field definitions. Validates field structure and base properties. Type-specific field properties are allowed but not strictly validated.",
+	"$id": "https://raw.githubusercontent.com/WordPress/secure-custom-fields/trunk/schemas/field-fragments/field-base.schema.json",
+	"title": "SCF Field Base",
+	"description": "Base field schema with shared properties and definitions. Used by the generation script to compose field.schema.json.",
 	"$comment": "WordPress doesn't support 'allOf', so we use '$ref' with explicit 'required' arrays. Since PHP's array_merge() replaces (not merges) nested arrays, we must redeclare all required fields from the definition plus 'parent'.",
 	"oneOf": [
 		{

--- a/schemas/field-group.schema.json
+++ b/schemas/field-group.schema.json
@@ -27,15 +27,15 @@
 					"minLength": 1,
 					"description": "Unique identifier for the field group with group_ prefix (e.g. 'group_abc123')"
 				},
-				"title": { "$ref": "file://common.schema.json#/definitions/title" },
+				"title": { "$ref": "common.schema.json#/definitions/title" },
 				"fields": {
 					"type": "array",
-					"items": { "$ref": "file://field.schema.json#/definitions/field" },
+					"items": { "$ref": "field.schema.json#/definitions/field" },
 					"description": "Array of field definitions. If empty array, field group appears but contains no fields."
 				},
-				"menu_order": { "$ref": "file://common.schema.json#/definitions/menu_order" },
-				"active": { "$ref": "file://common.schema.json#/definitions/active" },
-				"modified": { "$ref": "file://common.schema.json#/definitions/modified" },
+				"menu_order": { "$ref": "common.schema.json#/definitions/menu_order" },
+				"active": { "$ref": "common.schema.json#/definitions/active" },
+				"modified": { "$ref": "common.schema.json#/definitions/modified" },
 				"location": {
 					"type": "array",
 					"items": { "$ref": "#/definitions/locationGroup" },

--- a/schemas/field.schema.json
+++ b/schemas/field.schema.json
@@ -1,0 +1,381 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://raw.githubusercontent.com/WordPress/secure-custom-fields/trunk/schemas/field.schema.json",
+    "title": "SCF Field",
+    "description": "Schema for Secure Custom Fields field definitions. Auto-generated from field-fragments/.",
+    "oneOf": [
+        {
+            "description": "Single field object with required parent",
+            "$ref": "#/definitions/field",
+            "required": [
+                "key",
+                "label",
+                "name",
+                "type",
+                "parent"
+            ]
+        },
+        {
+            "description": "Array of field objects with required parent",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/field",
+                "required": [
+                    "key",
+                    "label",
+                    "name",
+                    "type",
+                    "parent"
+                ]
+            },
+            "minItems": 1
+        }
+    ],
+    "definitions": {
+        "field": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "text"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "default_value": {
+                            "type": "string",
+                            "default": "",
+                            "description": "Default value for the field"
+                        },
+                        "maxlength": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ],
+                            "default": "",
+                            "description": "Maximum character length (empty string for unlimited)"
+                        },
+                        "placeholder": {
+                            "type": "string",
+                            "default": "",
+                            "description": "Placeholder text shown when field is empty"
+                        },
+                        "prepend": {
+                            "type": "string",
+                            "default": "",
+                            "description": "Text or HTML displayed before the input"
+                        },
+                        "append": {
+                            "type": "string",
+                            "default": "",
+                            "description": "Text or HTML displayed after the input"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "textarea",
+                                "number",
+                                "range",
+                                "email",
+                                "url",
+                                "password",
+                                "image",
+                                "file",
+                                "wysiwyg",
+                                "oembed",
+                                "gallery",
+                                "select",
+                                "checkbox",
+                                "radio",
+                                "button_group",
+                                "true_false",
+                                "link",
+                                "post_object",
+                                "page_link",
+                                "relationship",
+                                "taxonomy",
+                                "user",
+                                "google_map",
+                                "date_picker",
+                                "date_time_picker",
+                                "time_picker",
+                                "color_picker",
+                                "icon_picker",
+                                "message",
+                                "accordion",
+                                "tab",
+                                "group",
+                                "repeater",
+                                "flexible_content",
+                                "clone",
+                                "nav_menu",
+                                "separator",
+                                "output"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        }
+                    },
+                    "additionalProperties": true
+                }
+            ]
+        },
+        "conditionalLogicGroup": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/conditionalLogicRule"
+            },
+            "minItems": 1,
+            "description": "Group of conditional logic rules (AND logic within group)"
+        },
+        "conditionalLogicRule": {
+            "type": "object",
+            "required": [
+                "field",
+                "operator"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "field": {
+                    "type": "string",
+                    "pattern": "^field_.+$",
+                    "description": "Field key to check"
+                },
+                "operator": {
+                    "type": "string",
+                    "enum": [
+                        "==",
+                        "!=",
+                        "!==",
+                        "==empty",
+                        "!=empty",
+                        "==pattern",
+                        "==contains",
+                        "!=contains",
+                        "<",
+                        ">"
+                    ],
+                    "description": "Comparison operator"
+                },
+                "value": {
+                    "type": "string",
+                    "description": "Value to compare against (not required for ==empty and !=empty operators)"
+                }
+            }
+        }
+    }
+}

--- a/schemas/post-type.schema.json
+++ b/schemas/post-type.schema.json
@@ -27,23 +27,23 @@
 					"minLength": 1,
 					"description": "Unique identifier for the post type with post_type_ prefix (e.g. 'post_type_book')"
 				},
-				"title": { "$ref": "file://common.schema.json#/definitions/title" },
+				"title": { "$ref": "common.schema.json#/definitions/title" },
 				"post_type": {
 					"type": "string",
 					"pattern": "^[a-z0-9_-]+$",
 					"minLength": 1,
 					"maxLength": 20,
 					"not": {
-						"$ref": "file://common.schema.json#/definitions/wordpressReservedTerms"
+						"$ref": "common.schema.json#/definitions/wordpressReservedTerms"
 					},
 					"description": "The post type key passed to register_post_type() (e.g. 'book', 'product'). Max 20 characters, lowercase letters/numbers/underscores/dashes only, cannot be WordPress reserved terms."
 				},
-				"menu_order": { "$ref": "file://common.schema.json#/definitions/menu_order" },
-				"active": { "$ref": "file://common.schema.json#/definitions/active" },
-				"advanced_configuration": { "$ref": "file://common.schema.json#/definitions/advanced_configuration" },
-				"modified": { "$ref": "file://common.schema.json#/definitions/modified" },
-				"import_source": { "$ref": "file://common.schema.json#/definitions/import_source" },
-				"import_date": { "$ref": "file://common.schema.json#/definitions/import_date" },
+				"menu_order": { "$ref": "common.schema.json#/definitions/menu_order" },
+				"active": { "$ref": "common.schema.json#/definitions/active" },
+				"advanced_configuration": { "$ref": "common.schema.json#/definitions/advanced_configuration" },
+				"modified": { "$ref": "common.schema.json#/definitions/modified" },
+				"import_source": { "$ref": "common.schema.json#/definitions/import_source" },
+				"import_date": { "$ref": "common.schema.json#/definitions/import_date" },
 
 				"labels": {
 					"type": "object",

--- a/schemas/taxonomy.schema.json
+++ b/schemas/taxonomy.schema.json
@@ -27,24 +27,24 @@
 					"minLength": 1,
 					"description": "Unique identifier for the taxonomy with taxonomy_ prefix (e.g. 'taxonomy_genre')"
 				},
-				"title": { "$ref": "file://common.schema.json#/definitions/title" },
+				"title": { "$ref": "common.schema.json#/definitions/title" },
 				"taxonomy": {
 					"type": "string",
 					"pattern": "^[a-z0-9_-]*$",
 					"minLength": 1,
 					"maxLength": 32,
 					"not": {
-						"$ref": "file://common.schema.json#/definitions/wordpressReservedTerms"
+						"$ref": "common.schema.json#/definitions/wordpressReservedTerms"
 					},
 					"description": "The taxonomy key passed to register_taxonomy() (e.g. 'genre', 'product_tag'). Max 32 characters, lowercase letters/numbers/underscores/dashes only, cannot be WordPress reserved terms."
 				},
 
-				"menu_order": { "$ref": "file://common.schema.json#/definitions/menu_order" },
-				"active": { "$ref": "file://common.schema.json#/definitions/active" },
-				"advanced_configuration": { "$ref": "file://common.schema.json#/definitions/advanced_configuration" },
-				"modified": { "$ref": "file://common.schema.json#/definitions/modified" },
-				"import_source": { "$ref": "file://common.schema.json#/definitions/import_source" },
-				"import_date": { "$ref": "file://common.schema.json#/definitions/import_date" },
+				"menu_order": { "$ref": "common.schema.json#/definitions/menu_order" },
+				"active": { "$ref": "common.schema.json#/definitions/active" },
+				"advanced_configuration": { "$ref": "common.schema.json#/definitions/advanced_configuration" },
+				"modified": { "$ref": "common.schema.json#/definitions/modified" },
+				"import_source": { "$ref": "common.schema.json#/definitions/import_source" },
+				"import_date": { "$ref": "common.schema.json#/definitions/import_date" },
 
 				"object_type": {
 					"type": "array",

--- a/schemas/ui-options-page.schema.json
+++ b/schemas/ui-options-page.schema.json
@@ -27,19 +27,19 @@
 					"minLength": 1,
 					"description": "Unique identifier for the options page with ui_options_page_ prefix (e.g. 'ui_options_page_site_settings')"
 				},
-				"title": { "$ref": "file://common.schema.json#/definitions/title" },
+				"title": { "$ref": "common.schema.json#/definitions/title" },
 				"menu_slug": {
 					"type": "string",
 					"pattern": "^[a-z0-9_-]+$",
 					"minLength": 1,
 					"description": "The menu slug used in the admin URL (e.g. 'site-settings'). Lowercase letters, numbers, underscores, and dashes only."
 				},
-				"menu_order": { "$ref": "file://common.schema.json#/definitions/menu_order" },
-				"active": { "$ref": "file://common.schema.json#/definitions/active" },
-				"advanced_configuration": { "$ref": "file://common.schema.json#/definitions/advanced_configuration" },
-				"modified": { "$ref": "file://common.schema.json#/definitions/modified" },
-				"import_source": { "$ref": "file://common.schema.json#/definitions/import_source" },
-				"import_date": { "$ref": "file://common.schema.json#/definitions/import_date" },
+				"menu_order": { "$ref": "common.schema.json#/definitions/menu_order" },
+				"active": { "$ref": "common.schema.json#/definitions/active" },
+				"advanced_configuration": { "$ref": "common.schema.json#/definitions/advanced_configuration" },
+				"modified": { "$ref": "common.schema.json#/definitions/modified" },
+				"import_source": { "$ref": "common.schema.json#/definitions/import_source" },
+				"import_date": { "$ref": "common.schema.json#/definitions/import_date" },
 
 				"page_title": {
 					"type": "string",

--- a/tests/php/includes/SCFSchemaBuilderTest.php
+++ b/tests/php/includes/SCFSchemaBuilderTest.php
@@ -122,11 +122,9 @@ class SCFSchemaBuilderTest extends BaseTestCase {
 	}
 
 	/**
-	 * Test resolve_refs triggers _doing_it_wrong for unresolvable $ref.
-	 *
-	 * @expectedIncorrectUsage SCF_Schema_Builder::resolve_refs
+	 * Test resolve_refs returns original schema for unresolvable $ref.
 	 */
-	public function test_resolve_refs_triggers_doing_it_wrong_for_missing_definition() {
+	public function test_resolve_refs_returns_original_for_missing_definition() {
 		$schema = array(
 			'$ref' => '#/definitions/nonExistentDef',
 		);
@@ -204,5 +202,32 @@ class SCFSchemaBuilderTest extends BaseTestCase {
 			$this->assertArrayHasKey( 'label', $type_variant['properties'] );
 			$this->assertArrayHasKey( 'type', $type_variant['properties'] );
 		}
+	}
+
+	/**
+	 * Test resolve_refs handles nested definition paths.
+	 *
+	 * Refs like "#/definitions/shared/default_value" should resolve nested paths.
+	 */
+	public function test_resolve_refs_resolves_nested_definition_paths() {
+		$schema = array(
+			'$ref' => '#/definitions/shared/nested',
+		);
+
+		$root_schema = array(
+			'definitions' => array(
+				'shared' => array(
+					'nested' => array(
+						'type'        => 'string',
+						'description' => 'A nested definition',
+					),
+				),
+			),
+		);
+
+		$result = $this->builder->resolve_refs( $schema, $root_schema );
+
+		$this->assertEquals( 'string', $result['type'] );
+		$this->assertEquals( 'A nested definition', $result['description'] );
 	}
 }

--- a/tests/php/includes/SCFSchemaBuilderTest.php
+++ b/tests/php/includes/SCFSchemaBuilderTest.php
@@ -230,4 +230,88 @@ class SCFSchemaBuilderTest extends BaseTestCase {
 		$this->assertEquals( 'string', $result['type'] );
 		$this->assertEquals( 'A nested definition', $result['description'] );
 	}
+
+	/**
+	 * Test resolve_refs resolves relative file refs.
+	 *
+	 * Refs like "common.schema.json#/definitions/title" should load and resolve
+	 * definitions from external schema files.
+	 */
+	public function test_resolve_refs_resolves_relative_file_refs() {
+		$schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'title' => array(
+					'$ref' => 'common.schema.json#/definitions/title',
+				),
+			),
+		);
+
+		$result = $this->builder->resolve_refs( $schema, $schema );
+
+		// The title property should be resolved from common.schema.json.
+		$this->assertArrayHasKey( 'title', $result['properties'] );
+		$this->assertEquals( 'string', $result['properties']['title']['type'] );
+		$this->assertArrayNotHasKey( '$ref', $result['properties']['title'] );
+	}
+
+	/**
+	 * Test resolve_refs resolves wordpressReservedTerms from common.schema.json.
+	 *
+	 * This validates the specific use case where post-type.schema.json uses:
+	 * "not": { "$ref": "common.schema.json#/definitions/wordpressReservedTerms" }
+	 */
+	public function test_resolve_refs_resolves_wordpress_reserved_terms() {
+		$schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'post_type' => array(
+					'type' => 'string',
+					'not'  => array(
+						'$ref' => 'common.schema.json#/definitions/wordpressReservedTerms',
+					),
+				),
+			),
+		);
+
+		$result = $this->builder->resolve_refs( $schema, $schema );
+
+		// The "not" constraint should be resolved with the enum of reserved terms.
+		$this->assertArrayHasKey( 'not', $result['properties']['post_type'] );
+		$this->assertArrayHasKey( 'enum', $result['properties']['post_type']['not'] );
+		$this->assertContains( 'post', $result['properties']['post_type']['not']['enum'] );
+		$this->assertContains( 'page', $result['properties']['post_type']['not']['enum'] );
+		$this->assertContains( 'attachment', $result['properties']['post_type']['not']['enum'] );
+	}
+
+	/**
+	 * Test resolve_refs returns original schema for non-existent external file.
+	 */
+	public function test_resolve_refs_returns_original_for_missing_external_file() {
+		$schema = array(
+			'$ref' => 'nonexistent.schema.json#/definitions/foo',
+		);
+
+		$result = $this->builder->resolve_refs( $schema, $schema );
+
+		// Should return original schema when external file not found.
+		$this->assertEquals( $schema, $result );
+	}
+
+	/**
+	 * Test resolve_refs with custom base_path parameter.
+	 */
+	public function test_resolve_refs_with_custom_base_path() {
+		$schema = array(
+			'$ref' => 'common.schema.json#/definitions/active',
+		);
+
+		// Use explicit base path.
+		$base_path = ACF_PATH . 'schemas/';
+		$result    = $this->builder->resolve_refs( $schema, $schema, $base_path );
+
+		// Should resolve the active definition.
+		$this->assertEquals( 'boolean', $result['type'] );
+		$this->assertArrayNotHasKey( '$ref', $result );
+	}
 }

--- a/tests/php/includes/abilities/test-scf-internal-post-type-abilities.php
+++ b/tests/php/includes/abilities/test-scf-internal-post-type-abilities.php
@@ -618,6 +618,59 @@ class Test_SCF_Internal_Post_Type_Abilities extends BaseTestCase {
 	}
 
 	/**
+	 * Test get_entity_schema resolves relative file refs from common.schema.json.
+	 *
+	 * This ensures that refs like "$ref": "common.schema.json#/definitions/title"
+	 * are properly resolved before being passed to WordPress Abilities API.
+	 */
+	public function test_get_entity_schema_resolves_relative_file_refs() {
+		$reflection = new ReflectionClass( $this->abilities );
+		$method     = $reflection->getMethod( 'get_entity_schema' );
+		$method->setAccessible( true );
+
+		$schema = $method->invoke( $this->abilities );
+
+		// Title property should be resolved from common.schema.json (not a $ref).
+		$this->assertArrayHasKey( 'title', $schema['properties'] );
+		$this->assertArrayNotHasKey( '$ref', $schema['properties']['title'], 'Title should be resolved, not a $ref' );
+		$this->assertEquals( 'string', $schema['properties']['title']['type'] );
+
+		// Active property should also be resolved.
+		$this->assertArrayHasKey( 'active', $schema['properties'] );
+		$this->assertArrayNotHasKey( '$ref', $schema['properties']['active'], 'Active should be resolved, not a $ref' );
+		$this->assertEquals( 'boolean', $schema['properties']['active']['type'] );
+	}
+
+	/**
+	 * Test get_entity_schema resolves wordpressReservedTerms constraint.
+	 *
+	 * The taxonomy.schema.json uses "not": { "$ref": "common.schema.json#/definitions/wordpressReservedTerms" }
+	 * to prevent reserved terms. This should be resolved to include the actual enum values.
+	 */
+	public function test_get_entity_schema_resolves_reserved_terms_constraint() {
+		$reflection = new ReflectionClass( $this->abilities );
+		$method     = $reflection->getMethod( 'get_entity_schema' );
+		$method->setAccessible( true );
+
+		$schema = $method->invoke( $this->abilities );
+
+		// The taxonomy property should have a "not" constraint with resolved enum.
+		$this->assertArrayHasKey( 'taxonomy', $schema['properties'] );
+		$taxonomy_schema = $schema['properties']['taxonomy'];
+
+		$this->assertArrayHasKey( 'not', $taxonomy_schema, 'Taxonomy should have "not" constraint' );
+		$this->assertArrayNotHasKey( '$ref', $taxonomy_schema['not'], 'Reserved terms should be resolved, not a $ref' );
+		$this->assertArrayHasKey( 'enum', $taxonomy_schema['not'], 'Reserved terms should be an enum' );
+
+		// Verify some known reserved terms are present.
+		$reserved_terms = $taxonomy_schema['not']['enum'];
+		$this->assertContains( 'post', $reserved_terms, 'Reserved terms should include "post"' );
+		$this->assertContains( 'page', $reserved_terms, 'Reserved terms should include "page"' );
+		$this->assertContains( 'attachment', $reserved_terms, 'Reserved terms should include "attachment"' );
+		$this->assertContains( 'category', $reserved_terms, 'Reserved terms should include "category"' );
+	}
+
+	/**
 	 * Test get_scf_identifier_schema returns valid schema
 	 */
 	public function test_get_scf_identifier_schema_returns_array() {


### PR DESCRIPTION
## What

Makes JSON schemas fully compliant with JSON Schema draft-07. This includes resolving the "Field fragments" into a single Field schema rather than composing it at runtime. In a nutshell, the main goal of draft-07 is leveraging `$ref` for reusability.

## Why

External validators and IDEs couldn't properly validate the schemas because of the `$ref` format and field property merging we were using for reusability and convenience: the field fragments that were being resolved at runtime are a practical way to reuse all the common properties all fields have, but that meant that the invididual schemas, while technically v07 compliant, were not capable of validating real, whole field JSON data if not using SCF's runtime builder to "make them full".

## How

On the one hand, reorganizing field schemas into a clearer fragment structure where:
  - `field-fragments/field-base.schema.json` contains shared definitions
  - `field-fragments/{category}/*.schema.json` contains type-specific properties.

Then, instead of merging the base + fragment at runtime as needed, we use the JSON Builder to generate a unified `field.schema.json` file, which is then used as any other plain schema. The generated file still cointains `$ref`s that are resolved at runtime because of the limited WP schema support: we _could_ resolve them _before_ generating the file, but this still maintains a good level of reusability in the full Field schema file (there will be 35 individual field definitions that must contain all properties, as we can't leverage `allOf` and other advanced schema options that we would also also need to resolve at runtime for the abilities API) while maintaining full draft-07 compliance.

To ensure the autogenerated `field.schema.json` file is kept in sync, this PR also adds a CI workflow that verifies the generated schema stays in sync with source fragments on every PR that touches schema files.

Finally, this also ensures external refs are properly resolved for WP's internal schema validation and replaces custom reference formats with standard JSON Schema v7 relative refs (e.g., `common.schema.json#/definitions/title`).

## Testing Instructions

1. Run `php bin/generate-field-schema.php --check`: it should report "in sync"
2. Modify any fragment file, run `--check` again: it should fail
3. Run `php bin/generate-field-schema.php` to regenerate
4. Validate `schemas/field.schema.json` with an external JSON Schema validator
5. Run `vendor/bin/phpunit tests/php/includes/SCFSchemaBuilderTest.php`: all tests should pass