### PR TITLE
JSON Schemas: add `basic` fields schema fragments

### DIFF
--- a/schemas/field-fragments/basic/email.schema.json
+++ b/schemas/field-fragments/basic/email.schema.json
@@ -1,0 +1,14 @@
+{
+	"title": "SCF Email Field Fragment",
+	"description": "Type-specific properties for email fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "email" ]
+		},
+		"default_value": { "$ref": "#/definitions/default_value" },
+		"placeholder": { "$ref": "#/definitions/placeholder" },
+		"prepend": { "$ref": "#/definitions/prepend" },
+		"append": { "$ref": "#/definitions/append" }
+	}
+}

--- a/schemas/field-fragments/basic/number.schema.json
+++ b/schemas/field-fragments/basic/number.schema.json
@@ -1,0 +1,29 @@
+{
+	"title": "SCF Number Field Fragment",
+	"description": "Type-specific properties for number fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "number" ]
+		},
+		"default_value": { "$ref": "#/definitions/default_value_numeric" },
+		"min": {
+			"type": [ "integer", "number", "string" ],
+			"default": "",
+			"description": "Minimum value (empty string for unlimited)"
+		},
+		"max": {
+			"type": [ "integer", "number", "string" ],
+			"default": "",
+			"description": "Maximum value (empty string for unlimited)"
+		},
+		"step": {
+			"type": [ "integer", "number", "string" ],
+			"default": "",
+			"description": "Step increment (empty string for default, 'any' for no restriction)"
+		},
+		"placeholder": { "$ref": "#/definitions/placeholder" },
+		"prepend": { "$ref": "#/definitions/prepend" },
+		"append": { "$ref": "#/definitions/append" }
+	}
+}

--- a/schemas/field-fragments/basic/password.schema.json
+++ b/schemas/field-fragments/basic/password.schema.json
@@ -1,0 +1,13 @@
+{
+	"title": "SCF Password Field Fragment",
+	"description": "Type-specific properties for password fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "password" ]
+		},
+		"placeholder": { "$ref": "#/definitions/placeholder" },
+		"prepend": { "$ref": "#/definitions/prepend" },
+		"append": { "$ref": "#/definitions/append" }
+	}
+}

--- a/schemas/field-fragments/basic/range.schema.json
+++ b/schemas/field-fragments/basic/range.schema.json
@@ -1,0 +1,28 @@
+{
+	"title": "SCF Range Field Fragment",
+	"description": "Type-specific properties for range slider fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "range" ]
+		},
+		"default_value": { "$ref": "#/definitions/default_value_numeric" },
+		"min": {
+			"type": [ "integer", "number", "string" ],
+			"default": "",
+			"description": "Minimum value (empty string for unlimited)"
+		},
+		"max": {
+			"type": [ "integer", "number", "string" ],
+			"default": "",
+			"description": "Maximum value (empty string for unlimited)"
+		},
+		"step": {
+			"type": [ "integer", "number", "string" ],
+			"default": "",
+			"description": "Step increment (empty string for default, 'any' for no restriction)"
+		},
+		"prepend": { "$ref": "#/definitions/prepend" },
+		"append": { "$ref": "#/definitions/append" }
+	}
+}

--- a/schemas/field-fragments/basic/text.schema.json
+++ b/schemas/field-fragments/basic/text.schema.json
@@ -1,39 +1,15 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://raw.githubusercontent.com/WordPress/secure-custom-fields/trunk/schemas/field-fragments/basic/text.schema.json",
-	"title": "SCF Text Field",
+	"title": "SCF Text Field Fragment",
 	"description": "Type-specific properties for text fields",
 	"type": "object",
