### PR TITLE
Prepare 6.8.0 Release

### DIFF
--- a/docs/code-reference/META.md
+++ b/docs/code-reference/META.md
@@ -10,6 +10,12 @@ This file tracks code elements that need documentation.
 - `acf/bindings/field_not_supported_message`
 - `acf/blocks/binding_value`
 
+## abilities/class-scf-field-abilities.php
+
+### Hooks
+
+- `scf_field_parent_exists`
+
 ## acf-bidirectional-functions.php
 
 ### Hooks
@@ -372,12 +378,16 @@ This file tracks code elements that need documentation.
 
 - `acf/blocks/default_block_version`
 - `acf/blocks/default_block_version`
+- `acf/blocks/fields_needing_wide_popover`
+- `acf/blocks/fields_to_open_in_expanded_editor`
 - `acf/blocks/no_fields_assigned_message`
 - `acf/blocks/post_block_template_render`
 - `acf/blocks/pre_block_template_render`
 - `acf/blocks/prevent_edit_forms_on_rest_endpoints`
 - `acf/blocks/render_capability`
 - `acf/blocks/template_not_found_message`
+- `acf/blocks/top_toolbar_fields`
+- `acf/blocks/top_toolbar_fields`
 - `acf/blocks/wrap_frontend_innerblocks`
 - `acf/pre_save_block`
 - `acf/register_block_type_args`
@@ -603,6 +613,12 @@ This file tracks code elements that need documentation.
 ### Hooks
 
 - `acf/ui_options_page/registration_args`
+
+## post-types/class-scf-field-manager.php
+
+### Hooks
+
+- `acf/prepare_field_for_export`
 
 ## rest-api/acf-rest-api-functions.php
 

--- a/docs/code-reference/blocks-file.md
+++ b/docs/code-reference/blocks-file.md
@@ -351,9 +351,8 @@ Helper function that returns the HTML attributes required for toolbar inline edi
 
 * Required. A list of the fields, each of which will be displayed in the popup toolbar.
 Each field can be passed as one of the following.
-  * A string (e.g. `'my_field_name'`)
-  * An associative array with specific keys:
-
+* A string (e.g. `'my_field_name'`)
+An associative array with specific keys:
 * @type string  $field_name  The name of the field to display in the toolbar.
 * @type string  $field_icon  An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
 * @type string  $field_label A string to use as the label for the button in the toolbar.
@@ -385,9 +384,8 @@ This function prepares a fields array for being localized and used on the fronte
 
 * Required. A list of the fields, each of which will be displayed in the popup toolbar.
 Each field can be passed as one of the following.
-  * A string (e.g. `'my_field_name'`)
-  * An associative array with specific keys:
-
+* A string (e.g. `'my_field_name'`)
+An associative array with specific keys:
 * @type string $field_name  The name of the field to display in the toolbar.
 * @type string $field_icon  An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
 * @type string $field_label A string to use as the label for the button in the toolbar.

--- a/docs/code-reference/blocks-file.md
+++ b/docs/code-reference/blocks-file.md
@@ -181,6 +181,13 @@ Enqueues and localizes block scripts and styles.
 * @since   ACF 5.7.13
 * @return  void
 
+## `acf_enqueue_in_iframe_styles()`
+
+Enqueues scripts and styles to load inside the block editor iframe.
+This allows us to do things like style contenteditable, and other inline editing elements.
+
+* @since ACF 6.7
+
 ## `acf_enqueue_block_type_assets()`
 
 Enqueues scripts and styles for a specific block type.
@@ -337,5 +344,63 @@ that need to be saved to post meta.
 * @since ACF 6.3
 * @param string $content The content saved for the post.
 * @return array An array containing the field values that need to be saved.
