### PR TITLE
JSON Schemas: add `relational` fields schema fragments

### DIFF
--- a/schemas/field-fragments/content/gallery.schema.json
+++ b/schemas/field-fragments/content/gallery.schema.json
@@ -16,16 +16,8 @@
 		"max_height": { "$ref": "#/definitions/max_height" },
 		"max_size": { "$ref": "#/definitions/max_size" },
 		"mime_types": { "$ref": "#/definitions/mime_types" },
-		"min": {
-			"type": "integer",
-			"default": 0,
-			"description": "Minimum number of images required"
-		},
-		"max": {
-			"type": "integer",
-			"default": 0,
-			"description": "Maximum number of images allowed (0 for no limit)"
-		},
+		"min": { "$ref": "#/definitions/min" },
+		"max": { "$ref": "#/definitions/max" },
 		"insert": {
 			"type": "string",
 			"enum": [ "append", "prepend" ],

--- a/schemas/field-fragments/field-base.schema.json
+++ b/schemas/field-fragments/field-base.schema.json
@@ -309,6 +309,31 @@
 			"enum": [ "vertical", "horizontal" ],
 			"default": "vertical",
 			"description": "Layout direction for choices (default varies by field type)"
+		},
+		"min": {
+			"type": "integer",
+			"default": 0,
+			"description": "Minimum number of items required (0 for no minimum)"
+		},
+		"max": {
+			"type": "integer",
+			"default": 0,
+			"description": "Maximum number of items allowed (0 for no limit)"
+		},
+		"post_type": {
+			"type": "array",
+			"default": [],
+			"description": "Limit selection to specific post types (empty for all)"
+		},
+		"taxonomy_filter": {
+			"type": "array",
+			"default": [],
+			"description": "Limit selection to posts with specific taxonomy terms"
+		},
+		"bidirectional_target": {
+			"type": "array",
+			"default": [],
+			"description": "Target fields for bidirectional relationships"
 		}
 	}
 }

--- a/schemas/field-fragments/relational/link.schema.json
+++ b/schemas/field-fragments/relational/link.schema.json
@@ -1,0 +1,16 @@
+{
+	"title": "SCF Link Field Fragment",
+	"description": "Type-specific properties for link fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "link" ]
+		},
+		"return_format": {
+			"type": "string",
+			"enum": [ "array", "url" ],
+			"default": "array",
+			"description": "Value returned (array with url/title/target or just URL string)"
+		}
+	}
+}

--- a/schemas/field-fragments/relational/page-link.schema.json
+++ b/schemas/field-fragments/relational/page-link.schema.json
@@ -1,0 +1,19 @@
+{
+	"title": "SCF Page Link Field Fragment",
+	"description": "Type-specific properties for page link fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "page_link" ]
+		},
+		"post_type": { "$ref": "#/definitions/post_type" },
+		"taxonomy": { "$ref": "#/definitions/taxonomy_filter" },
+		"allow_null": { "$ref": "#/definitions/allow_null" },
+		"multiple": { "$ref": "#/definitions/multiple" },
+		"allow_archives": {
+			"type": "integer",
+			"default": 1,
+			"description": "Allow archive URLs to be selected (1 for yes, 0 for no)"
+		}
+	}
+}

--- a/schemas/field-fragments/relational/post-object.schema.json
+++ b/schemas/field-fragments/relational/post-object.schema.json
@@ -1,0 +1,26 @@
+{
+	"title": "SCF Post Object Field Fragment",
+	"description": "Type-specific properties for post object fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "post_object" ]
+		},
+		"post_type": { "$ref": "#/definitions/post_type" },
+		"taxonomy": { "$ref": "#/definitions/taxonomy_filter" },
+		"allow_null": { "$ref": "#/definitions/allow_null" },
+		"multiple": { "$ref": "#/definitions/multiple" },
+		"return_format": {
+			"type": "string",
+			"enum": [ "object", "id" ],
+			"default": "object",
+			"description": "Value returned (WP_Post object or post ID)"
+		},
+		"ui": {
+			"type": "integer",
+			"default": 1,
+			"description": "Use enhanced Select2 UI (1 for yes, 0 for no)"
+		},
+		"bidirectional_target": { "$ref": "#/definitions/bidirectional_target" }
+	}
+}

