### PR TITLE
JSON Schemas: add `layout` fields schema fragments

### DIFF
--- a/includes/class-scf-schema-builder.php
+++ b/includes/class-scf-schema-builder.php
@@ -117,6 +117,49 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 		}
 
 		/**
+		 * Merges schema properties intelligently, preserving base type definitions.
+		 *
+		 * When merging the 'type' property, if the fragment only defines 'enum',
+		 * we preserve the base's 'type': 'string' definition.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param array $base_props Base properties from field-base.schema.json.
+		 * @param array $type_props Type-specific properties from fragment files.
+		 * @return array Merged properties.
+		 */
+		private function merge_schema_properties( array $base_props, array $type_props ): array {
+			$merged = $base_props;
+
+			foreach ( $type_props as $prop_name => $prop_value ) {
+				// Special handling for 'type' property to preserve "type": "string".
+				if ( 'type' === $prop_name && isset( $merged['type'] ) && is_array( $merged['type'] ) && is_array( $prop_value ) ) {
+					// If base has "type": "string" and fragment only has "enum", merge them.
+					if ( isset( $merged['type']['type'] ) && isset( $prop_value['enum'] ) ) {
+						$merged['type'] = array(
+							'type' => $merged['type']['type'],
+							'enum' => $prop_value['enum'],
+						);
+						// Preserve description if present in base.
+						if ( isset( $merged['type']['description'] ) ) {
+							$merged['type']['description'] = $merged['type']['description'];
+						}
+						continue;
+					}
+				}
+
+				// For other properties, recursively merge arrays or overwrite.
+				if ( isset( $merged[ $prop_name ] ) && is_array( $merged[ $prop_name ] ) && is_array( $prop_value ) ) {
+					$merged[ $prop_name ] = array_merge( $merged[ $prop_name ], $prop_value );
+				} else {
+					$merged[ $prop_name ] = $prop_value;
+				}
+			}
+
+			return $merged;
+		}
+
+		/**
 		 * Composes a field schema with oneOf containing all type variants.
 		 *
 		 * Each variant merges base field properties with type-specific properties,
@@ -146,30 +189,31 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 				$variants[] = array(
 					'type'                 => 'object',
 					'required'             => array( 'key', 'label', 'name', 'type', 'parent' ),
-					'properties'           => array_merge( $base_props, $type_props ),
+					'properties'           => $this->merge_schema_properties( $base_props, $type_props ),
 					'additionalProperties' => $type_schema['additionalProperties'] ?? false,
 				);
 			}
 
 			// Temporary fallback for field types without specific schemas.
-			// This will be removed once all 35 field types have dedicated schema files.
-			// Exclude types that have specific schemas by modifying the type enum.
+			// Only added when there are types that don't have dedicated schema files.
 			$known_types    = array_keys( $type_schemas );
 			$all_types      = $base_props['type']['enum'] ?? array();
 			$fallback_types = array_values( array_diff( $all_types, $known_types ) );
 
-			$fallback_props         = $base_props;
-			$fallback_props['type'] = array(
-				'type' => 'string',
-				'enum' => $fallback_types,
-			);
+			if ( ! empty( $fallback_types ) ) {
+				$fallback_props         = $base_props;
+				$fallback_props['type'] = array(
+					'type' => 'string',
+					'enum' => $fallback_types,
+				);
 
-			$variants[] = array(
-				'type'                 => 'object',
-				'required'             => array( 'key', 'label', 'name', 'type', 'parent' ),
-				'properties'           => $fallback_props,
-				'additionalProperties' => true,
-			);
+				$variants[] = array(
+					'type'                 => 'object',
+					'required'             => array( 'key', 'label', 'name', 'type', 'parent' ),
+					'properties'           => $fallback_props,
+					'additionalProperties' => true,
+				);
+			}
 
 			$this->composed_field_schema = array(
 				'oneOf' => $variants,

--- a/schemas/field-fragments/field-base.schema.json
+++ b/schemas/field-fragments/field-base.schema.json
@@ -344,6 +344,26 @@
 			"type": "integer",
 			"default": 0,
 			"description": "Set current date/time as default value (1 for yes, 0 for no)"
+		},
+		"sub_fields": {
+			"type": "array",
+			"default": [],
+			"description": "Nested fields within this field"
+		},
+		"layout_display": {
+			"type": "string",
+			"enum": [ "block", "table", "row" ],
+			"description": "Visual layout style for rendering fields"
+		},
+		"button_label": {
+			"type": "string",
+			"default": "",
+			"description": "Text label for the add row button"
+		},
+		"endpoint": {
+			"type": "integer",
+			"default": 0,
+			"description": "Define an endpoint for the previous accordion/tab group"
 		}
 	}
 }

--- a/schemas/field-fragments/layout/accordion.schema.json
+++ b/schemas/field-fragments/layout/accordion.schema.json
@@ -1,0 +1,21 @@
+{
+	"title": "SCF Accordion Field Fragment",
+	"description": "Type-specific properties for accordion fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "accordion" ]
+		},
+		"open": {
+			"type": "integer",
+			"default": 0,
+			"description": "Display this accordion as open on page load"
+		},
+		"multi_expand": {
+			"type": "integer",
+			"default": 0,
+			"description": "Allow this accordion to open without closing others"
+		},
+		"endpoint": { "$ref": "#/definitions/endpoint" }
+	}
+}

--- a/schemas/field-fragments/layout/clone.schema.json
+++ b/schemas/field-fragments/layout/clone.schema.json
@@ -1,0 +1,35 @@
+{
+	"title": "SCF Clone Field Fragment",
+	"description": "Type-specific properties for clone fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "clone" ]
+		},
+		"clone": {
+			"type": [ "string", "array" ],
+			"default": "",
+			"description": "Field keys or group keys to clone"
+		},
+		"prefix_label": {
+			"type": "integer",
+			"default": 0,
+			"description": "Prefix cloned field labels with this field's label"
+		},
+		"prefix_name": {
+			"type": "integer",
+			"default": 0,
+			"description": "Prefix cloned field names with this field's name"
+		},
+		"display": {
+			"type": "string",
+			"enum": [ "group", "seamless" ],
+			"default": "seamless",
+			"description": "Display style for cloned fields"
+		},
+		"layout": {
+			"$ref": "#/definitions/layout_display",
+			"default": "block"
+		}
+	}
+}

--- a/schemas/field-fragments/layout/flexible-content.schema.json
+++ b/schemas/field-fragments/layout/flexible-content.schema.json
@@ -1,0 +1,30 @@
+{
+	"title": "SCF Flexible Content Field Fragment",
+	"description": "Type-specific properties for flexible content fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "flexible_content" ]
+		},
+		"layouts": {
+			"type": "array",
+			"default": [],
+			"description": "Available layout configurations"
+		},
+		"min": {
+			"type": [ "integer", "string" ],
+			"default": "",
+			"description": "Minimum number of layouts (empty for no limit)"
+		},
+		"max": {
+			"type": [ "integer", "string" ],
+			"default": "",
+			"description": "Maximum number of layouts (empty for no limit)"
+		},
+		"button_label": {
+			"type": "string",
+			"default": "Add Row",
+			"description": "Text label for the add row button"
+		}
+	}
+}

--- a/schemas/field-fragments/layout/group.schema.json
+++ b/schemas/field-fragments/layout/group.schema.json
@@ -1,0 +1,15 @@
+{
+	"title": "SCF Group Field Fragment",
+	"description": "Type-specific properties for group fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "group" ]
+		},
+		"sub_fields": { "$ref": "#/definitions/sub_fields" },
+		"layout": {
+			"$ref": "#/definitions/layout_display",
+			"default": "block"
+		}
+	}
+}

--- a/schemas/field-fragments/layout/message.schema.json
+++ b/schemas/field-fragments/layout/message.schema.json
@@ -1,0 +1,26 @@
+{
+	"title": "SCF Message Field Fragment",
+	"description": "Type-specific properties for message fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "message" ]
+		},
+		"message": {
+			"type": "string",
+			"default": "",
+			"description": "Message content to display"
+		},
+		"esc_html": {
+			"type": "integer",
+			"default": 0,
+			"description": "Display HTML as visible text instead of rendering"
+		},
+		"new_lines": {
+			"type": "string",
+			"enum": [ "wpautop", "br", "" ],
+			"default": "wpautop",
+			"description": "Controls how new lines are rendered"
+		}
+	}
+}

--- a/schemas/field-fragments/layout/output.schema.json
+++ b/schemas/field-fragments/layout/output.schema.json
@@ -1,0 +1,15 @@
+{
+	"title": "SCF Output Field Fragment",
+	"description": "Type-specific properties for output fields (deprecated since ACF 6.3.2)",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "output" ]
+		},
+		"html": {
+			"type": "boolean",
+			"default": false,
+			"description": "Whether to output raw HTML"
+		}
+	}
+}

--- a/schemas/field-fragments/layout/repeater.schema.json
+++ b/schemas/field-fragments/layout/repeater.schema.json
@@ -14,6 +14,11 @@
 			"default": "table"
 		},
 		"button_label": { "$ref": "#/definitions/button_label" },
+		"pagination": {
+			"type": [ "boolean", "integer" ],
+			"default": 0,
+			"description": "Enable pagination for repeaters with many rows"
+		},
 		"rows_per_page": {
 			"type": "integer",
 			"default": 20,

--- a/schemas/field-fragments/layout/repeater.schema.json
+++ b/schemas/field-fragments/layout/repeater.schema.json
@@ -1,0 +1,28 @@
+{
+	"title": "SCF Repeater Field Fragment",
+	"description": "Type-specific properties for repeater fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "repeater" ]
+		},
+		"sub_fields": { "$ref": "#/definitions/sub_fields" },
+		"min": { "$ref": "#/definitions/min" },
+		"max": { "$ref": "#/definitions/max" },
+		"layout": {
+			"$ref": "#/definitions/layout_display",
+			"default": "table"
+		},
+		"button_label": { "$ref": "#/definitions/button_label" },
+		"rows_per_page": {
+			"type": "integer",
+			"default": 20,
+			"description": "Number of rows displayed per page when pagination is enabled"
+		},
+		"collapsed": {
+			"type": "string",
+			"default": "",
+			"description": "Field key to use as collapsed row title"
+		}
+	}
+}

--- a/schemas/field-fragments/layout/separator.schema.json
+++ b/schemas/field-fragments/layout/separator.schema.json
@@ -1,0 +1,10 @@
+{
+	"title": "SCF Separator Field Fragment",
+	"description": "Type-specific properties for separator fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "separator" ]
+		}
+	}
+}

--- a/schemas/field-fragments/layout/tab.schema.json
+++ b/schemas/field-fragments/layout/tab.schema.json
@@ -1,0 +1,22 @@
+{
+	"title": "SCF Tab Field Fragment",
+	"description": "Type-specific properties for tab fields",
+	"type": "object",
+	"properties": {
+		"type": {
+			"enum": [ "tab" ]
+		},
+		"placement": {
+			"type": "string",
+			"enum": [ "top", "left" ],
+			"default": "top",
+			"description": "Tab placement position"
+		},
+		"endpoint": { "$ref": "#/definitions/endpoint" },
+		"selected": {
+			"type": "integer",
+			"default": 0,
+			"description": "Whether this tab is selected by default"
+		}
+	}
+}

--- a/schemas/field.schema.json
+++ b/schemas/field.schema.json
@@ -4085,6 +4085,127 @@
                         },
                         "type": {
                             "enum": [
+                                "output"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "html": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Whether to output raw HTML"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
                                 "repeater"
                             ]
                         },
@@ -5338,9 +5459,7 @@
                         },
                         "type": {
                             "type": "string",
-                            "enum": [
-                                "output"
-                            ]
+                            "enum": []
                         },
                         "instructions": {
                             "type": "string",

--- a/schemas/field.schema.json
+++ b/schemas/field.schema.json
@@ -3408,6 +3408,1074 @@
                         },
                         "type": {
                             "enum": [
+                                "accordion"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "open": {
+                            "type": "integer",
+                            "default": 0,
+                            "description": "Display this accordion as open on page load"
+                        },
+                        "multi_expand": {
+                            "type": "integer",
+                            "default": 0,
+                            "description": "Allow this accordion to open without closing others"
+                        },
+                        "endpoint": {
+                            "$ref": "#/definitions/endpoint"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "clone"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "clone": {
+                            "type": [
+                                "string",
+                                "array"
+                            ],
+                            "default": "",
+                            "description": "Field keys or group keys to clone"
+                        },
+                        "prefix_label": {
+                            "type": "integer",
+                            "default": 0,
+                            "description": "Prefix cloned field labels with this field's label"
+                        },
+                        "prefix_name": {
+                            "type": "integer",
+                            "default": 0,
+                            "description": "Prefix cloned field names with this field's name"
+                        },
+                        "display": {
+                            "type": "string",
+                            "enum": [
+                                "group",
+                                "seamless"
+                            ],
+                            "default": "seamless",
+                            "description": "Display style for cloned fields"
+                        },
+                        "layout": {
+                            "$ref": "#/definitions/layout_display",
+                            "default": "block"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "flexible_content"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "layouts": {
+                            "type": "array",
+                            "default": [],
+                            "description": "Available layout configurations"
+                        },
+                        "min": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ],
+                            "default": "",
+                            "description": "Minimum number of layouts (empty for no limit)"
+                        },
+                        "max": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ],
+                            "default": "",
+                            "description": "Maximum number of layouts (empty for no limit)"
+                        },
+                        "button_label": {
+                            "type": "string",
+                            "default": "Add Row",
+                            "description": "Text label for the add row button"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "group"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "sub_fields": {
+                            "$ref": "#/definitions/sub_fields"
+                        },
+                        "layout": {
+                            "$ref": "#/definitions/layout_display",
+                            "default": "block"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "message"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "message": {
+                            "type": "string",
+                            "default": "",
+                            "description": "Message content to display"
+                        },
+                        "esc_html": {
+                            "type": "integer",
+                            "default": 0,
+                            "description": "Display HTML as visible text instead of rendering"
+                        },
+                        "new_lines": {
+                            "type": "string",
+                            "enum": [
+                                "wpautop",
+                                "br",
+                                ""
+                            ],
+                            "default": "wpautop",
+                            "description": "Controls how new lines are rendered"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "repeater"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "sub_fields": {
+                            "$ref": "#/definitions/sub_fields"
+                        },
+                        "min": {
+                            "$ref": "#/definitions/min"
+                        },
+                        "max": {
+                            "$ref": "#/definitions/max"
+                        },
+                        "layout": {
+                            "$ref": "#/definitions/layout_display",
+                            "default": "table"
+                        },
+                        "button_label": {
+                            "$ref": "#/definitions/button_label"
+                        },
+                        "rows_per_page": {
+                            "type": "integer",
+                            "default": 20,
+                            "description": "Number of rows displayed per page when pagination is enabled"
+                        },
+                        "collapsed": {
+                            "type": "string",
+                            "default": "",
+                            "description": "Field key to use as collapsed row title"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "separator"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
+                                "tab"
+                            ]
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean",
+                                    "enum": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "integer",
+                                    "enum": [
+                                        0
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/conditionalLogicGroup"
+                                    }
+                                }
+                            ],
+                            "description": "Conditional logic rules for field visibility"
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        },
+                        "placement": {
+                            "type": "string",
+                            "enum": [
+                                "top",
+                                "left"
+                            ],
+                            "default": "top",
+                            "description": "Tab placement position"
+                        },
+                        "endpoint": {
+                            "$ref": "#/definitions/endpoint"
+                        },
+                        "selected": {
+                            "type": "integer",
+                            "default": 0,
+                            "description": "Whether this tab is selected by default"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "enum": [
                                 "link"
                             ]
                         },
@@ -4271,14 +5339,6 @@
                         "type": {
                             "type": "string",
                             "enum": [
-                                "message",
-                                "accordion",
-                                "tab",
-                                "group",
-                                "repeater",
-                                "flexible_content",
-                                "clone",
-                                "separator",
                                 "output"
                             ]
                         },
@@ -4601,6 +5661,30 @@
             "type": "integer",
             "default": 0,
             "description": "Set current date/time as default value (1 for yes, 0 for no)"
+        },
+        "sub_fields": {
+            "type": "array",
+            "default": [],
+            "description": "Nested fields within this field"
+        },
+        "layout_display": {
+            "type": "string",
+            "enum": [
+                "block",
+                "table",
+                "row"
+            ],
+            "description": "Visual layout style for rendering fields"
+        },
+        "button_label": {
+            "type": "string",
+            "default": "",
+            "description": "Text label for the add row button"
+        },
+        "endpoint": {
+            "type": "integer",
+            "default": 0,
+            "description": "Define an endpoint for the previous accordion/tab group"
         }
     }
 }

--- a/schemas/field.schema.json
+++ b/schemas/field.schema.json
@@ -64,6 +64,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "color_picker"
                             ]
@@ -218,6 +219,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "date_picker"
                             ]
@@ -350,6 +352,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "date_time_picker"
                             ]
@@ -482,6 +485,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "google_map"
                             ]
@@ -618,6 +622,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "icon_picker"
                             ]
@@ -774,6 +779,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "time_picker"
                             ]
@@ -900,6 +906,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "email"
                             ]
@@ -1028,6 +1035,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "number"
                             ]
@@ -1183,6 +1191,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "password"
                             ]
@@ -1308,6 +1317,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "range"
                             ]
@@ -1460,6 +1470,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "text"
                             ]
@@ -1591,6 +1602,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "textarea"
                             ]
@@ -1722,6 +1734,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "url"
                             ]
@@ -1844,6 +1857,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "button_group"
                             ]
@@ -1981,6 +1995,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "checkbox"
                             ]
@@ -2129,6 +2144,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "nav_menu"
                             ]
@@ -2263,6 +2279,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "radio"
                             ]
@@ -2404,6 +2421,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "select"
                             ]
@@ -2558,6 +2576,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "true_false"
                             ]
@@ -2699,6 +2718,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "file"
                             ]
@@ -2830,6 +2850,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "gallery"
                             ]
@@ -2991,6 +3012,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "image"
                             ]
@@ -3137,6 +3159,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "oembed"
                             ]
@@ -3263,6 +3286,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "wysiwyg"
                             ]
@@ -3407,6 +3431,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "accordion"
                             ]
@@ -3536,6 +3561,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "clone"
                             ]
@@ -3683,6 +3709,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "flexible_content"
                             ]
@@ -3825,6 +3852,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "group"
                             ]
@@ -3948,6 +3976,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "message"
                             ]
@@ -4084,6 +4113,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "output"
                             ]
@@ -4205,6 +4235,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "repeater"
                             ]
@@ -4304,6 +4335,14 @@
                         "button_label": {
                             "$ref": "#/definitions/button_label"
                         },
+                        "pagination": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": 0,
+                            "description": "Enable pagination for repeaters with many rows"
+                        },
                         "rows_per_page": {
                             "type": "integer",
                             "default": 20,
@@ -4347,6 +4386,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "separator"
                             ]
@@ -4463,6 +4503,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "tab"
                             ]
@@ -4596,6 +4637,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "link"
                             ]
@@ -4721,6 +4763,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "page_link"
                             ]
@@ -4854,6 +4897,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "post_object"
                             ]
@@ -4999,6 +5043,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "relationship"
                             ]
@@ -5153,6 +5198,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "taxonomy"
                             ]
@@ -5318,6 +5364,7 @@
                             "description": "Accessible label for screen readers"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "user"
                             ]
@@ -5427,121 +5474,6 @@
                         }
                     },
                     "additionalProperties": false
-                },
-                {
-                    "type": "object",
-                    "required": [
-                        "key",
-                        "label",
-                        "name",
-                        "type"
-                    ],
-                    "properties": {
-                        "key": {
-                            "type": "string",
-                            "pattern": "^field_.+$",
-                            "minLength": 1,
-                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
-                        },
-                        "label": {
-                            "type": "string",
-                            "minLength": 1,
-                            "description": "The label displayed for this field"
-                        },
-                        "name": {
-                            "type": "string",
-                            "pattern": "^[a-zA-Z0-9_-]*$",
-                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
-                        },
-                        "aria-label": {
-                            "type": "string",
-                            "description": "Accessible label for screen readers"
-                        },
-                        "type": {
-                            "type": "string",
-                            "enum": []
-                        },
-                        "instructions": {
-                            "type": "string",
-                            "description": "Instructions for content editors"
-                        },
-                        "required": {
-                            "type": [
-                                "boolean",
-                                "integer"
-                            ],
-                            "default": false,
-                            "description": "Whether the field is required"
-                        },
-                        "conditional_logic": {
-                            "anyOf": [
-                                {
-                                    "type": "boolean",
-                                    "enum": [
-                                        false
-                                    ]
-                                },
-                                {
-                                    "type": "integer",
-                                    "enum": [
-                                        0
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        ""
-                                    ]
-                                },
-                                {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/definitions/conditionalLogicGroup"
-                                    }
-                                }
-                            ],
-                            "description": "Conditional logic rules for field visibility"
-                        },
-                        "wrapper": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "width": {
-                                    "type": "string",
-                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
-                                },
-                                "class": {
-                                    "type": "string",
-                                    "description": "CSS class(es) for the field wrapper"
-                                },
-                                "id": {
-                                    "type": "string",
-                                    "description": "HTML ID for the field wrapper"
-                                }
-                            },
-                            "description": "Wrapper element settings"
-                        },
-                        "menu_order": {
-                            "type": "integer",
-                            "description": "Order of the field within its parent"
-                        },
-                        "parent": {
-                            "oneOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "integer"
-                                }
-                            ],
-                            "description": "Parent field or field group key/ID"
-                        },
-                        "parent_layout": {
-                            "type": "string",
-                            "description": "Parent layout key for flexible content sub-fields"
-                        }
-                    },
-                    "additionalProperties": true
                 }
             ]
         },

--- a/tests/php/includes/SCFSchemaBuilderTest.php
+++ b/tests/php/includes/SCFSchemaBuilderTest.php
@@ -154,15 +154,20 @@ class SCFSchemaBuilderTest extends BaseTestCase {
 	}
 
 	/**
-	 * Test compose_field_schema includes fallback variant.
+	 * Test compose_field_schema only adds fallback when types are missing schemas.
+	 *
+	 * With all 39 field types having dedicated schemas, no fallback variant
+	 * should be present. The fallback (with additionalProperties: true) is
+	 * only added when there are field types without schema files.
 	 */