+
+## `acf_inline_toolbar_editing_attrs()`
+
+Helper function that returns the HTML attributes required for toolbar inline editing as a string, escaped and ready for output.
+
+* Required. A list of the fields, each of which will be displayed in the popup toolbar.
+Each field can be passed as one of the following.
+  * A string (e.g. `'my_field_name'`)
+  * An associative array with specific keys:
+
+* @type string  $field_name  The name of the field to display in the toolbar.
+* @type string  $field_icon  An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
+* @type string  $field_label A string to use as the label for the button in the toolbar.
+* @type boolean $use_expanded_editor Default is false, which opens the field in the popover. Set to true to open in the expanded editor.
+* @type string  $popover_min_width Enter the CSS width value to use for the popover. Default is "300px".
+* @param array $fields List of fields.
+* @param array $args   Additional options controlling toolbar display and behavior.
+* @type string $toolbar_icon  Optional. An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
+* @type string $toolbar_title Optional. A string to be used as the toolbar title. If not passed, the name of the first field will be used.
+* @type string $uid           Optional. A unique identifier that isn't used by any other inline fields in this block. Pass if you have 2 elements that conflict.
+* @return string A string containing the attributes.
+
+## `acf_inline_text_editing_attrs()`
+
+Helper function that returns the HTML attributes required for inline text editing as a string, escaped and ready for output.
+
+* @param string $field_name A string which is the name of the field to update when the user types into the HTML element.
+* @param array  $args       Array {
+Optional. An array of additional args which can control how the popover identifier is displayed.
+* @type string $toolbar_icon  Optional. An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
+* @type string $toolbar_title Optional. A string to be used as the toolbar title. If not passed, the name of the first field will be used.
+* @type string $placeholder   Optional. Optional. A string which will be used as the placeholder in the typable text area.
+}
+* @return string A string containing the attributes.
+
+## `acf_process_block_toolbar_fields()`
+
+This function prepares a fields array for being localized and used on the frontend as block toolbar fields.
+
+* Required. A list of the fields, each of which will be displayed in the popup toolbar.
+Each field can be passed as one of the following.
+  * A string (e.g. `'my_field_name'`)
+  * An associative array with specific keys:
+
+* @type string $field_name  The name of the field to display in the toolbar.
+* @type string $field_icon  An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
+* @type string $field_label A string to use as the label for the button in the toolbar.
+* @param array $fields List of fields.
+* @return array The array of fields, prepared for JS localization.
+
+## `acf_inline_editing_field_is_empty()`
+
+Helper function for block render templates to check if an acf field has a value.
+This is relevant when autoInlineEditing is enabled for a block, because empty fields
+will have acf_auto_inline_editing_field_name_ + field_name as their value if they are empty.
+
+* @param string $field_name Field name.
+* @return boolean True if the field is empty, false if it has a value.
 
 ---

--- a/docs/code-reference/rest-api/class-acf-rest-types-endpoint-file.md
+++ b/docs/code-reference/rest-api/class-acf-rest-types-endpoint-file.md
@@ -9,37 +9,47 @@ Class SCF_Rest_Types_Endpoint
 
 ### `__construct`
 
-Initialize the class.
+Initialize the class and register hooks.
 
 * @since SCF 6.5.0
+* @since 6.7.0 Simplified hook registration.
+
+### `is_valid_source`
+
+Validate source parameter.
+
+* @since 6.7.0
+* @param string $source The source value to validate.
+* @return bool True if valid, false otherwise.
 
 ### `filter_types_request`
 
-Filter post types requests, fires for both collection and individual requests.
-We only want to handle individual requets to ensure the post type requested matches the source.
+Filter post types requests for individual post type requests.
 
 * @since SCF 6.5.0
-* @param mixed           $response The current response, either response or null.
+* @since 6.7.0 Use is_valid_source() helper method.
+* @param mixed           $response The current response.
 * @param array           $handler  The handler for the route.
 * @param WP_REST_Request $request  The request object.
-* @return mixed The response or null.
+* @return mixed The response or WP_Error.
 
 ### `filter_post_type`
 
 Filter individual post type in the response.
 
 * @since SCF 6.5.0
-* @param WP_REST_Response $response The response object.
+* @since 6.7.0 Use is_valid_source() helper method.
+* @param WP_REST_Response $response  The response object.
 * @param WP_Post_Type     $post_type The post type object.
-* @param WP_REST_Request  $request The request object.
-* @return WP_REST_Response|null The filtered response or null to filter it out.
+* @param WP_REST_Request  $request   The request object.
+* @return WP_REST_Response|null The filtered response or null.
 
 ### `get_source_post_types`
 