-	"required": [ "type" ],
 	"properties": {
 		"type": {
 			"enum": [ "text" ]
 		},
-		"default_value": {
-			"type": "string",
-			"default": "",
-			"description": "Default value for the field"
-		},
-		"maxlength": {
-			"type": [ "integer", "string" ],
-			"default": "",
-			"description": "Maximum character length (empty string for unlimited)"
-		},
-		"placeholder": {
-			"type": "string",
-			"default": "",
-			"description": "Placeholder text shown when field is empty"
-		},
-		"prepend": {
-			"type": "string",
-			"default": "",
-			"description": "Text or HTML displayed before the input"
-		},
-		"append": {
-			"type": "string",
-			"default": "",
-			"description": "Text or HTML displayed after the input"
-		}
-	},
-	"additionalProperties": false
+		"default_value": { "$ref": "#/definitions/default_value" },
+		"maxlength": { "$ref": "#/definitions/maxlength" },
+		"placeholder": { "$ref": "#/definitions/placeholder" },
+		"prepend": { "$ref": "#/definitions/prepend" },
+		"append": { "$ref": "#/definitions/append" }
+	}
 }

--- a/schemas/field-fragments/basic/textarea.schema.json
+++ b/schemas/field-fragments/basic/textarea.schema.json
@@ -1,0 +1,15 @@
+{
+	"title": "SCF Textarea Field Fragment",
+	"description": "Type-specific properties for textarea fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "textarea" ]
+		},
+		"default_value": { "$ref": "#/definitions/default_value" },
+		"maxlength": { "$ref": "#/definitions/maxlength" },
+		"rows": { "$ref": "#/definitions/rows" },
+		"placeholder": { "$ref": "#/definitions/placeholder" },
+		"new_lines": { "$ref": "#/definitions/new_lines" }
+	}
+}

--- a/schemas/field-fragments/basic/url.schema.json
+++ b/schemas/field-fragments/basic/url.schema.json
@@ -1,0 +1,12 @@
+{
+	"title": "SCF URL Field Fragment",
+	"description": "Type-specific properties for URL fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "url" ]
+		},
+		"default_value": { "$ref": "#/definitions/default_value" },
+		"placeholder": { "$ref": "#/definitions/placeholder" }
+	}
+}

--- a/schemas/field-fragments/field-base.schema.json
+++ b/schemas/field-fragments/field-base.schema.json
@@ -184,6 +184,47 @@
 					"description": "Value to compare against (not required for ==empty and !=empty operators)"
 				}
 			}
+		},
+		"default_value": {
+			"type": "string",
+			"default": "",
+			"description": "Default value for the field"
+		},
+		"default_value_numeric": {
+			"type": [ "string", "number" ],
+			"default": "",
+			"description": "Default value for numeric fields (string for empty, number for value)"
+		},
+		"placeholder": {
+			"type": "string",
+			"default": "",
+			"description": "Placeholder text shown when field is empty"
+		},
+		"prepend": {
+			"type": "string",
+			"default": "",
+			"description": "Text or HTML displayed before the input"
+		},
+		"append": {
+			"type": "string",
+			"default": "",
+			"description": "Text or HTML displayed after the input"
+		},
+		"maxlength": {
+			"type": [ "integer", "string" ],
+			"default": "",
+			"description": "Maximum character length (empty string for unlimited)"
+		},
+		"rows": {
+			"type": [ "integer", "string" ],
+			"default": "",
+			"description": "Number of rows for textarea display"
+		},
+		"new_lines": {
+			"type": "string",
+			"enum": [ "wpautop", "br", "" ],
+			"default": "",
+			"description": "How to handle new lines in output (wpautop, br, or none)"
 		}
 	}
 }

