### PR TITLE
Fix: Hide duplicate Command Palette commands on WordPress 6.9+

### DIFF
--- a/assets/src/js/commands/admin-commands.js
+++ b/assets/src/js/commands/admin-commands.js
@@ -16,7 +16,16 @@ import { createElement } from '@wordpress/element';
 import { Icon } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
-import { layout, plus, postList, category, settings, tool, upload, download } from '@wordpress/icons';
+import {
+	layout,
+	plus,
+	postList,
+	category,
+	settings,
+	tool,
+	upload,
+	download,
+} from '@wordpress/icons';
 
 /**
  * Register admin commands for SCF
@@ -29,7 +38,7 @@ const registerAdminCommands = () => {
 	const commandStore = dispatch( 'core/commands' );
 	const adminUrl = window.acf?.data?.admin_url || '';
 
-	const commands = [
+	const viewCommands = [
 		{
 			name: 'field-groups',
 			label: __( 'Field Groups', 'secure-custom-fields' ),
@@ -48,24 +57,6 @@ const registerAdminCommands = () => {
 			],
 		},
 		{
-			name: 'new-field-group',
-			label: __( 'Create New Field Group', 'secure-custom-fields' ),
-			url: 'post-new.php',
-			urlArgs: { post_type: 'acf-field-group' },
-			icon: plus,
-			description: __(
-				'SCF: Create a new field group to organize custom fields',
-				'secure-custom-fields'
-			),
-			keywords: [
-				'add',
-				'new',
-				'create',
-				'field group',
-				'custom fields',
-			],
-		},
-		{
 			name: 'post-types',
 			label: __( 'Post Types', 'secure-custom-fields' ),
 			url: 'edit.php',
@@ -76,18 +67,6 @@ const registerAdminCommands = () => {
 				'secure-custom-fields'
 			),
 			keywords: [ 'cpt', 'content types', 'manage post types' ],
-		},
-		{
-			name: 'new-post-type',
-			label: __( 'Create New Post Type', 'secure-custom-fields' ),
-			url: 'post-new.php',
-			urlArgs: { post_type: 'acf-post-type' },
-			icon: plus,
-			description: __(
-				'SCF: Create a new custom post type',
-				'secure-custom-fields'
-			),
-			keywords: [ 'add', 'new', 'create', 'cpt', 'content type' ],
 		},
 		{
 			name: 'taxonomies',
@@ -102,25 +81,6 @@ const registerAdminCommands = () => {
 			keywords: [ 'categories', 'tags', 'terms', 'custom taxonomies' ],
 		},
 		{
-			name: 'new-taxonomy',
-			label: __( 'Create New Taxonomy', 'secure-custom-fields' ),
-			url: 'post-new.php',
-			urlArgs: { post_type: 'acf-taxonomy' },
-			icon: plus,
-			description: __(
-				'SCF: Create a new custom taxonomy',
-				'secure-custom-fields'
-			),
-			keywords: [
-				'add',
-				'new',
-				'create',
-				'taxonomy',
-				'categories',
-				'tags',
-			],
-		},
-		{
 			name: 'options-pages',
 			label: __( 'Options Pages', 'secure-custom-fields' ),
 			url: 'edit.php',
@@ -131,18 +91,6 @@ const registerAdminCommands = () => {
 				'secure-custom-fields'
 			),
 			keywords: [ 'settings', 'global options', 'site options' ],
-		},
-		{
-			name: 'new-options-page',
-			label: __( 'Create New Options Page', 'secure-custom-fields' ),
-			url: 'post-new.php',
-			urlArgs: { post_type: 'acf-ui-options-page' },
-			icon: plus,
-			description: __(
-				'SCF: Create a new custom options page',
-				'secure-custom-fields'
-			),
-			keywords: [ 'add', 'new', 'create', 'options', 'settings page' ],
 		},
 		{
 			name: 'tools',
@@ -182,7 +130,72 @@ const registerAdminCommands = () => {
 		},
 	];
 
-	commands.forEach( ( command ) => {
+	// Create commands - not in SCF's admin menu, so not duplicated.
+	const createCommands = [
+		{
+			name: 'new-field-group',
+			label: __( 'Create New Field Group', 'secure-custom-fields' ),
+			url: 'post-new.php',
+			urlArgs: { post_type: 'acf-field-group' },
+			icon: plus,
+			description: __(
+				'SCF: Create a new field group to organize custom fields',
+				'secure-custom-fields'
+			),
+			keywords: [
+				'add',
+				'new',
+				'create',
+				'field group',
+				'custom fields',
+			],
+		},
+		{
+			name: 'new-post-type',
+			label: __( 'Create New Post Type', 'secure-custom-fields' ),
+			url: 'post-new.php',
+			urlArgs: { post_type: 'acf-post-type' },
+			icon: plus,
+			description: __(
+				'SCF: Create a new custom post type',
+				'secure-custom-fields'
+			),
+			keywords: [ 'add', 'new', 'create', 'cpt', 'content type' ],
+		},
+		{
+			name: 'new-taxonomy',
+			label: __( 'Create New Taxonomy', 'secure-custom-fields' ),
+			url: 'post-new.php',
+			urlArgs: { post_type: 'acf-taxonomy' },
+			icon: plus,
+			description: __(
+				'SCF: Create a new custom taxonomy',
+				'secure-custom-fields'
+			),
+			keywords: [
+				'add',
+				'new',
+				'create',
+				'taxonomy',
+				'categories',
+				'tags',
+			],
+		},
+		{
+			name: 'new-options-page',
+			label: __( 'Create New Options Page', 'secure-custom-fields' ),
+			url: 'post-new.php',
+			urlArgs: { post_type: 'acf-ui-options-page' },
+			icon: plus,
+			description: __(
+				'SCF: Create a new custom options page',
+				'secure-custom-fields'
+			),
+			keywords: [ 'add', 'new', 'create', 'options', 'settings page' ],
+		},
+	];
+
+	const registerCommand = ( command ) => {
 		commandStore.registerCommand( {
 			name: 'scf/' + command.name,
 			label: command.label,
@@ -197,7 +210,17 @@ const registerAdminCommands = () => {
 				close();
 			},
 		} );
-	} );
+	};
+
+	// WordPress 6.9+ adds Command Palette commands for all admin menu items.
+	const wpVersion = window.acf.data.wp_version;
+	const isWp69Plus =
+		wpVersion.localeCompare( '6.9', undefined, { numeric: true } ) >= 0;
+
+	if ( ! isWp69Plus ) {
+		viewCommands.forEach( registerCommand );
+	}
+	createCommands.forEach( registerCommand );
 };
 
 if ( 'requestIdleCallback' in window ) {

--- a/assets/src/js/commands/custom-post-type-commands.js
+++ b/assets/src/js/commands/custom-post-type-commands.js
@@ -37,64 +37,87 @@ const registerPostTypeCommands = () => {
 	const adminUrl = window.acf.data.admin_url || '';
 	const postTypes = window.acf.data.customPostTypes;
 
+	// WordPress 6.9+ adds Command Palette commands for all admin menu items.
+	const wpVersion = window.acf.data.wp_version;
+	const isWp69Plus =
+		wpVersion.localeCompare( '6.9', undefined, { numeric: true } ) >= 0;
+
 	postTypes.forEach( ( postType ) => {
 		// Skip invalid post types or those missing required labels
-		if ( ! postType?.name || ! postType?.all_items || ! postType?.add_new_item ) {
+		if (
+			! postType?.name ||
+			! postType?.all_items ||
+			! postType?.add_new_item
+		) {
 			return;
 		}
 
-		// Register "View All" command for this post type
-		commandStore.registerCommand( {
-			name: `scf/cpt-${ postType.name }`,
-			label: postType.all_items,
-			icon: createElement( Icon, { icon: page } ),
-			context: 'admin',
-			description: postType.all_items,
-			keywords: [
-				'post type',
-				'content',
-				'cpt',
-				postType.name,
-				postType.label,
-			].filter( Boolean ),
-			callback: ( { close } ) => {
-				document.location = addQueryArgs(adminUrl + 'edit.php', {
-					post_type: postType.name
-				});
-				close();
-			},
-		} );
+		// Navigation commands are already included in WP 6.9+.
+		if ( ! isWp69Plus ) {
+			// Register "View All" command for this post type
+			commandStore.registerCommand( {
+				name: `scf/cpt-${ postType.name }`,
+				label: postType.all_items,
+				icon: createElement( Icon, { icon: page } ),
+				context: 'admin',
+				description: postType.all_items,
+				keywords: [
+					'post type',
+					'content',
+					'cpt',
+					postType.name,
+					postType.label,
+				].filter( Boolean ),
+				callback: ( { close } ) => {
+					document.location = addQueryArgs( adminUrl + 'edit.php', {
+						post_type: postType.name,
+					} );
+					close();
+				},
+			} );
 
-		// Register "Add New" command for this post type
-		commandStore.registerCommand( {
-			name: `scf/new-${ postType.name }`,
-			label: postType.add_new_item,
-			icon: createElement( Icon, { icon: plus } ),
-			context: 'admin',
-			description: postType.add_new_item,
-			keywords: [
-				'add',
-				'new',
-				'create',
-				'content',
-				postType.name,
-				postType.label,
-			],
-			callback: ( { close } ) => {
-				document.location = addQueryArgs(adminUrl + 'post-new.php', {
-					post_type: postType.name
-				});
-				close();
-			},
-		} );
+			// Register "Add New" command for this post type
+			commandStore.registerCommand( {
+				name: `scf/new-${ postType.name }`,
+				label: postType.add_new_item,
+				icon: createElement( Icon, { icon: plus } ),
+				context: 'admin',
+				description: postType.add_new_item,
+				keywords: [
+					'add',
+					'new',
+					'create',
+					'content',
+					postType.name,
+					postType.label,
+				],
+				callback: ( { close } ) => {
+					document.location = addQueryArgs(
+						adminUrl + 'post-new.php',
+						{
+							post_type: postType.name,
+						}
+					);
+					close();
+				},
+			} );
+		}
 
-		// Register "Edit Post Type" command for registered CPTs
+		// Register "Edit Post Type" command
 		commandStore.registerCommand( {
 			name: `scf/edit-${ postType.name }`,
-			label: sprintf(__('Edit post type: %s', 'secure-custom-fields'), postType.label),
+			label: sprintf(
+				/* translators: %s: post type label */
+				__( 'Edit post type: %s', 'secure-custom-fields' ),
+				postType.label
+			),
 			icon: createElement( Icon, { icon: edit } ),
 			context: 'admin',