--- a/schemas/field-fragments/relational/relationship.schema.json
+++ b/schemas/field-fragments/relational/relationship.schema.json
@@ -1,0 +1,31 @@
+{
+	"title": "SCF Relationship Field Fragment",
+	"description": "Type-specific properties for relationship fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "relationship" ]
+		},
+		"post_type": { "$ref": "#/definitions/post_type" },
+		"taxonomy": { "$ref": "#/definitions/taxonomy_filter" },
+		"min": { "$ref": "#/definitions/min" },
+		"max": { "$ref": "#/definitions/max" },
+		"filters": {
+			"type": "array",
+			"default": [ "search", "post_type", "taxonomy" ],
+			"description": "Enabled filters for the relationship field UI"
+		},
+		"elements": {
+			"type": "array",
+			"default": [],
+			"description": "Additional elements to display (e.g., 'featured_image')"
+		},
+		"return_format": {
+			"type": "string",
+			"enum": [ "object", "id" ],
+			"default": "object",
+			"description": "Value returned (WP_Post object or post ID)"
+		},
+		"bidirectional_target": { "$ref": "#/definitions/bidirectional_target" }
+	}
+}

--- a/schemas/field-fragments/relational/taxonomy.schema.json
+++ b/schemas/field-fragments/relational/taxonomy.schema.json
@@ -1,0 +1,45 @@
+{
+	"title": "SCF Taxonomy Field Fragment",
+	"description": "Type-specific properties for taxonomy term selection fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "taxonomy" ]
+		},
+		"taxonomy": {
+			"type": "string",
+			"default": "category",
+			"description": "The taxonomy to select terms from"
+		},
+		"field_type": {
+			"type": "string",
+			"enum": [ "checkbox", "multi_select", "radio", "select" ],
+			"default": "checkbox",
+			"description": "UI type for term selection"
+		},
+		"multiple": { "$ref": "#/definitions/multiple" },
+		"allow_null": { "$ref": "#/definitions/allow_null" },
+		"return_format": {
+			"type": "string",
+			"enum": [ "object", "id" ],
+			"default": "id",
+			"description": "Value returned (WP_Term object or term ID)"
+		},
+		"add_term": {
+			"type": "integer",
+			"default": 1,
+			"description": "Allow new terms to be created (1 for yes, 0 for no)"
+		},
+		"load_terms": {
+			"type": "integer",
+			"default": 0,
+			"description": "Load terms assigned to post (1 for yes, 0 for no)"
+		},
+		"save_terms": {
+			"type": "integer",
+			"default": 0,
+			"description": "Connect selected terms to post (1 for yes, 0 for no)"
+		},
+		"bidirectional_target": { "$ref": "#/definitions/bidirectional_target" }
+	}
+}

--- a/schemas/field-fragments/relational/user.schema.json
+++ b/schemas/field-fragments/relational/user.schema.json
@@ -1,0 +1,24 @@
+{
+	"title": "SCF User Field Fragment",
+	"description": "Type-specific properties for user selection fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "user" ]
+		},
+		"role": {
+			"type": "string",
+			"default": "",
+			"description": "Limit to specific user role (empty for all roles)"
+		},
+		"multiple": { "$ref": "#/definitions/multiple" },
+		"allow_null": { "$ref": "#/definitions/allow_null" },
+		"return_format": {
+			"type": "string",
+			"enum": [ "array", "object", "id" ],
+			"default": "array",
+			"description": "Value returned (user array, WP_User object, or user ID)"
+		},
+		"bidirectional_target": { "$ref": "#/definitions/bidirectional_target" }
+	}
+}

