### PR TITLE
JSON Schemas: add `content` fields schema fragments

### DIFF
--- a/schemas/field-fragments/content/file.schema.json
+++ b/schemas/field-fragments/content/file.schema.json
@@ -1,0 +1,15 @@
+{
+	"title": "SCF File Field Fragment",
+	"description": "Type-specific properties for file fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "file" ]
+		},
+		"return_format": { "$ref": "#/definitions/return_format_media" },
+		"library": { "$ref": "#/definitions/library" },
+		"min_size": { "$ref": "#/definitions/min_size" },
+		"max_size": { "$ref": "#/definitions/max_size" },
+		"mime_types": { "$ref": "#/definitions/mime_types" }
+	}
+}

--- a/schemas/field-fragments/content/gallery.schema.json
+++ b/schemas/field-fragments/content/gallery.schema.json
@@ -1,0 +1,36 @@
+{
+	"title": "SCF Gallery Field Fragment",
+	"description": "Type-specific properties for gallery fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "gallery" ]
+		},
+		"return_format": { "$ref": "#/definitions/return_format_media" },
+		"preview_size": { "$ref": "#/definitions/preview_size" },
+		"library": { "$ref": "#/definitions/library" },
+		"min_width": { "$ref": "#/definitions/min_width" },
+		"min_height": { "$ref": "#/definitions/min_height" },
+		"min_size": { "$ref": "#/definitions/min_size" },
+		"max_width": { "$ref": "#/definitions/max_width" },
+		"max_height": { "$ref": "#/definitions/max_height" },
+		"max_size": { "$ref": "#/definitions/max_size" },
+		"mime_types": { "$ref": "#/definitions/mime_types" },
+		"min": {
+			"type": "integer",
+			"default": 0,
+			"description": "Minimum number of images required"
+		},
+		"max": {
+			"type": "integer",
+			"default": 0,
+			"description": "Maximum number of images allowed (0 for no limit)"
+		},
+		"insert": {
+			"type": "string",
+			"enum": [ "append", "prepend" ],
+			"default": "append",
+			"description": "Where to insert new images (append or prepend)"
+		}
+	}
+}

--- a/schemas/field-fragments/content/image.schema.json
+++ b/schemas/field-fragments/content/image.schema.json
@@ -1,0 +1,20 @@
+{
+	"title": "SCF Image Field Fragment",
+	"description": "Type-specific properties for image fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "image" ]
+		},
+		"return_format": { "$ref": "#/definitions/return_format_media" },
+		"preview_size": { "$ref": "#/definitions/preview_size" },
+		"library": { "$ref": "#/definitions/library" },
+		"min_width": { "$ref": "#/definitions/min_width" },
+		"min_height": { "$ref": "#/definitions/min_height" },
+		"min_size": { "$ref": "#/definitions/min_size" },
+		"max_width": { "$ref": "#/definitions/max_width" },
+		"max_height": { "$ref": "#/definitions/max_height" },
+		"max_size": { "$ref": "#/definitions/max_size" },
+		"mime_types": { "$ref": "#/definitions/mime_types" }
+	}
+}

--- a/schemas/field-fragments/content/oembed.schema.json
+++ b/schemas/field-fragments/content/oembed.schema.json
@@ -1,0 +1,20 @@
+{
+	"title": "SCF oEmbed Field Fragment",
+	"description": "Type-specific properties for oEmbed fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "oembed" ]
+		},
+		"width": {
+			"type": "string",
+			"default": "",
+			"description": "Maximum width of embedded content in pixels (empty for default)"
+		},
+		"height": {
+			"type": "string",
+			"default": "",
+			"description": "Maximum height of embedded content in pixels (empty for default)"
+		}
+	}
+}

