### PR TITLE
Tests: Add PHPUnit tests for input and form functions

### DIFF
--- a/tests/php/includes/functions/test-acf-form-functions.php
+++ b/tests/php/includes/functions/test-acf-form-functions.php
@@ -1,0 +1,331 @@
+<?php
+/**
+ * Tests for ACF Form Functions.
+ *
+ * Tests functions from includes/acf-form-functions.php including:
+ * - Form data storage and retrieval
+ * - Form data HTML rendering
+ * - Post save operations
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Class Test_ACF_Form_Functions
+ *
+ * Tests for ACF form handling functions.
+ */
+class Test_ACF_Form_Functions extends BaseTestCase {
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+		acf_get_store( 'form' )->reset();
+		$_POST = array();
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		acf_get_store( 'form' )->reset();
+		$_POST = array();
+		parent::tear_down();
+	}
+
+	// =========================================================================
+	// acf_set_form_data() / acf_get_form_data() Tests
+	// =========================================================================
+
+	/**
+	 * Test form data storage and retrieval.
+	 */
+	public function test_acf_form_data_storage() {
+		// Store and retrieve single value.
+		acf_set_form_data( 'post_id', 123 );
+		$this->assertEquals( 123, acf_get_form_data( 'post_id' ) );
+
+		// Store multiple values.
+		acf_set_form_data( 'screen', 'post' );
+		acf_set_form_data( 'validation', true );
+		$this->assertEquals( 'post', acf_get_form_data( 'screen' ) );
+		$this->assertTrue( acf_get_form_data( 'validation' ) );
+
+		// Missing key returns null.
+		$this->assertNull( acf_get_form_data( 'nonexistent_key' ) );
+
+		// Can store false values.
+		acf_set_form_data( 'validation', false );
+		$this->assertFalse( acf_get_form_data( 'validation' ) );
+
+		// Can store arrays.
+		$data = array(
+			'screen'  => 'post',
+			'post_id' => 456,
+		);
+		acf_set_form_data( 'settings', $data );
+		$this->assertEquals( $data, acf_get_form_data( 'settings' ) );
+
+		// Overwrites existing values.
+		acf_set_form_data( 'post_id', 789 );
+		$this->assertEquals( 789, acf_get_form_data( 'post_id' ) );
+	}
+
+	// =========================================================================
+	// acf_form_data() Tests
+	// =========================================================================
+
+	/**
+	 * Test that acf_form_data outputs expected HTML structure.
+	 */
+	public function test_acf_form_data_html_output() {
+		ob_start();
+		acf_form_data(
+			array(
+				'screen'  => 'post',
+				'post_id' => 123,
+			)
+		);
+		$output = ob_get_clean();
+
+		// Container.
+		$this->assertStringContainsString( '<div id="acf-form-data"', $output );
+		$this->assertStringContainsString( 'class="acf-hidden"', $output );
+
+		// Hidden inputs.
+		$this->assertStringContainsString( 'type="hidden"', $output );
+		$this->assertStringContainsString( 'name="_acf_screen"', $output );
+		$this->assertStringContainsString( 'value="post"', $output );
+		$this->assertStringContainsString( 'name="_acf_post_id"', $output );
+		$this->assertStringContainsString( 'value="123"', $output );
+	}
+
+	/**
+	 * Test that acf_form_data applies default values.
+	 */
+	public function test_acf_form_data_defaults() {
+		ob_start();
+		acf_form_data( array() );
+		$output = ob_get_clean();
+
+		// Default screen is 'post'.
+		$this->assertStringContainsString( 'name="_acf_screen"', $output );
+		$this->assertMatchesRegularExpression( '/name="_acf_screen"[^>]*value="post"/', $output );
+
+		// Default post_id is 0.
+		$this->assertStringContainsString( 'name="_acf_post_id"', $output );
+
+		// Default validation is true (1).
+		$this->assertStringContainsString( 'name="_acf_validation"', $output );
+
+		// Nonce is generated.
+		$this->assertStringContainsString( 'name="_acf_nonce"', $output );
+		$this->assertMatchesRegularExpression( '/name="_acf_nonce"[^>]*value="[a-f0-9]+"/', $output );
+
+		// Changed input included.
+		$this->assertStringContainsString( 'name="_acf_changed"', $output );
+	}
+
+	/**
+	 * Test that acf_form_data sets store and fires actions.
+	 */
+	public function test_acf_form_data_side_effects() {
+		$action_called       = false;
+		$input_action_called = false;
+
+		add_action(
+			'acf/form_data',
+			function () use ( &$action_called ) {
+				$action_called = true;
+			}
+		);
+
+		add_action(
+			'acf/input/form_data',
+			function () use ( &$input_action_called ) {
+				$input_action_called = true;
+			}
+		);
+
+		ob_start();
+		acf_form_data(
+			array(
+				'screen'  => 'user',
+				'post_id' => 789,
+			)
+		);
+		ob_get_clean();
+
+		// Store is set.
+		$this->assertEquals( 'user', acf_get_form_data( 'screen' ) );
+
+		// Actions fired.
+		$this->assertTrue( $action_called, 'acf/form_data action should be called' );
+		$this->assertTrue( $input_action_called, 'acf/input/form_data action should be called' );
+	}
+
+	// =========================================================================
+	// acf_save_post() Tests
+	// =========================================================================
+
+	/**
+	 * Test acf_save_post return values and basic behavior.
+	 */
+	public function test_acf_save_post_basic() {
+		// Returns false without ACF data.
+		$this->assertFalse( acf_save_post( 123 ) );
+
+		// Returns false with empty ACF array.
+		$_POST['acf'] = array();
+		$this->assertFalse( acf_save_post( 123 ) );
+
+		// Returns true with ACF data.
+		$_POST['acf'] = array( 'field_abc123' => 'test value' );
+		$this->assertTrue( acf_save_post( 123 ) );
+	}
+
+	/**
+	 * Test acf_save_post accepts values parameter override.
+	 */
+	public function test_acf_save_post_values_parameter() {
+		$values          = array( 'field_test' => 'override value' );
+		$received_values = null;
+
+		add_action(
+			'acf/save_post',
+			function () use ( &$received_values ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput -- Test intentionally reads raw $_POST to verify function behavior.
+				$received_values = isset( $_POST['acf'] ) ? $_POST['acf'] : null;
+			}
+		);
+
+		$result = acf_save_post( 456, $values );
+
+		$this->assertTrue( $result );
+		$this->assertEquals( $values, $received_values );
+	}
+
+	/**
+	 * Test acf_save_post sets form data and fires action.
+	 */
+	public function test_acf_save_post_side_effects() {
+		$_POST['acf'] = array( 'field_test' => 'value' );
+
+		$received_post_id = null;
+		add_action(
+			'acf/save_post',
+			function ( $post_id ) use ( &$received_post_id ) {
+				$received_post_id = $post_id;
+			}
+		);
+
+		acf_save_post( 999 );
+
+		// Form data is set.
+		$this->assertEquals( 999, acf_get_form_data( 'post_id' ) );
+
+		// Action receives correct post_id.
+		$this->assertEquals( 999, $received_post_id );
+	}
+
+	/**
+	 * Test acf_save_post handles various post_id formats.
+	 *
+	 * @dataProvider postIdFormatsProvider
+	 *
+	 * @param mixed $post_id Post ID to test.
+	 */
+	public function test_acf_save_post_post_id_formats( $post_id ) {
+		$_POST['acf'] = array( 'field_test' => 'value' );
+
+		$received_post_id = null;
+		add_action(
+			'acf/save_post',
+			function ( $id ) use ( &$received_post_id ) {
+				$received_post_id = $id;
+			}
+		);
+
+		$result = acf_save_post( $post_id );
+
+		$this->assertTrue( $result );
+		$this->assertEquals( $post_id, $received_post_id );
+	}
+
+	/**
+	 * Data provider for post ID formats.
+	 */
+	public function postIdFormatsProvider() {
+		return array(
+			'numeric' => array( 123 ),
+			'user'    => array( 'user_5' ),
+			'options' => array( 'options' ),
+			'term'    => array( 'term_10' ),
+		);
+	}
+
+	// =========================================================================
+	// _acf_do_save_post() Tests
+	// =========================================================================
+
+	/**
+	 * Test _acf_do_save_post handles missing data gracefully.
+	 */
+	public function test_acf_do_save_post_without_data() {
+		$_POST = array();
+
+		// Should not throw any errors.
+		_acf_do_save_post( 123 );
+		$this->assertTrue( true ); // No exception means success.
+	}
+
+	// =========================================================================
+	// Integration Tests
+	// =========================================================================
+
+	/**
+	 * Test complete form data flow from render to save.
+	 */
+	public function test_form_data_integration() {
+		// Render form data.
+		ob_start();
+		acf_form_data(
+			array(
+				'screen'  => 'post',
+				'post_id' => 123,
+			)
+		);
+		ob_get_clean();
+
+		// Verify form data was set.
+		$this->assertEquals( 'post', acf_get_form_data( 'screen' ) );
+
+		// Simulate form submission.
+		$_POST['acf'] = array( 'field_test' => 'submitted value' );
+
+		$saved_post_id = null;
+		add_action(
+			'acf/save_post',
+			function ( $post_id ) use ( &$saved_post_id ) {
+				$saved_post_id = $post_id;
+			}
+		);
+
+		acf_save_post( 123 );
+
+		$this->assertEquals( 123, $saved_post_id );
+	}
+
+	/**
+	 * Test that form data store is properly isolated between tests.
+	 */
+	public function test_form_data_store_isolation() {
+		acf_set_form_data( 'key1', 'value1' );
+		acf_get_store( 'form' )->reset();
+		$this->assertNull( acf_get_form_data( 'key1' ) );
+	}
+}