-	public function test_compose_field_schema_includes_fallback_variant() {
+	public function test_compose_field_schema_no_fallback_when_all_types_have_schemas() {
 		$result = $this->builder->compose_field_schema();
 
-		// Last variant should be the fallback with additionalProperties: true.
+		// All dedicated schemas have additionalProperties: false.
+		// If a fallback exists, it would have additionalProperties: true.
 		$last_variant = end( $result['oneOf'] );
 
-		$this->assertTrue( $last_variant['additionalProperties'] );
+		$this->assertFalse( $last_variant['additionalProperties'] );
 	}
 
 	/**

--- a/tests/php/schemas/FieldSchemaTest.php
+++ b/tests/php/schemas/FieldSchemaTest.php
@@ -763,6 +763,17 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Separator field with all type-specific properties should be valid',
 			),
+			'output field complete'           => array(
+				array(
+					'key'    => 'field_output_full',
+					'label'  => 'Full Output',
+					'name'   => 'output_full',
+					'type'   => 'output',
+					'parent' => 'group_test',
+					'html'   => true,
+				),
+				'Output field with all type-specific properties should be valid',
+			),
 		);
 	}
 
@@ -1151,6 +1162,17 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 					'layout' => 'invalid_layout',
 				),
 				'Clone with invalid layout should fail validation',
+			),
+			'invalid output html type'                 => array(
+				array(
+					'key'    => 'field_output_bad',
+					'label'  => 'Bad Output',
+					'name'   => 'bad_output',
+					'type'   => 'output',
+					'parent' => 'group_test',
+					'html'   => 'yes',
+				),
+				'Output with non-boolean html should fail validation',
 			),
 		);
 	}

--- a/tests/php/schemas/FieldSchemaTest.php
+++ b/tests/php/schemas/FieldSchemaTest.php
@@ -1086,6 +1086,17 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Repeater with invalid layout should fail validation',
 			),
+			'invalid repeater rows_per_page type'      => array(
+				array(
+					'key'           => 'field_repeater_bad_rows',
+					'label'         => 'Bad Repeater Rows',
+					'name'          => 'bad_repeater_rows',
+					'type'          => 'repeater',
+					'parent'        => 'group_test',
+					'rows_per_page' => 'twenty',
+				),
+				'Repeater with non-integer rows_per_page should fail validation',
+			),
 			'invalid tab placement'                    => array(
 				array(
 					'key'       => 'field_tab_bad',
@@ -1096,6 +1107,17 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 					'placement' => 'bottom',
 				),
 				'Tab with invalid placement should fail validation',
+			),
+			'invalid accordion open type'              => array(
+				array(
+					'key'    => 'field_accordion_bad_open',
+					'label'  => 'Bad Accordion Open',
+					'name'   => 'bad_accordion_open',
+					'type'   => 'accordion',
+					'parent' => 'group_test',
+					'open'   => 'yes',
+				),
+				'Accordion with non-integer open should fail validation',
 			),
 			'invalid message new_lines'                => array(
 				array(

--- a/tests/php/schemas/FieldSchemaTest.php
+++ b/tests/php/schemas/FieldSchemaTest.php
@@ -654,6 +654,115 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Google Map field with all type-specific properties should be valid',
 			),
+
+			// Layout fields.
+			'group field complete'            => array(
+				array(
+					'key'        => 'field_group_full',
+					'label'      => 'Full Group',
+					'name'       => 'group_full',
+					'type'       => 'group',
+					'parent'     => 'group_test',
+					'sub_fields' => array(),
+					'layout'     => 'block',
+				),
+				'Group field with all type-specific properties should be valid',
+			),
+			'repeater field complete'         => array(
+				array(
+					'key'           => 'field_repeater_full',
+					'label'         => 'Full Repeater',
+					'name'          => 'repeater_full',
+					'type'          => 'repeater',
+					'parent'        => 'group_test',
+					'sub_fields'    => array(),
+					'min'           => 0,
+					'max'           => 0,
+					'layout'        => 'table',
+					'button_label'  => '',
+					'rows_per_page' => 20,
+					'collapsed'     => '',
+				),
+				'Repeater field with all type-specific properties should be valid',
+			),
+			'flexible_content field complete' => array(
+				array(
+					'key'          => 'field_flexible_content_full',
+					'label'        => 'Full Flexible Content',
+					'name'         => 'flexible_content_full',
+					'type'         => 'flexible_content',
+					'parent'       => 'group_test',
+					'layouts'      => array(),
+					'min'          => '',
+					'max'          => '',
+					'button_label' => 'Add Row',
+				),
+				'Flexible Content field with all type-specific properties should be valid',
+			),
+			'tab field complete'              => array(
+				array(
+					'key'       => 'field_tab_full',
+					'label'     => 'Full Tab',
+					'name'      => 'tab_full',
+					'type'      => 'tab',
+					'parent'    => 'group_test',
+					'placement' => 'top',
+					'endpoint'  => 0,
+					'selected'  => 0,
+				),
+				'Tab field with all type-specific properties should be valid',
+			),
+			'accordion field complete'        => array(
+				array(
+					'key'          => 'field_accordion_full',
+					'label'        => 'Full Accordion',
+					'name'         => 'accordion_full',
+					'type'         => 'accordion',
+					'parent'       => 'group_test',
+					'open'         => 0,
+					'multi_expand' => 0,
+					'endpoint'     => 0,
+				),
+				'Accordion field with all type-specific properties should be valid',
+			),
+			'message field complete'          => array(
+				array(
+					'key'       => 'field_message_full',
+					'label'     => 'Full Message',
+					'name'      => 'message_full',
+					'type'      => 'message',
+					'parent'    => 'group_test',
+					'message'   => 'Hello world',
+					'esc_html'  => 0,
+					'new_lines' => 'wpautop',
+				),
+				'Message field with all type-specific properties should be valid',
+			),
+			'clone field complete'            => array(
+				array(
+					'key'          => 'field_clone_full',
+					'label'        => 'Full Clone',
+					'name'         => 'clone_full',
+					'type'         => 'clone',
+					'parent'       => 'group_test',
+					'clone'        => '',
+					'prefix_label' => 0,
+					'prefix_name'  => 0,
+					'display'      => 'seamless',
+					'layout'       => 'block',
+				),
+				'Clone field with all type-specific properties should be valid',
+			),
+			'separator field complete'        => array(
+				array(
+					'key'    => 'field_separator_full',
+					'label'  => 'Full Separator',
+					'name'   => 'separator_full',
+					'type'   => 'separator',
+					'parent' => 'group_test',
+				),
+				'Separator field with all type-specific properties should be valid',
+			),
 		);
 	}
 
@@ -952,6 +1061,74 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 					'height' => 400,
 				),
 				'Google Map with non-string height should fail validation',
+			),
+
+			// Layout field validation.
+			'invalid group layout'                     => array(
+				array(
+					'key'    => 'field_group_bad',
+					'label'  => 'Bad Group',
+					'name'   => 'bad_group',
+					'type'   => 'group',
+					'parent' => 'group_test',
+					'layout' => 'invalid_layout',
+				),
+				'Group with invalid layout should fail validation',
+			),
+			'invalid repeater layout'                  => array(
+				array(
+					'key'    => 'field_repeater_bad',
+					'label'  => 'Bad Repeater',
+					'name'   => 'bad_repeater',
+					'type'   => 'repeater',
+					'parent' => 'group_test',
+					'layout' => 'invalid_layout',
+				),
+				'Repeater with invalid layout should fail validation',
+			),
+			'invalid tab placement'                    => array(
+				array(
+					'key'       => 'field_tab_bad',
+					'label'     => 'Bad Tab',
+					'name'      => 'bad_tab',
+					'type'      => 'tab',
+					'parent'    => 'group_test',
+					'placement' => 'bottom',
+				),
+				'Tab with invalid placement should fail validation',
+			),
+			'invalid message new_lines'                => array(
+				array(
+					'key'       => 'field_message_bad',
+					'label'     => 'Bad Message',
+					'name'      => 'bad_message',
+					'type'      => 'message',
+					'parent'    => 'group_test',
+					'new_lines' => 'invalid_value',
+				),
+				'Message with invalid new_lines should fail validation',
+			),
+			'invalid clone display'                    => array(
+				array(
+					'key'     => 'field_clone_bad',
+					'label'   => 'Bad Clone',
+					'name'    => 'bad_clone',
+					'type'    => 'clone',
+					'parent'  => 'group_test',
+					'display' => 'invalid_display',
+				),
+				'Clone with invalid display should fail validation',
+			),
+			'invalid clone layout'                     => array(
+				array(
+					'key'    => 'field_clone_bad_layout',
+					'label'  => 'Bad Clone Layout',
+					'name'   => 'bad_clone_layout',
+					'type'   => 'clone',
+					'parent' => 'group_test',
+					'layout' => 'invalid_layout',
+				),
+				'Clone with invalid layout should fail validation',
 			),
 		);
 	}


### PR DESCRIPTION
## What

Part of #162. Adds JSON Schema fragments for layout field types.

## How

- Adding 9 new field type fragments (`group`, `repeater`, `flexible_content`, `tab`, `accordion`, `message`, `clone`, `separator`, `output`)
- Adding shared property definitions to `field-base.schema.json` (`sub_fields`, `layout_display`, `button_label`, `endpoint`)
- Adding tests for each layout field type

Note: `output` is deprecated but included for legacy backward compatibility (e.g. in case users still have it and use the Abilities API to list fields)