--- a/schemas/field-fragments/content/wysiwyg.schema.json
+++ b/schemas/field-fragments/content/wysiwyg.schema.json
@@ -1,0 +1,32 @@
+{
+	"title": "SCF WYSIWYG Field Fragment",
+	"description": "Type-specific properties for WYSIWYG editor fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "wysiwyg" ]
+		},
+		"default_value": { "$ref": "#/definitions/default_value" },
+		"tabs": {
+			"type": "string",
+			"enum": [ "all", "visual", "text" ],
+			"default": "all",
+			"description": "Which editor tabs to show (all, visual only, or text only)"
+		},
+		"toolbar": {
+			"type": "string",
+			"default": "full",
+			"description": "Toolbar configuration (full or basic)"
+		},
+		"media_upload": {
+			"type": "integer",
+			"default": 1,
+			"description": "Show media upload button (1 for yes, 0 for no)"
+		},
+		"delay": {
+			"type": "integer",
+			"default": 0,
+			"description": "Delay TinyMCE initialization until field is clicked (1 for yes, 0 for no)"
+		}
+	}
+}

--- a/schemas/field-fragments/field-base.schema.json
+++ b/schemas/field-fragments/field-base.schema.json
@@ -225,6 +225,58 @@
 			"enum": [ "wpautop", "br", "" ],
 			"default": "",
 			"description": "How to handle new lines in output (wpautop, br, or none)"
+		},
+		"return_format_media": {
+			"type": "string",
+			"enum": [ "array", "url", "id" ],
+			"default": "array",
+			"description": "How the media value is returned (array of data, URL string, or attachment ID)"
+		},
+		"library": {
+			"type": "string",
+			"enum": [ "all", "uploadedTo" ],
+			"default": "all",
+			"description": "Media library source (all media or uploaded to current post only)"
+		},
+		"mime_types": {
+			"type": "string",
+			"default": "",
+			"description": "Comma-separated list of allowed MIME types (e.g., 'image/png, image/jpeg')"
+		},
+		"preview_size": {
+			"type": "string",
+			"default": "medium",
+			"description": "Image size for preview display in admin"
+		},
+		"min_width": {
+			"type": "integer",
+			"default": 0,
+			"description": "Minimum image width in pixels (0 for no limit)"
+		},
+		"min_height": {
+			"type": "integer",
+			"default": 0,
+			"description": "Minimum image height in pixels (0 for no limit)"
+		},
+		"max_width": {
+			"type": "integer",
+			"default": 0,
+			"description": "Maximum image width in pixels (0 for no limit)"
+		},
+		"max_height": {
+			"type": "integer",
+			"default": 0,
+			"description": "Maximum image height in pixels (0 for no limit)"
+		},
+		"min_size": {
+			"type": "integer",
+			"default": 0,
+			"description": "Minimum file size in bytes (0 for no limit)"
+		},
+		"max_size": {
+			"type": "integer",
+			"default": 0,
+			"description": "Maximum file size in bytes (0 for no limit)"
 		}
 	}
 }

--- a/schemas/field-fragments/field-base.schema.json
+++ b/schemas/field-fragments/field-base.schema.json
@@ -271,12 +271,12 @@
 		"min_size": {
 			"type": "integer",
 			"default": 0,
-			"description": "Minimum file size in bytes (0 for no limit)"
+			"description": "Minimum file size in MB (0 for no limit)"
 		},
 		"max_size": {
 			"type": "integer",
 			"default": 0,
-			"description": "Maximum file size in bytes (0 for no limit)"
+			"description": "Maximum file size in MB (0 for no limit)"
 		}
 	}
 }

