### PR TITLE
Code Quality: Resolve `$ref`s in abilities`internal fields schemas for WordPress REST API

### DIFF
--- a/includes/abilities/class-scf-field-abilities.php
+++ b/includes/abilities/class-scf-field-abilities.php
@@ -146,14 +146,21 @@ if ( ! class_exists( 'SCF_Field_Abilities' ) ) :
 		/**
 		 * Gets the internal fields schema for fields.
 		 *
+		 * Resolves $ref references since WordPress REST API doesn't understand them.
+		 *
 		 * @since 6.8.0
 		 *
 		 * @return array
 		 */
 		private function get_internal_fields_schema() {
-			$validator = new SCF_JSON_Schema_Validator();
-			$schema    = $validator->load_schema( 'internal-properties' );
-			return json_decode( wp_json_encode( $schema->definitions->fieldInternalProperties ), true );
+			$validator        = new SCF_JSON_Schema_Validator();
+			$schema           = $validator->load_schema( 'internal-properties' );
+			$schema_array     = json_decode( wp_json_encode( $schema ), true );
+			$field_properties = $schema_array['definitions']['fieldInternalProperties'] ?? array();
+
+			// Resolve $refs for WordPress REST API compatibility.
+			$builder = acf_get_instance( 'SCF_Schema_Builder' );
+			return $builder->resolve_refs( $field_properties, $schema_array );
 		}
 
 		/**

--- a/includes/abilities/class-scf-internal-post-type-abilities.php
+++ b/includes/abilities/class-scf-internal-post-type-abilities.php
@@ -176,12 +176,19 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 		/**
 		 * Gets the internal fields schema.
 		 *
+		 * Resolves $ref references since WordPress REST API doesn't understand them.
+		 *
 		 * @return array
 		 */
 		private function get_internal_fields_schema() {
-			$validator = new SCF_JSON_Schema_Validator();
-			$schema    = $validator->load_schema( 'internal-properties' );
-			return json_decode( wp_json_encode( $schema->definitions->internalProperties ), true );
+			$validator      = new SCF_JSON_Schema_Validator();
+			$schema         = $validator->load_schema( 'internal-properties' );
+			$schema_array   = json_decode( wp_json_encode( $schema ), true );
+			$internal_props = $schema_array['definitions']['internalProperties'] ?? array();
+
+			// Resolve $refs for WordPress REST API compatibility.
+			$builder = acf_get_instance( 'SCF_Schema_Builder' );
+			return $builder->resolve_refs( $internal_props, $schema_array );
 		}
 
 		/**


### PR DESCRIPTION
## What
Follow-up to #302. Resolves `$ref` references in `internal-properties.schema.json` when used by abilities classes.

## Why
PR #302 ensured `$ref`s are resolved for the main field schema, but the abilities classes were still passing unresolved `$ref`s from `internal-properties.schema.json` to WordPress REST API validation, which doesn't understand them.

## How
Using the schema builder's `resolve_refs()` method in both `SCF_Field_Abilities` and `SCF_Internal_Post_Type_Abilities` to inline the referenced definitions before passing the schema to WordPress.

## Testing Instructions
1. PHPUnit tests should still pass, as they use the custom `justinrainbow` validator

This is more of a "cosmetic" and correctness fix for consumers, as:
- Before, WP REST validation would ignore internal properties
- After, WP correctly validates internal properties

But in both cases, the output will be the same (valid output).