-			description: sprintf(__('Edit the %s post type settings', 'secure-custom-fields'), postType.label),
+			description: sprintf(
+				/* translators: %s: post type label */
+				__( 'Edit the %s post type settings', 'secure-custom-fields' ),
+				postType.label
+			),
 			keywords: [
 				'edit',
 				'modify',
@@ -105,10 +128,10 @@ const registerPostTypeCommands = () => {
 				postType.label,
 			],
 			callback: ( { close } ) => {
-				document.location = addQueryArgs(adminUrl + 'post.php', {
+				document.location = addQueryArgs( adminUrl + 'post.php', {
 					post: postType.id,
-					action: 'edit'
-				});
+					action: 'edit',
+				} );
 				close();
 			},
 		} );

--- a/tests/js/commands/admin-commands.test.js
+++ b/tests/js/commands/admin-commands.test.js
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for admin commands version-based registration
+ */
+
+let mockCommandStore = null;
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn( () => mockCommandStore ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( { __: ( str ) => str } ) );
+jest.mock( '@wordpress/element', () => ( { createElement: jest.fn() } ) );
+jest.mock( '@wordpress/components', () => ( { Icon: 'Icon' } ) );
+jest.mock( '@wordpress/url', () => ( { addQueryArgs: jest.fn() } ) );
+jest.mock( '@wordpress/icons', () => ( {
+	layout: 'icon',
+	plus: 'icon',
+	postList: 'icon',
+	category: 'icon',
+	settings: 'icon',
+	tool: 'icon',
+	upload: 'icon',
+	download: 'icon',
+} ) );
+
+describe( 'Admin Commands', () => {
+	let mockRegisterCommand;
+	let capturedCallback;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		jest.resetModules();
+		mockRegisterCommand = jest.fn();
+		mockCommandStore = { registerCommand: mockRegisterCommand };
+		window.requestIdleCallback = jest.fn( ( cb ) => {
+			capturedCallback = cb;
+		} );
+	} );
+
+	// 7 viewCommands + 4 createCommands = 11 on WP < 6.9
+	// 4 createCommands only on WP 6.9+ (viewCommands skipped)
+	it.each( [
+		[ '6.8', 11 ],
+		[ '6.8.1', 11 ],
+		[ '6.9', 4 ],
+		[ '6.9-beta1', 4 ],
+		[ '6.9.1', 4 ],
+		[ '7.0', 4 ],
+	] )( 'WP %s registers %i commands', async ( wpVersion, expectedCount ) => {
+		window.acf = {
+			data: {
+				admin_url: 'http://example.com/wp-admin/',
+				wp_version: wpVersion,
+			},
+		};
+
+		await import( '../../../assets/src/js/commands/admin-commands.js' );
+		capturedCallback();
+
+		expect( mockRegisterCommand ).toHaveBeenCalledTimes( expectedCount );
+	} );
+
+	it( 'WP 6.9+ skips view commands but keeps create commands', async () => {
+		window.acf = {
+			data: {
+				admin_url: 'http://example.com/wp-admin/',
+				wp_version: '6.9',
+			},
+		};
+
+		await import( '../../../assets/src/js/commands/admin-commands.js' );
+		capturedCallback();
+
+		const names = mockRegisterCommand.mock.calls.map(
+			( c ) => c[ 0 ].name
+		);
+
+		// View commands should NOT be registered
+		expect( names ).not.toContain( 'scf/field-groups' );
+		expect( names ).not.toContain( 'scf/post-types' );
+
+		// Create commands should be registered
+		expect( names ).toContain( 'scf/new-field-group' );
+		expect( names ).toContain( 'scf/new-post-type' );
+	} );
+} );