--- a/schemas/field.schema.json
+++ b/schemas/field.schema.json
@@ -1008,13 +1008,720 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "enum": [
+                                "file"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "return_format": {
+                            "$ref": "#/definitions/return_format_media"
+                        },
+                        "library": {
+                            "$ref": "#/definitions/library"
+                        },
+                        "min_size": {
+                            "$ref": "#/definitions/min_size"
+                        },
+                        "max_size": {
+                            "$ref": "#/definitions/max_size"
+                        },
+                        "mime_types": {
+                            "$ref": "#/definitions/mime_types"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "gallery"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "return_format": {
+                            "$ref": "#/definitions/return_format_media"
+                        },
+                        "preview_size": {
+                            "$ref": "#/definitions/preview_size"
+                        },
+                        "library": {
+                            "$ref": "#/definitions/library"
+                        },
+                        "min_width": {
+                            "$ref": "#/definitions/min_width"
+                        },
+                        "min_height": {
+                            "$ref": "#/definitions/min_height"
+                        },
+                        "min_size": {
+                            "$ref": "#/definitions/min_size"
+                        },
+                        "max_width": {
+                            "$ref": "#/definitions/max_width"
+                        },
+                        "max_height": {
+                            "$ref": "#/definitions/max_height"
+                        },
+                        "max_size": {
+                            "$ref": "#/definitions/max_size"
+                        },
+                        "mime_types": {
+                            "$ref": "#/definitions/mime_types"
+                        },
+                        "min": {
+                            "type": "integer",
+                            "default": 0,
+                            "description": "Minimum number of images required"
+                        },
+                        "max": {
+                            "type": "integer",
+                            "default": 0,
+                            "description": "Maximum number of images allowed (0 for no limit)"
+                        },
+                        "insert": {
                             "type": "string",
                             "enum": [
-                                "image",
-                                "file",
-                                "wysiwyg",
-                                "oembed",
-                                "gallery",
+                                "append",
+                                "prepend"
+                            ],
+                            "default": "append",
+                            "description": "Where to insert new images (append or prepend)"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "image"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "return_format": {
+                            "$ref": "#/definitions/return_format_media"
+                        },
+                        "preview_size": {
+                            "$ref": "#/definitions/preview_size"
+                        },
+                        "library": {
+                            "$ref": "#/definitions/library"
+                        },
+                        "min_width": {
+                            "$ref": "#/definitions/min_width"
+                        },
+                        "min_height": {
+                            "$ref": "#/definitions/min_height"
+                        },
+                        "min_size": {
+                            "$ref": "#/definitions/min_size"
+                        },
+                        "max_width": {
+                            "$ref": "#/definitions/max_width"
+                        },
+                        "max_height": {
+                            "$ref": "#/definitions/max_height"
+                        },
+                        "max_size": {
+                            "$ref": "#/definitions/max_size"
+                        },
+                        "mime_types": {
+                            "$ref": "#/definitions/mime_types"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "oembed"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "width": {
+                            "type": "string",
+                            "default": "",
+                            "description": "Maximum width of embedded content in pixels (empty for default)"
+                        },
+                        "height": {
+                            "type": "string",
+                            "default": "",
+                            "description": "Maximum height of embedded content in pixels (empty for default)"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "wysiwyg"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "default_value": {
+                            "$ref": "#/definitions/default_value"
+                        },
+                        "tabs": {
+                            "type": "string",
+                            "enum": [
+                                "all",
+                                "visual",
+                                "text"
+                            ],
+                            "default": "all",
+                            "description": "Which editor tabs to show (all, visual only, or text only)"
+                        },
+                        "toolbar": {
+                            "type": "string",
+                            "default": "full",
+                            "description": "Toolbar configuration (full or basic)"
+                        },
+                        "media_upload": {
+                            "type": "integer",
+                            "default": 1,
+                            "description": "Show media upload button (1 for yes, 0 for no)"
+                        },
+                        "delay": {
+                            "type": "integer",
+                            "default": 0,
+                            "description": "Delay TinyMCE initialization until field is clicked (1 for yes, 0 for no)"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "type": "string",
+                            "enum": [
                                 "select",
                                 "checkbox",
                                 "radio",
@@ -1224,6 +1931,65 @@
             ],
             "default": "",
             "description": "How to handle new lines in output (wpautop, br, or none)"
+        },
+        "return_format_media": {
+            "type": "string",
+            "enum": [
+                "array",
+                "url",
+                "id"
+            ],
+            "default": "array",
+            "description": "How the media value is returned (array of data, URL string, or attachment ID)"
+        },
+        "library": {
+            "type": "string",
+            "enum": [
+                "all",
+                "uploadedTo"
+            ],
+            "default": "all",
+            "description": "Media library source (all media or uploaded to current post only)"
+        },
+        "mime_types": {
+            "type": "string",
+            "default": "",
+            "description": "Comma-separated list of allowed MIME types (e.g., 'image/png, image/jpeg')"
+        },
+        "preview_size": {
+            "type": "string",
+            "default": "medium",
+            "description": "Image size for preview display in admin"
+        },
+        "min_width": {
+            "type": "integer",
+            "default": 0,
+            "description": "Minimum image width in pixels (0 for no limit)"
+        },
+        "min_height": {
+            "type": "integer",
+            "default": 0,
+            "description": "Minimum image height in pixels (0 for no limit)"
+        },
+        "max_width": {
+            "type": "integer",
+            "default": 0,
+            "description": "Maximum image width in pixels (0 for no limit)"
+        },
+        "max_height": {
+            "type": "integer",
+            "default": 0,
+            "description": "Maximum image height in pixels (0 for no limit)"
+        },
+        "min_size": {
+            "type": "integer",
+            "default": 0,
+            "description": "Minimum file size in bytes (0 for no limit)"
+        },
+        "max_size": {
+            "type": "integer",
+            "default": 0,
+            "description": "Maximum file size in bytes (0 for no limit)"
         }
     }
 }

--- a/schemas/field.schema.json
+++ b/schemas/field.schema.json
@@ -1984,12 +1984,12 @@
         "min_size": {
             "type": "integer",
             "default": 0,
-            "description": "Minimum file size in bytes (0 for no limit)"
+            "description": "Minimum file size in MB (0 for no limit)"
         },
         "max_size": {
             "type": "integer",
             "default": 0,
-            "description": "Maximum file size in bytes (0 for no limit)"
+            "description": "Maximum file size in MB (0 for no limit)"
         }
     }
 }

--- a/tests/php/schemas/FieldSchemaTest.php
+++ b/tests/php/schemas/FieldSchemaTest.php
@@ -281,6 +281,93 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Password field with all type-specific properties should be valid',
 			),