-Get an array of post types for each source.
+Get post types for a specific source.
 
 * @since SCF 6.5.0
-* @param string $source The source to get post types for.
+* @param string $source The source to get post types for (core, scf, other).
 * @return array An array of post type names for the specified source.
 
 ### `register_extra_fields`
@@ -75,6 +85,7 @@ Register the source parameter for the post types endpoint.
 Get the source parameter definition
 
 * @since SCF 6.5.0
+* @since 6.7.0 Use VALID_SOURCES constant.
 * @return array Parameter definition
 
 ### `add_parameter_to_endpoints`

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -1642,8 +1642,8 @@ function acf_get_block_meta_values_to_save( $content = '' ) {
  * Required. A list of the fields, each of which will be displayed in the popup toolbar.
  * Each field can be passed as one of the following.
  *
- * - A string (e.g. `'my_field_name'`)
- * - An associative array with specific keys:
+ * A string (e.g. `'my_field_name'`)
+ * An associative array with specific keys:
  *
  * @type string  $field_name  The name of the field to display in the toolbar.
  * @type string  $field_icon  An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
@@ -1835,8 +1835,8 @@ function acf_inline_text_editing_attrs( $field_name, $args = array() ): string {
  * Required. A list of the fields, each of which will be displayed in the popup toolbar.
  * Each field can be passed as one of the following.
  *
- * - A string (e.g. `'my_field_name'`)
- * - An associative array with specific keys:
+ * A string (e.g. `'my_field_name'`)
+ * An associative array with specific keys:
  *
  * @type string $field_name  The name of the field to display in the toolbar.
  * @type string $field_icon  An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.

--- a/readme.txt
+++ b/readme.txt
@@ -52,6 +52,27 @@ This plugin builds upon and is a fork of the previous work done by the contribut
 
 == Changelog ==
 
+= 6.8.0 =
+*Release Date 30 Dec 2025*
+
+*Features*
+
+- Abilities integration: addded field abilities for Field Groups.
+- Abilities integration: added trash/untrash abilities for internal post types.
+- All backports up to 6.7.0.2.
+- JSON Schemas: Added several fields schemas.
+- WooCommerce HPOS: Added support for custom fields on any WooCommerce Order Types.
+- Added PHPUnit tests.
+
+*Fixes*
+
+- Hide duplicated Command Palette Commands on WP 6.9+.
+- Fix field schema validation for WP Rest API.
+- Fix checkbox toggle functionality.
+
+
+= 6.7.0 =
+
 = 6.7.1 =
 *Release Date 10 Dec 2025*
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: fields, custom fields, meta, scf
 Requires at least: 6.0
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 6.7.1
+Stable tag: 6.8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -6,7 +6,7 @@
  * Plugin Name:       Secure Custom Fields
  * Plugin URI:        https://developer.wordpress.org/secure-custom-fields/
  * Description:       Secure Custom Fields (SCF) offers an intuitive way for developers to enhance WordPress content management by adding extra fields and options without coding requirements.
- * Version:           6.7.1
+ * Version:           6.8.0
  * Author:            WordPress.org
  * Author URI:        https://wordpress.org/
  * Text Domain:       secure-custom-fields
@@ -33,7 +33,7 @@ if ( ! class_exists( 'ACF' ) ) {
 		 *
 		 * @var string
 		 */
-		public $version = '6.7.1';
+		public $version = '6.8.0';
 
 		/**
 		 * The plugin settings array.


### PR DESCRIPTION
*Release Date 30 Dec 2025*

*Features*

- Abilities integration: added field abilities for Field Groups and individual Fields.
- Abilities integration: added trash/untrash abilities for internal post types.
- All backports up to 6.7.0.2.
- JSON Schemas: Added all field schemas.
- WooCommerce HPOS: Added support for custom fields on any WooCommerce Order Types.
- Added PHPUnit tests.

*Fixes*

- Hide duplicated Command Palette Commands on WP 6.9+.
- Fix field schema validation for WP Rest API.
- Fix checkbox toggle functionality.