--- a/tests/js/commands/custom-post-type-commands.test.js
+++ b/tests/js/commands/custom-post-type-commands.test.js
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for custom post type commands version-based registration
+ */
+
+let mockCommandStore = null;
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn( () => mockCommandStore ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( str ) => str,
+	sprintf: ( str, ...args ) => str.replace( /%s/g, () => args.shift() ),
+} ) );
+jest.mock( '@wordpress/element', () => ( { createElement: jest.fn() } ) );
+jest.mock( '@wordpress/components', () => ( { Icon: 'Icon' } ) );
+jest.mock( '@wordpress/url', () => ( { addQueryArgs: jest.fn() } ) );
+jest.mock( '@wordpress/icons', () => ( {
+	page: 'icon',
+	plus: 'icon',
+	edit: 'icon',
+} ) );
+
+describe( 'Custom Post Type Commands', () => {
+	let mockRegisterCommand;
+	let capturedCallback;
+
+	const mockPostTypes = [
+		{
+			name: 'book',
+			label: 'Books',
+			all_items: 'All Books',
+			add_new_item: 'Add New Book',
+			id: 123,
+		},
+		{
+			name: 'movie',
+			label: 'Movies',
+			all_items: 'All Movies',
+			add_new_item: 'Add New Movie',
+			id: 456,
+		},
+	];
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		jest.resetModules();
+		mockRegisterCommand = jest.fn();
+		mockCommandStore = { registerCommand: mockRegisterCommand };
+		window.requestIdleCallback = jest.fn( ( cb ) => {
+			capturedCallback = cb;
+		} );
+	} );
+
+	it.each( [
+		[ '6.8', 6 ], // 3 commands × 2 CPTs
+		[ '6.8.1', 6 ],
+		[ '6.9', 2 ], // Only Edit × 2 CPTs
+		[ '6.9-RC1', 2 ],
+		[ '6.9.1', 2 ],
+		[ '7.0', 2 ],
+	] )(
+		'WP %s registers %i commands for 2 CPTs',
+		async ( wpVersion, expectedCount ) => {
+			window.acf = {
+				data: {
+					admin_url: 'http://example.com/wp-admin/',
+					wp_version: wpVersion,
+					customPostTypes: mockPostTypes,
+				},
+			};
+
+			await import(
+				'../../../assets/src/js/commands/custom-post-type-commands.js'
+			);
+			capturedCallback();
+
+			expect( mockRegisterCommand ).toHaveBeenCalledTimes(
+				expectedCount
+			);
+		}
+	);
+
+	it( 'WP 6.9+ skips navigation commands but keeps Edit command', async () => {
+		window.acf = {
+			data: {
+				admin_url: 'http://example.com/wp-admin/',
+				wp_version: '6.9',
+				customPostTypes: mockPostTypes,
+			},
+		};
+
+		await import(
+			'../../../assets/src/js/commands/custom-post-type-commands.js'
+		);
+		capturedCallback();
+
+		const names = mockRegisterCommand.mock.calls.map(
+			( c ) => c[ 0 ].name
+		);
+
+		// Navigation commands should NOT be registered
+		expect( names ).not.toContain( 'scf/cpt-book' );
+		expect( names ).not.toContain( 'scf/new-book' );
+
+		// Edit commands should be registered
+		expect( names ).toContain( 'scf/edit-book' );
+		expect( names ).toContain( 'scf/edit-movie' );
+	} );
+} );