+
+			// Content fields.
+			'image field complete'         => array(
+				array(
+					'key'           => 'field_image_full',
+					'label'         => 'Full Image',
+					'name'          => 'image_full',
+					'type'          => 'image',
+					'parent'        => 'group_test',
+					'return_format' => 'array',
+					'preview_size'  => 'medium',
+					'library'       => 'all',
+					'min_width'     => 0,
+					'min_height'    => 0,
+					'min_size'      => 0,
+					'max_width'     => 0,
+					'max_height'    => 0,
+					'max_size'      => 0,
+					'mime_types'    => '',
+				),
+				'Image field with all type-specific properties should be valid',
+			),
+			'file field complete'          => array(
+				array(
+					'key'           => 'field_file_full',
+					'label'         => 'Full File',
+					'name'          => 'file_full',
+					'type'          => 'file',
+					'parent'        => 'group_test',
+					'return_format' => 'array',
+					'library'       => 'all',
+					'min_size'      => 0,
+					'max_size'      => 0,
+					'mime_types'    => '',
+				),
+				'File field with all type-specific properties should be valid',
+			),
+			'gallery field complete'       => array(
+				array(
+					'key'           => 'field_gallery_full',
+					'label'         => 'Full Gallery',
+					'name'          => 'gallery_full',
+					'type'          => 'gallery',
+					'parent'        => 'group_test',
+					'return_format' => 'array',
+					'preview_size'  => 'medium',
+					'library'       => 'all',
+					'min'           => 0,
+					'max'           => 0,
+					'min_width'     => 0,
+					'min_height'    => 0,
+					'min_size'      => 0,
+					'max_width'     => 0,
+					'max_height'    => 0,
+					'max_size'      => 0,
+					'mime_types'    => '',
+					'insert'        => 'append',
+				),
+				'Gallery field with all type-specific properties should be valid',
+			),
+			'wysiwyg field complete'       => array(
+				array(
+					'key'           => 'field_wysiwyg_full',
+					'label'         => 'Full WYSIWYG',
+					'name'          => 'wysiwyg_full',
+					'type'          => 'wysiwyg',
+					'parent'        => 'group_test',
+					'default_value' => '',
+					'tabs'          => 'all',
+					'toolbar'       => 'full',
+					'media_upload'  => 1,
+					'delay'         => 0,
+				),
+				'WYSIWYG field with all type-specific properties should be valid',
+			),
+			'oembed field complete'        => array(
+				array(
+					'key'    => 'field_oembed_full',
+					'label'  => 'Full oEmbed',
+					'name'   => 'oembed_full',
+					'type'   => 'oembed',
+					'parent' => 'group_test',
+					'width'  => '',
+					'height' => '',
+				),
+				'oEmbed field with all type-specific properties should be valid',
+			),
 		);
 	}
 