--- a/tests/php/includes/functions/test-acf-input-functions.php
+++ b/tests/php/includes/functions/test-acf-input-functions.php
@@ -1,0 +1,600 @@
+<?php
+/**
+ * Tests for ACF Input Functions.
+ *
+ * Tests functions from includes/acf-input-functions.php including:
+ * - Attribute filtering and escaping
+ * - HTML input generation (hidden, text, file, textarea, checkbox, radio, select)
+ * - KSES allowed HTML handling
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Class Test_ACF_Input_Functions
+ *
+ * Tests for ACF input generation and attribute handling functions.
+ */
+class Test_ACF_Input_Functions extends BaseTestCase {
+
+	// =========================================================================
+	// Helper Methods
+	// =========================================================================
+
+	/**
+	 * Assert that HTML output contains expected input attributes.
+	 *
+	 * @param string $html     The HTML output to check.
+	 * @param string $type     Expected input type.
+	 * @param array  $contains Additional strings that should be present.
+	 */
+	protected function assertInputContains( $html, $type, $contains = array() ) {
+		$this->assertStringContainsString( '<input', $html );
+		$this->assertStringContainsString( "type=\"{$type}\"", $html );
+		foreach ( $contains as $string ) {
+			$this->assertStringContainsString( $string, $html );
+		}
+	}
+
+	/**
+	 * Capture output from an echo function.
+	 *
+	 * @param callable $func Function to call.
+	 * @param array    $args Arguments to pass.
+	 * @return string Captured output.
+	 */
+	protected function captureOutput( $func, $args = array() ) {
+		ob_start();
+		call_user_func_array( $func, $args );
+		return ob_get_clean();
+	}
+
+	// =========================================================================
+	// acf_filter_attrs() Tests
+	// =========================================================================
+
+	/**
+	 * Test that acf_filter_attrs filters out empty values but keeps zero values.
+	 */
+	public function test_acf_filter_attrs_filtering() {
+		$attrs = array(
+			'name'     => 'test_field',
+			'value'    => '',
+			'class'    => 'my-class',
+			'id'       => '',
+			'zero_str' => '0',
+			'zero_int' => 0,
+		);
+
+		$result = acf_filter_attrs( $attrs );
+
+		$this->assertArrayHasKey( 'name', $result );
+		$this->assertArrayHasKey( 'class', $result );
+		$this->assertArrayHasKey( 'zero_str', $result );
+		$this->assertArrayHasKey( 'zero_int', $result );
+		$this->assertArrayNotHasKey( 'value', $result );
+		$this->assertArrayNotHasKey( 'id', $result );
+	}
+
+	/**
+	 * Test boolean attribute handling (required, readonly, disabled, multiple).
+	 *
+	 * @dataProvider booleanAttributesProvider
+	 *
+	 * @param string $attr  Attribute name.
+	 * @param mixed  $value Input value.
+	 * @param mixed  $expected Expected result (attribute name if true, absent if false).
+	 */
+	public function test_acf_filter_attrs_boolean_attributes( $attr, $value, $expected ) {
+		$result = acf_filter_attrs( array( $attr => $value ) );
+
+		if ( null === $expected ) {
+			$this->assertArrayNotHasKey( $attr, $result );
+		} else {
+			$this->assertEquals( $expected, $result[ $attr ] );
+		}
+	}
+
+	/**
+	 * Data provider for boolean attributes.
+	 */
+	public function booleanAttributesProvider() {
+		return array(
+			'required true'  => array( 'required', true, 'required' ),
+			'required false' => array( 'required', false, null ),
+			'readonly true'  => array( 'readonly', true, 'readonly' ),
+			'readonly false' => array( 'readonly', false, null ),
+			'disabled true'  => array( 'disabled', true, 'disabled' ),
+			'multiple true'  => array( 'multiple', true, 'multiple' ),
+		);
+	}
+
+	// =========================================================================
+	// acf_esc_attrs() Tests
+	// =========================================================================
+
+	/**
+	 * Test that acf_esc_attrs generates valid HTML attributes.
+	 */
+	public function test_acf_esc_attrs_generates_html_attributes() {
+		$result = acf_esc_attrs(
+			array(
+				'name'  => 'field_name',
+				'id'    => 'field_id',
+				'class' => 'my-class',
+			)
+		);
+
+		$this->assertStringContainsString( 'name="field_name"', $result );
+		$this->assertStringContainsString( 'id="field_id"', $result );
+		$this->assertStringContainsString( 'class="my-class"', $result );
+	}
+
+	/**
+	 * Test value trimming behavior (trims all except 'value' attribute).
+	 */
+	public function test_acf_esc_attrs_trims_strings_except_value() {
+		$result = acf_esc_attrs(
+			array(
+				'name'  => '  padded  ',
+				'value' => '  has spaces  ',
+			)
+		);
+
+		$this->assertStringContainsString( 'name="padded"', $result );
+		$this->assertStringContainsString( 'value="  has spaces  "', $result );
+	}
+
+	/**
+	 * Test type conversion (booleans to int, arrays/objects to JSON).
+	 */
+	public function test_acf_esc_attrs_type_conversion() {
+		$result = acf_esc_attrs(
+			array(
+				'data-active'   => true,
+				'data-disabled' => false,
+				'data-settings' => array( 'key' => 'value' ),
+			)
+		);
+
+		$this->assertStringContainsString( 'data-active="1"', $result );
+		$this->assertStringContainsString( 'data-disabled="0"', $result );
+		$this->assertStringContainsString( 'data-settings=', $result );
+	}
+
+	/**
+	 * Test XSS prevention through HTML entity escaping.
+	 */
+	public function test_acf_esc_attrs_escapes_html_entities() {
+		$result = acf_esc_attrs( array( 'value' => '<script>alert("xss")</script>' ) );
+
+		$this->assertStringNotContainsString( '<script>', $result );
+		$this->assertStringContainsString( '&lt;script&gt;', $result );
+	}
+
+	// =========================================================================
+	// acf_esc_html() Tests
+	// =========================================================================
+
+	/**
+	 * Test acf_esc_html behavior with various inputs.
+	 *
+	 * @dataProvider escHtmlProvider
+	 *
+	 * @param mixed  $input    Input value.
+	 * @param string $contains String that should be in result (or false for non-scalar).
+	 * @param string $excludes String that should NOT be in result.
+	 */
+	public function test_acf_esc_html( $input, $contains, $excludes = null ) {
+		$result = acf_esc_html( $input );
+
+		if ( false === $contains ) {
+			$this->assertFalse( $result );
+		} else {
+			$this->assertStringContainsString( $contains, $result );
+			if ( $excludes ) {
+				$this->assertStringNotContainsString( $excludes, $result );
+			}
+		}
+	}
+
+	/**
+	 * Data provider for acf_esc_html tests.
+	 */
+	public function escHtmlProvider() {
+		return array(
+			'plain text'      => array( 'Hello World', 'Hello World' ),
+			'allowed tags'    => array( '<strong>Bold</strong>', '<strong>' ),
+			'disallowed tags' => array( '<script>xss</script>Safe', 'Safe', '<script>' ),
+			'array input'     => array( array( 'test' ), false ),
+			'object input'    => array( new stdClass(), false ),
+		);
+	}
+
+	// =========================================================================
+	// _acf_kses_allowed_html() Tests
+	// =========================================================================
+
+	/**
+	 * Test KSES allowed HTML filter behavior.
+	 */
+	public function test_acf_kses_allowed_html() {
+		global $allowedposttags;
+
+		// ACF context returns allowed post tags.
+		$this->assertEquals( $allowedposttags, _acf_kses_allowed_html( array(), 'acf' ) );
+
+		// Other contexts pass through.
+		$tags = array( 'div' => array() );
+		$this->assertEquals( $tags, _acf_kses_allowed_html( $tags, 'post' ) );
+	}
+
+	// =========================================================================
+	// Input Generation Tests (Hidden, Text, File, Textarea)
+	// =========================================================================
+
+	/**
+	 * Test hidden input generation.
+	 */
+	public function test_acf_get_hidden_input() {
+		$result = acf_get_hidden_input(
+			array(
+				'name'  => 'my_field',
+				'value' => 'my_value',
+			)
+		);
+
+		$this->assertInputContains( $result, 'hidden', array( 'name="my_field"', 'value="my_value"' ) );
+
+		// Empty attrs still produces valid hidden input.
+		$this->assertInputContains( acf_get_hidden_input( array() ), 'hidden' );
+	}
+
+	/**
+	 * Test text input generation.
+	 */
+	public function test_acf_get_text_input() {
+		// Basic text input.
+		$result = acf_get_text_input( array( 'name' => 'text_field' ) );
+		$this->assertInputContains( $result, 'text', array( 'name="text_field"' ) );
+
+		// Type override.
+		$result = acf_get_text_input(
+			array(
+				'type' => 'email',
+				'name' => 'email_field',
+			)
+		);
+		$this->assertInputContains( $result, 'email' );
+
+		// XSS prevention.
+		$result = acf_get_text_input( array( 'value' => '<script>alert("xss")</script>' ) );
+		$this->assertStringNotContainsString( '<script>', $result );
+	}
+
+	/**
+	 * Test file input generation with nonce handling.
+	 */
+	public function test_acf_get_file_input() {
+		// Basic file input.
+		$result = acf_get_file_input( array( 'name' => 'file_field' ) );
+		$this->assertInputContains( $result, 'file', array( 'name="file_field"' ) );
+
+		// With explicit key - includes nonce.
+		$result = acf_get_file_input(
+			array(
+				'name' => 'acf[field_abc123]',
+				'key'  => 'field_abc123',
+			)
+		);
+		$this->assertStringContainsString( 'acf[field_abc123_file_nonce]', $result );
+		$this->assertEquals( 2, substr_count( $result, '<input' ) );
+
+		// Key extracted from name.
+		$result = acf_get_file_input( array( 'name' => 'acf[field_xyz789]' ) );
+		$this->assertStringContainsString( 'acf[field_xyz789_file_nonce]', $result );
+
+		// Simple name - no nonce.
+		$result = acf_get_file_input( array( 'name' => 'simple_file' ) );
+		$this->assertEquals( 1, substr_count( $result, '<input' ) );
+	}
+
+	/**
+	 * Test textarea input generation.
+	 */
+	public function test_acf_get_textarea_input() {
+		$result = acf_get_textarea_input(
+			array(
+				'name'  => 'textarea_field',
+				'value' => 'Hello World',
+			)
+		);
+
+		$this->assertStringContainsString( '<textarea', $result );
+		$this->assertStringContainsString( '</textarea>', $result );
+		$this->assertStringContainsString( 'name="textarea_field"', $result );
+		$this->assertStringContainsString( 'Hello World', $result );
+
+		// XSS prevention.
+		$result = acf_get_textarea_input( array( 'value' => '<script>alert("xss")</script>' ) );
+		$this->assertStringNotContainsString( '<script>alert', $result );
+
+		// Empty value.
+		$result = acf_get_textarea_input( array( 'name' => 'test' ) );
+		$this->assertStringContainsString( '><', $result );
+	}
+
+	// =========================================================================
+	// Checkbox/Radio Input Tests
+	// =========================================================================
+
+	/**
+	 * Test checkbox input generation.
+	 */
+	public function test_acf_get_checkbox_input() {
+		// Basic checkbox.
+		$result = acf_get_checkbox_input(
+			array(
+				'name'  => 'checkbox_field',
+				'value' => '1',
+				'label' => 'Accept Terms',
+			)
+		);
+		$this->assertStringContainsString( '<label', $result );
+		$this->assertInputContains( $result, 'checkbox', array( 'Accept Terms' ) );
+
+		// Checked state adds selected class.
+		$result = acf_get_checkbox_input(
+			array(
+				'name'    => 'checkbox_field',
+				'value'   => '1',
+				'checked' => true,
+				'label'   => 'Test',
+			)
+		);
+		$this->assertStringContainsString( 'class="selected"', $result );
+
+		// XSS prevention in label.
+		$result = acf_get_checkbox_input(
+			array(
+				'name'  => 'test',
+				'value' => '1',
+				'label' => '<script>alert("xss")</script>',
+			)
+		);
+		$this->assertStringNotContainsString( '<script>alert', $result );
+	}
+
+	/**
+	 * Test checkbox button group mode with ARIA attributes.
+	 *
+	 * @dataProvider buttonGroupProvider
+	 *
+	 * @param bool   $checked         Whether the option is checked.
+	 * @param string $expected_aria   Expected aria-checked value.
+	 * @param string $expected_tabindex Expected tabindex value.
+	 */
+	public function test_acf_get_checkbox_input_button_group( $checked, $expected_aria, $expected_tabindex ) {
+		$attrs = array(
+			'name'         => 'btn_group',
+			'value'        => '1',
+			'label'        => 'Option',
+			'button_group' => true,
+		);
+
+		if ( $checked ) {
+			$attrs['checked'] = true;
+		}
+
+		$result = acf_get_checkbox_input( $attrs );
+
+		$this->assertStringContainsString( 'role="radio"', $result );
+		$this->assertStringContainsString( "aria-checked=\"{$expected_aria}\"", $result );
+		$this->assertStringContainsString( "tabindex=\"{$expected_tabindex}\"", $result );
+	}
+
+	/**
+	 * Data provider for button group tests.
+	 */
+	public function buttonGroupProvider() {
+		return array(
+			'checked'   => array( true, 'true', '0' ),
+			'unchecked' => array( false, 'false', '-1' ),
+		);
+	}
+
+	/**
+	 * Test radio input generation (wrapper for checkbox with radio type).
+	 */
+	public function test_acf_get_radio_input() {
+		$result = acf_get_radio_input(
+			array(
+				'name'    => 'radio_field',
+				'value'   => 'option1',
+				'label'   => 'Option 1',
+				'checked' => true,
+			)
+		);
+
+		$this->assertInputContains( $result, 'radio', array( 'Option 1', 'class="selected"' ) );
+	}
+
+	// =========================================================================
+	// Select Input Tests
+	// =========================================================================
+
+	/**
+	 * Test select input generation.
+	 */
+	public function test_acf_get_select_input() {
+		$result = acf_get_select_input(
+			array(
+				'name'    => 'select_field',
+				'choices' => array(
+					'opt1' => 'Option 1',
+					'opt2' => 'Option 2',
+				),
+				'value'   => 'opt2',
+			)
+		);
+
+		$this->assertStringContainsString( '<select', $result );
+		$this->assertStringContainsString( '</select>', $result );
+		$this->assertStringContainsString( 'name="select_field"', $result );
+		$this->assertStringContainsString( 'Option 1', $result );
+		$this->assertStringContainsString( 'Option 2', $result );
+		$this->assertStringContainsString( 'selected="selected"', $result );
+
+		// Empty choices.
+		$result = acf_get_select_input(
+			array(
+				'name'    => 'empty',
+				'choices' => array(),
+			)
+		);
+		$this->assertStringNotContainsString( '<option', $result );
+	}
+
+	/**
+	 * Test select option walking with optgroups.
+	 */
+	public function test_acf_walk_select_input() {
+		// Simple options.
+		$result = acf_walk_select_input(
+			array(
+				'val1' => 'Label 1',
+				'val2' => 'Label 2',
+			),
+			array( 'val2' )
+		);
+
+		$this->assertStringContainsString( 'value="val1"', $result );
+		$this->assertStringContainsString( 'Label 1', $result );
+		$this->assertStringContainsString( 'selected="selected"', $result );
+		$this->assertStringContainsString( 'data-i="0"', $result );
+
+		// Optgroups.
+		$result = acf_walk_select_input(
+			array(
+				'Group 1' => array(
+					'val1' => 'Option 1',
+					'val2' => 'Option 2',
+				),
+				'Group 2' => array(
+					'val3' => 'Option 3',
+				),
+			),
+			array( 'val1' )
+		);
+
+		$this->assertStringContainsString( '<optgroup label="Group 1">', $result );
+		$this->assertStringContainsString( '<optgroup label="Group 2">', $result );
+		$this->assertStringContainsString( '</optgroup>', $result );
+		$this->assertStringContainsString( 'selected="selected"', $result );
+
+		// Empty choices.
+		$this->assertEquals( '', acf_walk_select_input( array(), array() ) );
+	}
+
+	// =========================================================================
+	// Echo Function Tests (consolidated)
+	// =========================================================================
+
+	/**
+	 * Test that echo functions output correctly.
+	 *
+	 * @dataProvider echoFunctionsProvider
+	 *
+	 * @param string $func     Function name.
+	 * @param array  $attrs    Attributes to pass.
+	 * @param string $contains String that should be in output.
+	 */
+	public function test_echo_functions( $func, $attrs, $contains ) {
+		$output = $this->captureOutput( $func, array( $attrs ) );
+		$this->assertStringContainsString( $contains, $output );
+	}
+
+	/**
+	 * Data provider for echo function tests.
+	 */
+	public function echoFunctionsProvider() {
+		return array(
+			'acf_hidden_input'   => array( 'acf_hidden_input', array( 'name' => 'test' ), 'type="hidden"' ),
+			'acf_text_input'     => array( 'acf_text_input', array( 'name' => 'test' ), 'type="text"' ),
+			'acf_file_input'     => array( 'acf_file_input', array( 'name' => 'test' ), 'type="file"' ),
+			'acf_textarea_input' => array( 'acf_textarea_input', array( 'name' => 'test' ), '<textarea' ),
+			'acf_checkbox_input' => array(
+				'acf_checkbox_input',
+				array(
+					'name'  => 'test',
+					'value' => '1',
+					'label' => 'L',
+				),
+				'type="checkbox"',
+			),
+			'acf_radio_input'    => array(
+				'acf_radio_input',
+				array(
+					'name'  => 'test',
+					'value' => '1',
+					'label' => 'L',
+				),
+				'type="radio"',
+			),
+			'acf_select_input'   => array(
+				'acf_select_input',
+				array(
+					'name'    => 'test',
+					'choices' => array( 'a' => 'A' ),
+				),
+				'<select',
+			),
+		);
+	}
+
+	// =========================================================================
+	// Alias Function Tests (consolidated)
+	// =========================================================================
+
+	/**
+	 * Test that alias functions work correctly.
+	 *
+	 * @dataProvider aliasFunctionsProvider
+	 *
+	 * @param string $alias    Alias function name.
+	 * @param string $original Original function name.
+	 * @param bool   $is_echo  Whether the alias echoes output.
+	 */
+	public function test_alias_functions( $alias, $original, $is_echo = false ) {
+		$attrs = array(
+			'name'     => 'test',
+			'value'    => 'hello',
+			'required' => true,
+		);
+
+		if ( $is_echo ) {
+			$output = $this->captureOutput( $alias, array( $attrs ) );
+			$this->assertEquals( call_user_func( $original, $attrs ), $output );
+		} else {
+			$this->assertEquals(
+				call_user_func( $original, $attrs ),
+				call_user_func( $alias, $attrs )
+			);
+		}
+	}
+
+	/**
+	 * Data provider for alias function tests.
+	 */
+	public function aliasFunctionsProvider() {
+		return array(
+			'acf_clean_atts' => array( 'acf_clean_atts', 'acf_filter_attrs', false ),
+			'acf_esc_atts'   => array( 'acf_esc_atts', 'acf_esc_attrs', false ),
+			'acf_esc_attr'   => array( 'acf_esc_attr', 'acf_esc_attrs', false ),
+			'acf_esc_attr_e' => array( 'acf_esc_attr_e', 'acf_esc_attrs', true ),
+			'acf_esc_atts_e' => array( 'acf_esc_atts_e', 'acf_esc_attrs', true ),
+		);
+	}
+}


### PR DESCRIPTION
## What
Part of #315.

Adds PHPUnit test coverage for SCF input and form functions.

## Why

Input functions generate all HTML form elements and handle attribute escaping for XSS prevention.

## How

With the help of Claude, adding 53 tests covering:
- Attribute filtering and escaping
- HTML escaping with KSES
- Input generation
- Checkbox and radio inputs with button group ARIA support
- Select inputs with optgroup handling
- Echo function variants
- Alias functions
- Form data storage and retrieval
- Form data HTML rendering
- Post save operations
- Various post ID formats

## Testing Instructions

Run the test suite: `./vendor/bin/phpunit --filter "Test_ACF_Input_Functions|Test_ACF_Form_Functions"`