### PR DESCRIPTION
## What

Fixes #224.

Hides duplicate Command Palette commands on WordPress 6.9+.

## Why

WordPress 6.9 introduces built-in Command Palette navigation for all admin menu items, creating duplicates with SCF's custom commands. Users would see the same navigation options twice.

## How

Checking WordPress version using `window.acf.data.wp_version` value. On WP 6.9+:

- **admin-commands.js**: Splits commands into `viewCommands` (hidden on 6.9+) and `createCommands` (always shown). The "Create New..." commands are kept because SCF doesn't have "Add New" submenu items, so WordPress core doesn't generate those.

- **custom-post-type-commands.js**: Hides "View All" and "Add New" commands for user-created CPTs on 6.9+. Keeps "Edit Post Type" command, which is unique to SCF.

## Testing Instructions

1. On WP < 6.9: Open Command Palette, verify all SCF commands appear (Field Groups, Create New Field Group, Post Types, etc.)
2. On WP 6.9+: Open Command Palette, verify only "Create New..." commands and "Edit post type: X" commands from SCF appear

## Screenshots

| Before | After |
|--------|-------|
|     <img width="1010" height="451" alt="image" src="https://github.com/user-attachments/assets/ee4f8afd-6a68-4143-8a6f-961e8d345e6f" />   | <img width="1010" height="441" alt="image" src="https://github.com/user-attachments/assets/58d20ba1-d67c-40f6-8021-736cb56e2cbf" /> |