@@ -292,7 +379,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 	public function invalidEntitiesProvider(): array {
 		return array(
 			// Required fields validation.
-			'missing key'            => array(
+			'missing key'                 => array(
 				array(
 					'label'  => 'No Key Field',
 					'name'   => 'no_key',
@@ -301,7 +388,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Field without key should fail validation',
 			),
-			'missing label'          => array(
+			'missing label'               => array(
 				array(
 					'key'    => 'field_no_label',
 					'name'   => 'no_label',
@@ -310,7 +397,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Field without label should fail validation',
 			),
-			'missing type'           => array(
+			'missing type'                => array(
 				array(
 					'key'    => 'field_no_type',
 					'label'  => 'No Type',
@@ -319,7 +406,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Field without type should fail validation',
 			),
-			'missing parent'         => array(
+			'missing parent'              => array(
 				array(
 					'key'   => 'field_no_parent',
 					'label' => 'No Parent',
@@ -330,7 +417,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 			),
 
 			// Pattern validation.
-			'invalid key pattern'    => array(
+			'invalid key pattern'         => array(
 				array(
 					'key'    => 'invalid_field_key',
 					'label'  => 'Bad Key Field',
@@ -342,7 +429,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 			),
 
 			// Enum validation.
-			'invalid type'           => array(
+			'invalid type'                => array(
 				array(
 					'key'    => 'field_bad_type',
 					'label'  => 'Bad Type Field',
@@ -352,7 +439,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Field with invalid type should fail validation',
 			),
-			'invalid new_lines enum' => array(
+			'invalid new_lines enum'      => array(
 				array(
 					'key'       => 'field_textarea_bad_nl',
 					'label'     => 'Bad New Lines',
@@ -362,6 +449,52 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 					'new_lines' => 'invalid_value',
 				),
 				'Textarea with invalid new_lines value should fail validation',
+			),
+
+			// Content field validation.
+			'invalid image return_format' => array(
+				array(
+					'key'           => 'field_image_bad',
+					'label'         => 'Bad Image',
+					'name'          => 'bad_image',
+					'type'          => 'image',
+					'parent'        => 'group_test',
+					'return_format' => 'invalid_format',
+				),
+				'Image with invalid return_format should fail validation',
+			),
+			'invalid image library'       => array(
+				array(
+					'key'     => 'field_image_bad_lib',
+					'label'   => 'Bad Image Library',
+					'name'    => 'bad_image_lib',
+					'type'    => 'image',
+					'parent'  => 'group_test',
+					'library' => 'invalid_library',
+				),
+				'Image with invalid library should fail validation',
+			),
+			'invalid gallery insert'      => array(
+				array(
+					'key'    => 'field_gallery_bad_insert',
+					'label'  => 'Bad Gallery Insert',
+					'name'   => 'bad_gallery_insert',
+					'type'   => 'gallery',
+					'parent' => 'group_test',
+					'insert' => 'invalid_insert',
+				),
+				'Gallery with invalid insert should fail validation',
+			),
+			'invalid wysiwyg tabs'        => array(
+				array(
+					'key'    => 'field_wysiwyg_bad_tabs',
+					'label'  => 'Bad WYSIWYG Tabs',
+					'name'   => 'bad_wysiwyg_tabs',
+					'type'   => 'wysiwyg',
+					'parent' => 'group_test',
+					'tabs'   => 'invalid_tabs',
+				),
+				'WYSIWYG with invalid tabs should fail validation',
 			),
 		);
 	}


### PR DESCRIPTION
## What

Part of #162. Adds JSON Schema fragments for content field types.

## How

- Adding 5 new field type fragments (image, file, gallery, wysiwyg, oembed)
- Adding shared property definitions to `field-base.schema.json` for media fields
- Adding tests for each content field type