--- a/schemas/field.schema.json
+++ b/schemas/field.schema.json
@@ -65,6 +65,566 @@
                         },
                         "type": {
                             "enum": [
+                                "email"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "default_value": {
+                            "$ref": "#/definitions/default_value"
+                        },
+                        "placeholder": {
+                            "$ref": "#/definitions/placeholder"
+                        },
+                        "prepend": {
+                            "$ref": "#/definitions/prepend"
+                        },
+                        "append": {
+                            "$ref": "#/definitions/append"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "number"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "default_value": {
+                            "$ref": "#/definitions/default_value_numeric"
+                        },
+                        "min": {
+                            "type": [
+                                "integer",
+                                "number",
+                                "string"
+                            ],
+                            "default": "",
+                            "description": "Minimum value (empty string for unlimited)"
+                        },
+                        "max": {
+                            "type": [
+                                "integer",
+                                "number",
+                                "string"
+                            ],
+                            "default": "",
+                            "description": "Maximum value (empty string for unlimited)"
+                        },
+                        "step": {
+                            "type": [
+                                "integer",
+                                "number",
+                                "string"
+                            ],
+                            "default": "",
+                            "description": "Step increment (empty string for default, 'any' for no restriction)"
+                        },
+                        "placeholder": {
+                            "$ref": "#/definitions/placeholder"
+                        },
+                        "prepend": {
+                            "$ref": "#/definitions/prepend"
+                        },
+                        "append": {
+                            "$ref": "#/definitions/append"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "password"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "placeholder": {
+                            "$ref": "#/definitions/placeholder"
+                        },
+                        "prepend": {
+                            "$ref": "#/definitions/prepend"
+                        },
+                        "append": {
+                            "$ref": "#/definitions/append"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "range"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "default_value": {
+                            "$ref": "#/definitions/default_value_numeric"
+                        },
+                        "min": {
+                            "type": [
+                                "integer",
+                                "number",
+                                "string"
+                            ],
+                            "default": "",
+                            "description": "Minimum value (empty string for unlimited)"
+                        },
+                        "max": {
+                            "type": [
+                                "integer",
+                                "number",
+                                "string"
+                            ],
+                            "default": "",
+                            "description": "Maximum value (empty string for unlimited)"
+                        },
+                        "step": {
+                            "type": [
+                                "integer",
+                                "number",
+                                "string"
+                            ],
+                            "default": "",
+                            "description": "Step increment (empty string for default, 'any' for no restriction)"
+                        },
+                        "prepend": {
+                            "$ref": "#/definitions/prepend"
+                        },
+                        "append": {
+                            "$ref": "#/definitions/append"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
                                 "text"
                             ]
                         },
@@ -148,32 +708,272 @@
                             "description": "Parent layout key for flexible content sub-fields"
                         },
                         "default_value": {
-                            "type": "string",
-                            "default": "",
-                            "description": "Default value for the field"
+                            "$ref": "#/definitions/default_value"
                         },
                         "maxlength": {
-                            "type": [
-                                "integer",
-                                "string"
-                            ],
-                            "default": "",
-                            "description": "Maximum character length (empty string for unlimited)"
+                            "$ref": "#/definitions/maxlength"
                         },
                         "placeholder": {
-                            "type": "string",
-                            "default": "",
-                            "description": "Placeholder text shown when field is empty"
+                            "$ref": "#/definitions/placeholder"
                         },
                         "prepend": {
-                            "type": "string",
-                            "default": "",
-                            "description": "Text or HTML displayed before the input"
+                            "$ref": "#/definitions/prepend"
                         },
                         "append": {
+                            "$ref": "#/definitions/append"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
                             "type": "string",
-                            "default": "",
-                            "description": "Text or HTML displayed after the input"
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "textarea"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "default_value": {
+                            "$ref": "#/definitions/default_value"
+                        },
+                        "maxlength": {
+                            "$ref": "#/definitions/maxlength"
+                        },
+                        "rows": {
+                            "$ref": "#/definitions/rows"
+                        },
+                        "placeholder": {
+                            "$ref": "#/definitions/placeholder"
+                        },
+                        "new_lines": {
+                            "$ref": "#/definitions/new_lines"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "url"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "default_value": {
+                            "$ref": "#/definitions/default_value"
+                        },
+                        "placeholder": {
+                            "$ref": "#/definitions/placeholder"
                         }
                     },
                     "additionalProperties": false
@@ -210,12 +1010,6 @@
                         "type": {
                             "type": "string",
                             "enum": [
-                                "textarea",
-                                "number",
-                                "range",
-                                "email",
-                                "url",
-                                "password",
                                 "image",
                                 "file",
                                 "wysiwyg",
@@ -376,6 +1170,60 @@
                     "description": "Value to compare against (not required for ==empty and !=empty operators)"
                 }
             }
+        },
+        "default_value": {
+            "type": "string",
+            "default": "",
+            "description": "Default value for the field"
+        },
+        "default_value_numeric": {
+            "type": [
+                "string",
+                "number"
+            ],
+            "default": "",
+            "description": "Default value for numeric fields (string for empty, number for value)"
+        },
+        "placeholder": {
+            "type": "string",
+            "default": "",
+            "description": "Placeholder text shown when field is empty"
+        },
+        "prepend": {
+            "type": "string",
+            "default": "",
+            "description": "Text or HTML displayed before the input"
+        },
+        "append": {
+            "type": "string",
+            "default": "",
+            "description": "Text or HTML displayed after the input"
+        },
+        "maxlength": {
+            "type": [
+                "integer",
+                "string"
+            ],
+            "default": "",
+            "description": "Maximum character length (empty string for unlimited)"
+        },
+        "rows": {
+            "type": [
+                "integer",
+                "string"
+            ],
+            "default": "",
+            "description": "Number of rows for textarea display"
+        },
+        "new_lines": {
+            "type": "string",
+            "enum": [
+                "wpautop",
+                "br",
+                ""
+            ],
+            "default": "",
+            "description": "How to handle new lines in output (wpautop, br, or none)"
         }
     }
 }

--- a/tests/php/schemas/BaseSchemaTestCase.php
+++ b/tests/php/schemas/BaseSchemaTestCase.php
@@ -135,6 +135,11 @@ abstract class BaseSchemaTestCase extends TestCase {
 	 * Test validation with valid fixture files (JSON file import scenarios).
 	 */
 	public function test_valid_entities_from_fixture_files() {
+		if ( empty( $this->fixtures_path ) ) {
+			$this->assertTrue( true, 'No fixture files - using data providers only' );
+			return;
+		}
+
 		$valid_files = glob( $this->fixtures_path . 'valid/*.json' );
 		$this->assertNotEmpty( $valid_files, 'Should have valid fixture files' );
 
@@ -155,6 +160,11 @@ abstract class BaseSchemaTestCase extends TestCase {
 	 * Test validation with invalid fixture files (JSON file import scenarios).
 	 */
 	public function test_invalid_entities_from_fixture_files() {
+		if ( empty( $this->fixtures_path ) ) {
+			$this->assertTrue( true, 'No fixture files - using data providers only' );
+			return;
+		}
+
 		$invalid_files = glob( $this->fixtures_path . 'invalid/*.json' );
 		$this->assertNotEmpty( $invalid_files, 'Should have invalid fixture files' );
 

--- a/tests/php/schemas/FieldGroupSchemaTest.php
+++ b/tests/php/schemas/FieldGroupSchemaTest.php
@@ -138,50 +138,23 @@ class FieldGroupSchemaTest extends BaseSchemaTestCase {
 				),
 				'Field group with a text field should be valid',
 			),
-			'with all positions'            => array(
+			'with position'                 => array(
 				array(
 					'key'      => 'group_position_normal',
 					'title'    => 'Normal Position',
 					'fields'   => array(),
 					'position' => 'normal',
 				),
-				'Field group with normal position should be valid',
+				'Field group with valid position should be valid',
 			),
-			'position side'                 => array(
-				array(
-					'key'      => 'group_position_side',
-					'title'    => 'Side Position',
-					'fields'   => array(),
-					'position' => 'side',
-				),
-				'Field group with side position should be valid',
-			),
-			'position after title'          => array(
-				array(
-					'key'      => 'group_position_after',
-					'title'    => 'After Title Position',
-					'fields'   => array(),
-					'position' => 'acf_after_title',
-				),
-				'Field group with acf_after_title position should be valid',
-			),
-			'style default'                 => array(
+			'with style'                    => array(
 				array(
 					'key'    => 'group_style_default',
 					'title'  => 'Default Style',
 					'fields' => array(),
 					'style'  => 'default',
 				),
-				'Field group with default style should be valid',
-			),
-			'style seamless'                => array(
-				array(
-					'key'    => 'group_style_seamless',
-					'title'  => 'Seamless Style',
-					'fields' => array(),
-					'style'  => 'seamless',
-				),
-				'Field group with seamless style should be valid',
+				'Field group with valid style should be valid',
 			),
 			'active as boolean'             => array(
 				array(
@@ -238,69 +211,6 @@ class FieldGroupSchemaTest extends BaseSchemaTestCase {
 					'modified'              => 1700000000,
 				),
 				'Complete field group with all properties should be valid',
-			),
-			'field with conditional_logic'  => array(
-				array(
-					'key'    => 'group_conditional',
-					'title'  => 'Conditional Group',
-					'fields' => array(
-						array(
-							'key'               => 'field_toggle',
-							'label'             => 'Toggle',
-							'name'              => 'toggle',
-							'type'              => 'true_false',
-							'conditional_logic' => 0,
-						),
-						array(
-							'key'               => 'field_dependent',
-							'label'             => 'Dependent',
-							'name'              => 'dependent',
-							'type'              => 'text',
-							'conditional_logic' => array(
-								array(
-									array(
-										'field'    => 'field_toggle',
-										'operator' => '==',
-										'value'    => '1',
-									),
-								),
-							),
-						),
-					),
-				),
-				'Field group with conditional logic should be valid',
-			),
-			'field required as boolean'     => array(
-				array(
-					'key'    => 'group_req_bool',
-					'title'  => 'Required Boolean',
-					'fields' => array(
-						array(
-							'key'      => 'field_req_bool',
-							'label'    => 'Required Field',
-							'name'     => 'required_field',
-							'type'     => 'text',
-							'required' => true,
-						),
-					),
-				),
-				'Field with required as boolean should be valid',
-			),
-			'field required as integer'     => array(
-				array(
-					'key'    => 'group_req_int',
-					'title'  => 'Required Integer',
-					'fields' => array(
-						array(
-							'key'      => 'field_req_int',
-							'label'    => 'Required Field',
-							'name'     => 'required_field',
-							'type'     => 'text',
-							'required' => 1,
-						),
-					),
-				),
-				'Field with required as integer should be valid',
 			),
 		);
 	}
@@ -375,50 +285,6 @@ class FieldGroupSchemaTest extends BaseSchemaTestCase {
 					'style'  => 'invalid_style',
 				),
 				'Field group with invalid style should fail validation',
-			),
-			'field missing key'         => array(
-				array(
-					'key'    => 'group_field_no_key',
-					'title'  => 'Field Missing Key',
-					'fields' => array(
-						array(
-							'label' => 'No Key Field',
-							'name'  => 'no_key',
-							'type'  => 'text',
-						),
-					),
-				),
-				'Field without key should fail validation',
-			),
-			'field invalid key'         => array(
-				array(
-					'key'    => 'group_field_bad_key',
-					'title'  => 'Field Bad Key',
-					'fields' => array(
-						array(
-							'key'   => 'invalid_field_key',
-							'label' => 'Bad Key Field',
-							'name'  => 'bad_key',
-							'type'  => 'text',
-						),
-					),
-				),
-				'Field without field_ prefix should fail validation',
-			),
-			'field invalid type'        => array(
-				array(
-					'key'    => 'group_field_bad_type',
-					'title'  => 'Field Bad Type',
-					'fields' => array(
-						array(
-							'key'   => 'field_bad_type',
-							'label' => 'Bad Type Field',
-							'name'  => 'bad_type',
-							'type'  => 'nonexistent_type',
-						),
-					),
-				),
-				'Field with invalid type should fail validation',
 			),
 			'invalid hide_on_screen'    => array(
 				array(

--- a/tests/php/schemas/FieldSchemaTest.php
+++ b/tests/php/schemas/FieldSchemaTest.php
@@ -1,0 +1,368 @@
+<?php
+/**
+ * Tests for the SCF Field JSON Schema validation.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once 'BaseSchemaTestCase.php';
+
+/**
+ * Class FieldSchemaTest
+ *
+ * Tests JSON Schema validation for SCF fields.
+ * Validates standalone field definitions against field.schema.json.
+ */
+class FieldSchemaTest extends BaseSchemaTestCase {
+
+	/**
+	 * Get the schema type to test.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_type(): string {
+		return 'field';
+	}
+
+	/**
+	 * Get the path to the fixtures directory.
+	 * Empty string - no fixtures, data providers only.
+	 *
+	 * @return string
+	 */
+	protected function get_fixtures_path(): string {
+		return '';
+	}
+
+	/**
+	 * Get the definition name in the schema.
+	 *
+	 * @return string
+	 */
+	protected function get_definition_name(): string {
+		return 'field';
+	}
+
+	/**
+	 * Get the required fields for this schema.
+	 * Read from schema instead of hardcoding.
+	 *
+	 * @return array
+	 */
+	protected function get_required_fields(): array {
+		$schema = $this->validator->load_schema( 'field' );
+		return $schema->definitions->field->oneOf[0]->required ?? array();
+	}
+
+	/**
+	 * Override: field schema has nested oneOf in definitions.field.
+	 */
+	public function test_schema_loads() {
+		$schema = $this->validator->load_schema( 'field' );
+
+		$this->assertNotNull( $schema, 'Field schema should load' );
+		$this->assertObjectHasProperty( 'oneOf', $schema, 'Schema should have top-level oneOf' );
+		$this->assertObjectHasProperty( 'definitions', $schema, 'Schema should have definitions' );
+		$this->assertObjectHasProperty( 'field', $schema->definitions, 'Schema should define field' );
+		$this->assertObjectHasProperty( 'oneOf', $schema->definitions->field, 'Field definition should have oneOf for type variants' );
+	}
+
+	/**
+	 * Test that all implemented field types reject unknown properties.
+	 * Dynamically extracts implemented types from the schema.
+	 */
+	public function test_additional_properties_rejected_for_all_implemented_types() {
+		$schema = $this->validator->load_schema( 'field' );
+
+		// Extract types from oneOf variants that have additionalProperties: false.
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- JSON Schema property name.
+		$implemented_types = array();
+		foreach ( $schema->definitions->field->oneOf as $variant ) {
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- JSON Schema property name.
+			if ( isset( $variant->additionalProperties ) && false === $variant->additionalProperties ) {
+				$type = $variant->properties->type->enum[0] ?? null;
+				if ( $type ) {
+					$implemented_types[] = $type;
+				}
+			}
+		}
+
+		$this->assertNotEmpty( $implemented_types, 'Should have at least one implemented type with additionalProperties: false' );
+
+		foreach ( $implemented_types as $type ) {
+			$field = array(
+				'key'                   => 'field_test_' . $type,
+				'label'                 => 'Test ' . ucfirst( $type ),
+				'name'                  => 'test_' . $type,
+				'type'                  => $type,
+				'parent'                => 'group_test',
+				'unknown_fake_property' => 'should_fail',
+			);
+
+			$result = $this->validator->validate( $field, 'field' );
+			$this->assertFalse( $result, "$type field should reject unknown properties" );
+		}
+	}
+
+	/**
+	 * Data provider for valid fields.
+	 *
+	 * @return array
+	 */
+	public function validEntitiesProvider(): array {
+		return array(
+			// Base field tests.
+			'array of fields'              => array(
+				array(
+					array(
+						'key'    => 'field_first',
+						'label'  => 'First',
+						'name'   => 'first',
+						'type'   => 'text',
+						'parent' => 'group_test',
+					),
+					array(
+						'key'    => 'field_second',
+						'label'  => 'Second',
+						'name'   => 'second',
+						'type'   => 'number',
+						'parent' => 'group_test',
+					),
+				),
+				'Array of fields should validate successfully',
+			),
+			'field with conditional_logic' => array(
+				array(
+					'key'               => 'field_with_logic',
+					'label'             => 'Conditional Field',
+					'name'              => 'conditional',
+					'type'              => 'text',
+					'parent'            => 'group_test',
+					'conditional_logic' => array(
+						array(
+							array(
+								'field'    => 'field_toggle',
+								'operator' => '==',
+								'value'    => '1',
+							),
+						),
+					),
+				),
+				'Field with conditional logic should be valid',
+			),
+
+			// Multi-type property tests (properties accepting different types).
+			'maxlength as empty string'    => array(
+				array(
+					'key'       => 'field_maxlen_str',
+					'label'     => 'Maxlength String',
+					'name'      => 'maxlen_str',
+					'type'      => 'text',
+					'parent'    => 'group_test',
+					'maxlength' => '',
+				),
+				'Maxlength as empty string should be valid',
+			),
+			'required as integer'          => array(
+				array(
+					'key'      => 'field_req_int',
+					'label'    => 'Required Integer',
+					'name'     => 'req_int',
+					'type'     => 'text',
+					'parent'   => 'group_test',
+					'required' => 1,
+				),
+				'Required as integer should be valid',
+			),
+
+			// Complete field for each implemented type.
+			'text field complete'          => array(
+				array(
+					'key'           => 'field_text_full',
+					'label'         => 'Full Text Field',
+					'name'          => 'text_full',
+					'type'          => 'text',
+					'parent'        => 'group_test',
+					'required'      => true,
+					'default_value' => 'Default',
+					'maxlength'     => 100,
+					'placeholder'   => 'Enter text...',
+					'prepend'       => '$',
+					'append'        => '.00',
+				),
+				'Text field with all type-specific properties should be valid',
+			),
+			'textarea field complete'      => array(
+				array(
+					'key'           => 'field_textarea_full',
+					'label'         => 'Full Textarea',
+					'name'          => 'textarea_full',
+					'type'          => 'textarea',
+					'parent'        => 'group_test',
+					'default_value' => '',
+					'maxlength'     => 500,
+					'rows'          => 8,
+					'placeholder'   => 'Enter text...',
+					'new_lines'     => 'wpautop',
+				),
+				'Textarea field with all type-specific properties should be valid',
+			),
+			'number field complete'        => array(
+				array(
+					'key'           => 'field_number_full',
+					'label'         => 'Full Number',
+					'name'          => 'number_full',
+					'type'          => 'number',
+					'parent'        => 'group_test',
+					'default_value' => 50,
+					'min'           => 0,
+					'max'           => 100,
+					'step'          => 5,
+					'placeholder'   => '0-100',
+					'prepend'       => '#',
+					'append'        => 'units',
+				),
+				'Number field with all type-specific properties should be valid',
+			),
+			'range field complete'         => array(
+				array(
+					'key'           => 'field_range_full',
+					'label'         => 'Full Range',
+					'name'          => 'range_full',
+					'type'          => 'range',
+					'parent'        => 'group_test',
+					'default_value' => 50,
+					'min'           => 0,
+					'max'           => 100,
+					'step'          => 10,
+					'prepend'       => 'Min',
+					'append'        => 'Max',
+				),
+				'Range field with all type-specific properties should be valid',
+			),
+			'email field complete'         => array(
+				array(
+					'key'           => 'field_email_full',
+					'label'         => 'Full Email',
+					'name'          => 'email_full',
+					'type'          => 'email',
+					'parent'        => 'group_test',
+					'default_value' => '',
+					'placeholder'   => 'name@example.com',
+					'prepend'       => '@',
+					'append'        => '',
+				),
+				'Email field with all type-specific properties should be valid',
+			),
+			'url field complete'           => array(
+				array(
+					'key'           => 'field_url_full',
+					'label'         => 'Full URL',
+					'name'          => 'url_full',
+					'type'          => 'url',
+					'parent'        => 'group_test',
+					'default_value' => 'https://',
+					'placeholder'   => 'https://example.com',
+				),
+				'URL field with all type-specific properties should be valid',
+			),
+			'password field complete'      => array(
+				array(
+					'key'         => 'field_password_full',
+					'label'       => 'Full Password',
+					'name'        => 'password_full',
+					'type'        => 'password',
+					'parent'      => 'group_test',
+					'placeholder' => 'Enter password...',
+					'prepend'     => 'Key:',
+					'append'      => '',
+				),
+				'Password field with all type-specific properties should be valid',
+			),
+		);
+	}
+
+	/**
+	 * Data provider for invalid fields.
+	 *
+	 * @return array
+	 */
+	public function invalidEntitiesProvider(): array {
+		return array(
+			// Required fields validation.
+			'missing key'            => array(
+				array(
+					'label'  => 'No Key Field',
+					'name'   => 'no_key',
+					'type'   => 'text',
+					'parent' => 'group_test',
+				),
+				'Field without key should fail validation',
+			),
+			'missing label'          => array(
+				array(
+					'key'    => 'field_no_label',
+					'name'   => 'no_label',
+					'type'   => 'text',
+					'parent' => 'group_test',
+				),
+				'Field without label should fail validation',
+			),
+			'missing type'           => array(
+				array(
+					'key'    => 'field_no_type',
+					'label'  => 'No Type',
+					'name'   => 'no_type',
+					'parent' => 'group_test',
+				),
+				'Field without type should fail validation',
+			),
+			'missing parent'         => array(
+				array(
+					'key'   => 'field_no_parent',
+					'label' => 'No Parent',
+					'name'  => 'no_parent',
+					'type'  => 'text',
+				),
+				'Standalone field without parent should fail validation',
+			),
+
+			// Pattern validation.
+			'invalid key pattern'    => array(
+				array(
+					'key'    => 'invalid_field_key',
+					'label'  => 'Bad Key Field',
+					'name'   => 'bad_key',
+					'type'   => 'text',
+					'parent' => 'group_test',
+				),
+				'Field without field_ prefix should fail validation',
+			),
+
+			// Enum validation.
+			'invalid type'           => array(
+				array(
+					'key'    => 'field_bad_type',
+					'label'  => 'Bad Type Field',
+					'name'   => 'bad_type',
+					'type'   => 'nonexistent_type',
+					'parent' => 'group_test',
+				),
+				'Field with invalid type should fail validation',
+			),
+			'invalid new_lines enum' => array(
+				array(
+					'key'       => 'field_textarea_bad_nl',
+					'label'     => 'Bad New Lines',
+					'name'      => 'bad_new_lines',
+					'type'      => 'textarea',
+					'parent'    => 'group_test',
+					'new_lines' => 'invalid_value',
+				),
+				'Textarea with invalid new_lines value should fail validation',
+			),
+		);
+	}
+}


### PR DESCRIPTION
## What

Part of #162. Adds JSON Schema fragments for basic field types.

## How

- Adding 6 new field type fragments (email, number, password, range, textarea, url)
- Adding shared property definitions to `field-base.schema.json`, and refactoring the existing text fragment to use shared `$ref` definitions
- Adding dedicated `FieldSchemaTest` with tests for each basic field type