--- a/schemas/field.schema.json
+++ b/schemas/field.schema.json
@@ -2108,14 +2108,10 @@
                             "$ref": "#/definitions/mime_types"
                         },
                         "min": {
-                            "type": "integer",
-                            "default": 0,
-                            "description": "Minimum number of images required"
+                            "$ref": "#/definitions/min"
                         },
                         "max": {
-                            "type": "integer",
-                            "default": 0,
-                            "description": "Maximum number of images allowed (0 for no limit)"
+                            "$ref": "#/definitions/max"
                         },
                         "insert": {
                             "type": "string",
@@ -2575,14 +2571,870 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "enum": [
+                                "link"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "return_format": {
                             "type": "string",
                             "enum": [
-                                "link",
-                                "post_object",
-                                "page_link",
-                                "relationship",
-                                "taxonomy",
-                                "user",
+                                "array",
+                                "url"
+                            ],
+                            "default": "array",
+                            "description": "Value returned (array with url/title/target or just URL string)"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "page_link"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "post_type": {
+                            "$ref": "#/definitions/post_type"
+                        },
+                        "taxonomy": {
+                            "$ref": "#/definitions/taxonomy_filter"
+                        },
+                        "allow_null": {
+                            "$ref": "#/definitions/allow_null"
+                        },
+                        "multiple": {
+                            "$ref": "#/definitions/multiple"
+                        },
+                        "allow_archives": {
+                            "type": "integer",
+                            "default": 1,
+                            "description": "Allow archive URLs to be selected (1 for yes, 0 for no)"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "post_object"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "post_type": {
+                            "$ref": "#/definitions/post_type"
+                        },
+                        "taxonomy": {
+                            "$ref": "#/definitions/taxonomy_filter"
+                        },
+                        "allow_null": {
+                            "$ref": "#/definitions/allow_null"
+                        },
+                        "multiple": {
+                            "$ref": "#/definitions/multiple"
+                        },
+                        "return_format": {
+                            "type": "string",
+                            "enum": [
+                                "object",
+                                "id"
+                            ],
+                            "default": "object",
+                            "description": "Value returned (WP_Post object or post ID)"
+                        },
+                        "ui": {
+                            "type": "integer",
+                            "default": 1,
+                            "description": "Use enhanced Select2 UI (1 for yes, 0 for no)"
+                        },
+                        "bidirectional_target": {
+                            "$ref": "#/definitions/bidirectional_target"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "relationship"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "post_type": {
+                            "$ref": "#/definitions/post_type"
+                        },
+                        "taxonomy": {
+                            "$ref": "#/definitions/taxonomy_filter"
+                        },
+                        "min": {
+                            "$ref": "#/definitions/min"
+                        },
+                        "max": {
+                            "$ref": "#/definitions/max"
+                        },
+                        "filters": {
+                            "type": "array",
+                            "default": [
+                                "search",
+                                "post_type",
+                                "taxonomy"
+                            ],
+                            "description": "Enabled filters for the relationship field UI"
+                        },
+                        "elements": {
+                            "type": "array",
+                            "default": [],
+                            "description": "Additional elements to display (e.g., 'featured_image')"
+                        },
+                        "return_format": {
+                            "type": "string",
+                            "enum": [
+                                "object",
+                                "id"
+                            ],
+                            "default": "object",
+                            "description": "Value returned (WP_Post object or post ID)"
+                        },
+                        "bidirectional_target": {
+                            "$ref": "#/definitions/bidirectional_target"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "taxonomy"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "taxonomy": {
+                            "type": "string",
+                            "default": "category",
+                            "description": "The taxonomy to select terms from"
+                        },
+                        "field_type": {
+                            "type": "string",
+                            "enum": [
+                                "checkbox",
+                                "multi_select",
+                                "radio",
+                                "select"
+                            ],
+                            "default": "checkbox",
+                            "description": "UI type for term selection"
+                        },
+                        "multiple": {
+                            "$ref": "#/definitions/multiple"
+                        },
+                        "allow_null": {
+                            "$ref": "#/definitions/allow_null"
+                        },
+                        "return_format": {
+                            "type": "string",
+                            "enum": [
+                                "object",
+                                "id"
+                            ],
+                            "default": "id",
+                            "description": "Value returned (WP_Term object or term ID)"
+                        },
+                        "add_term": {
+                            "type": "integer",
+                            "default": 1,
+                            "description": "Allow new terms to be created (1 for yes, 0 for no)"
+                        },
+                        "load_terms": {
+                            "type": "integer",
+                            "default": 0,
+                            "description": "Load terms assigned to post (1 for yes, 0 for no)"
+                        },
+                        "save_terms": {
+                            "type": "integer",
+                            "default": 0,
+                            "description": "Connect selected terms to post (1 for yes, 0 for no)"
+                        },
+                        "bidirectional_target": {
+                            "$ref": "#/definitions/bidirectional_target"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "user"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "role": {
+                            "type": "string",
+                            "default": "",
+                            "description": "Limit to specific user role (empty for all roles)"
+                        },
+                        "multiple": {
+                            "$ref": "#/definitions/multiple"
+                        },
+                        "allow_null": {
+                            "$ref": "#/definitions/allow_null"
+                        },
+                        "return_format": {
+                            "type": "string",
+                            "enum": [
+                                "array",
+                                "object",
+                                "id"
+                            ],
+                            "default": "array",
+                            "description": "Value returned (user array, WP_User object, or user ID)"
+                        },
+                        "bidirectional_target": {
+                            "$ref": "#/definitions/bidirectional_target"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "type": "string",
+                            "enum": [
                                 "google_map",
                                 "date_picker",
                                 "date_time_picker",
@@ -2884,6 +3736,31 @@
             ],
             "default": "vertical",
             "description": "Layout direction for choices (default varies by field type)"
+        },
+        "min": {
+            "type": "integer",
+            "default": 0,
+            "description": "Minimum number of items required (0 for no minimum)"
+        },
+        "max": {
+            "type": "integer",
+            "default": 0,
+            "description": "Maximum number of items allowed (0 for no limit)"
+        },
+        "post_type": {
+            "type": "array",
+            "default": [],
+            "description": "Limit selection to specific post types (empty for all)"
+        },
+        "taxonomy_filter": {
+            "type": "array",
+            "default": [],
+            "description": "Limit selection to posts with specific taxonomy terms"
+        },
+        "bidirectional_target": {
+            "type": "array",
+            "default": [],
+            "description": "Target fields for bidirectional relationships"
         }
     }
 }

--- a/tests/php/schemas/FieldSchemaTest.php
+++ b/tests/php/schemas/FieldSchemaTest.php
@@ -468,6 +468,103 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Nav Menu field with all type-specific properties should be valid',
 			),
+
+			// Relational fields.
+			'post_object field complete'   => array(
+				array(
+					'key'                  => 'field_post_object_full',
+					'label'                => 'Full Post Object',
+					'name'                 => 'post_object_full',
+					'type'                 => 'post_object',
+					'parent'               => 'group_test',
+					'post_type'            => array(),
+					'taxonomy'             => array(),
+					'allow_null'           => 0,
+					'multiple'             => 0,
+					'return_format'        => 'object',
+					'ui'                   => 1,
+					'bidirectional_target' => array(),
+				),
+				'Post Object field with all type-specific properties should be valid',
+			),
+			'page_link field complete'     => array(
+				array(
+					'key'            => 'field_page_link_full',
+					'label'          => 'Full Page Link',
+					'name'           => 'page_link_full',
+					'type'           => 'page_link',
+					'parent'         => 'group_test',
+					'post_type'      => array(),
+					'taxonomy'       => array(),
+					'allow_null'     => 0,
+					'multiple'       => 0,
+					'allow_archives' => 1,
+				),
+				'Page Link field with all type-specific properties should be valid',
+			),
+			'relationship field complete'  => array(
+				array(
+					'key'                  => 'field_relationship_full',
+					'label'                => 'Full Relationship',
+					'name'                 => 'relationship_full',
+					'type'                 => 'relationship',
+					'parent'               => 'group_test',
+					'post_type'            => array(),
+					'taxonomy'             => array(),
+					'min'                  => 0,
+					'max'                  => 5,
+					'filters'              => array( 'search', 'post_type' ),
+					'elements'             => array(),
+					'return_format'        => 'object',
+					'bidirectional_target' => array(),
+				),
+				'Relationship field with all type-specific properties should be valid',
+			),
+			'taxonomy field complete'      => array(
+				array(
+					'key'                  => 'field_taxonomy_full',
+					'label'                => 'Full Taxonomy',
+					'name'                 => 'taxonomy_full',
+					'type'                 => 'taxonomy',
+					'parent'               => 'group_test',
+					'taxonomy'             => 'category',
+					'field_type'           => 'checkbox',
+					'multiple'             => 0,
+					'allow_null'           => 0,
+					'return_format'        => 'id',
+					'add_term'             => 1,
+					'load_terms'           => 0,
+					'save_terms'           => 0,
+					'bidirectional_target' => array(),
+				),
+				'Taxonomy field with all type-specific properties should be valid',
+			),
+			'user field complete'          => array(
+				array(
+					'key'                  => 'field_user_full',
+					'label'                => 'Full User',
+					'name'                 => 'user_full',
+					'type'                 => 'user',
+					'parent'               => 'group_test',
+					'role'                 => '',
+					'multiple'             => 0,
+					'allow_null'           => 0,
+					'return_format'        => 'array',
+					'bidirectional_target' => array(),
+				),
+				'User field with all type-specific properties should be valid',
+			),
+			'link field complete'          => array(
+				array(
+					'key'           => 'field_link_full',
+					'label'         => 'Full Link',
+					'name'          => 'link_full',
+					'type'          => 'link',
+					'parent'        => 'group_test',
+					'return_format' => 'array',
+				),
+				'Link field with all type-specific properties should be valid',
+			),
 		);
 	}
 
@@ -479,7 +576,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 	public function invalidEntitiesProvider(): array {
 		return array(
 			// Required fields validation.
-			'missing key'                  => array(
+			'missing key'                        => array(
 				array(
 					'label'  => 'No Key Field',
 					'name'   => 'no_key',
@@ -488,7 +585,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Field without key should fail validation',
 			),
-			'missing label'                => array(
+			'missing label'                      => array(
 				array(
 					'key'    => 'field_no_label',
 					'name'   => 'no_label',
@@ -497,7 +594,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Field without label should fail validation',
 			),
-			'missing type'                 => array(
+			'missing type'                       => array(
 				array(
 					'key'    => 'field_no_type',
 					'label'  => 'No Type',
@@ -506,7 +603,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Field without type should fail validation',
 			),
-			'missing parent'               => array(
+			'missing parent'                     => array(
 				array(
 					'key'   => 'field_no_parent',
 					'label' => 'No Parent',
@@ -517,7 +614,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 			),
 
 			// Pattern validation.
-			'invalid key pattern'          => array(
+			'invalid key pattern'                => array(
 				array(
 					'key'    => 'invalid_field_key',
 					'label'  => 'Bad Key Field',
@@ -529,7 +626,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 			),
 
 			// Enum validation.
-			'invalid type'                 => array(
+			'invalid type'                       => array(
 				array(
 					'key'    => 'field_bad_type',
 					'label'  => 'Bad Type Field',
@@ -539,7 +636,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Field with invalid type should fail validation',
 			),
-			'invalid new_lines enum'       => array(
+			'invalid new_lines enum'             => array(
 				array(
 					'key'       => 'field_textarea_bad_nl',
 					'label'     => 'Bad New Lines',
@@ -552,7 +649,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 			),
 
 			// Content field validation.
-			'invalid image return_format'  => array(
+			'invalid image return_format'        => array(
 				array(
 					'key'           => 'field_image_bad',
 					'label'         => 'Bad Image',
@@ -563,7 +660,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Image with invalid return_format should fail validation',
 			),
-			'invalid image library'        => array(
+			'invalid image library'              => array(
 				array(
 					'key'     => 'field_image_bad_lib',
 					'label'   => 'Bad Image Library',
@@ -574,7 +671,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Image with invalid library should fail validation',
 			),
-			'invalid gallery insert'       => array(
+			'invalid gallery insert'             => array(
 				array(
 					'key'    => 'field_gallery_bad_insert',
 					'label'  => 'Bad Gallery Insert',
@@ -585,7 +682,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Gallery with invalid insert should fail validation',
 			),
-			'invalid wysiwyg tabs'         => array(
+			'invalid wysiwyg tabs'               => array(
 				array(
 					'key'    => 'field_wysiwyg_bad_tabs',
 					'label'  => 'Bad WYSIWYG Tabs',
@@ -598,7 +695,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 			),
 
 			// Choice field validation.
-			'invalid select return_format' => array(
+			'invalid select return_format'       => array(
 				array(
 					'key'           => 'field_select_bad',
 					'label'         => 'Bad Select',
@@ -609,7 +706,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Select with invalid return_format should fail validation',
 			),
-			'invalid checkbox layout'      => array(
+			'invalid checkbox layout'            => array(
 				array(
 					'key'    => 'field_checkbox_bad',
 					'label'  => 'Bad Checkbox',
@@ -620,7 +717,7 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Checkbox with invalid layout should fail validation',
 			),
-			'invalid nav_menu save_format' => array(
+			'invalid nav_menu save_format'       => array(
 				array(
 					'key'         => 'field_nav_menu_bad',
 					'label'       => 'Bad Nav Menu',
@@ -630,6 +727,74 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 					'save_format' => 'invalid_format',
 				),
 				'Nav Menu with invalid save_format should fail validation',
+			),
+
+			// Relational field validation.
+			'invalid post_object return_format'  => array(
+				array(
+					'key'           => 'field_post_object_bad',
+					'label'         => 'Bad Post Object',
+					'name'          => 'bad_post_object',
+					'type'          => 'post_object',
+					'parent'        => 'group_test',
+					'return_format' => 'array',
+				),
+				'Post Object with invalid return_format should fail validation',
+			),
+			'invalid relationship return_format' => array(
+				array(
+					'key'           => 'field_relationship_bad',
+					'label'         => 'Bad Relationship',
+					'name'          => 'bad_relationship',
+					'type'          => 'relationship',
+					'parent'        => 'group_test',
+					'return_format' => 'array',
+				),
+				'Relationship with invalid return_format should fail validation',
+			),
+			'invalid taxonomy field_type'        => array(
+				array(
+					'key'        => 'field_taxonomy_bad_type',
+					'label'      => 'Bad Taxonomy Type',
+					'name'       => 'bad_taxonomy_type',
+					'type'       => 'taxonomy',
+					'parent'     => 'group_test',
+					'field_type' => 'invalid_type',
+				),
+				'Taxonomy with invalid field_type should fail validation',
+			),
+			'invalid taxonomy return_format'     => array(
+				array(
+					'key'           => 'field_taxonomy_bad_format',
+					'label'         => 'Bad Taxonomy Format',
+					'name'          => 'bad_taxonomy_format',
+					'type'          => 'taxonomy',
+					'parent'        => 'group_test',
+					'return_format' => 'array',
+				),
+				'Taxonomy with invalid return_format should fail validation',
+			),
+			'invalid user return_format'         => array(
+				array(
+					'key'           => 'field_user_bad',
+					'label'         => 'Bad User',
+					'name'          => 'bad_user',
+					'type'          => 'user',
+					'parent'        => 'group_test',
+					'return_format' => 'invalid_format',
+				),
+				'User with invalid return_format should fail validation',
+			),
+			'invalid link return_format'         => array(
+				array(
+					'key'           => 'field_link_bad',
+					'label'         => 'Bad Link',
+					'name'          => 'bad_link',
+					'type'          => 'link',
+					'parent'        => 'group_test',
+					'return_format' => 'object',
+				),
+				'Link with invalid return_format should fail validation',
 			),
 		);
 	}


### PR DESCRIPTION
## What

Part of #162. Adds JSON Schema fragments for relational field types.

## How

- Adding 6 new field type fragments (`post_object`, `page_link`, `relationship`, `taxonomy`, `user`, `link`)
- Adding shared property definitions to `field-base.schema.json` for relational fields (`min`, `max`, `post_type`, `taxonomy_filter`, `bidirectional_target`)
- Updating `gallery` fragment to use shared `min`/`max` refs (extracted on second use per DRY principle)
- Adding tests for each relational field type