### PR TITLE
Tests: Add PHPUnit tests for hook, WP, and bidirectional functions

### DIFF
--- a/tests/php/includes/functions/test-acf-bidirectional-functions.php
+++ b/tests/php/includes/functions/test-acf-bidirectional-functions.php
@@ -1,0 +1,448 @@
+<?php
+/**
+ * Tests for bidirectional field functions in includes/acf-bidirectional-functions.php
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for acf-bidirectional-functions.php
+ *
+ * Tests cover:
+ * - acf_get_valid_bidirectional_target_types() - Valid target types per object type
+ * - acf_build_bidirectional_target_current_choices() - Choice building for select2
+ * - acf_get_bidirectional_field_settings_instruction_text() - Instruction text generation
+ * - acf_update_bidirectional_values() - Bidirectional value updates (when testable)
+ */
+class Test_ACF_Bidirectional_Functions extends BaseTestCase {
+
+	/**
+	 * Original bidirection setting.
+	 *
+	 * @var bool
+	 */
+	private $original_bidirection_setting;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->original_bidirection_setting = acf_get_setting( 'enable_bidirection' );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		acf_update_setting( 'enable_bidirection', $this->original_bidirection_setting );
+		acf_set_data( 'acf_doing_bidirectional_update', false );
+		remove_all_filters( 'acf/bidirectional/supported_field_types_for_post' );
+		remove_all_filters( 'acf/bidirectional/supported_target_field_types' );
+	}
+
+	/**
+	 * Test acf_get_valid_bidirectional_target_types for term object type.
+	 */
+	public function test_get_valid_bidirectional_target_types_term() {
+		$result = acf_get_valid_bidirectional_target_types( 'term' );
+
+		$this->assertIsArray( $result, 'Result should be an array' );
+		$this->assertContains( 'taxonomy', $result, 'Term should support taxonomy field type' );
+	}
+
+	/**
+	 * Test acf_get_valid_bidirectional_target_types for user object type.
+	 */
+	public function test_get_valid_bidirectional_target_types_user() {
+		$result = acf_get_valid_bidirectional_target_types( 'user' );
+
+		$this->assertIsArray( $result, 'Result should be an array' );
+		$this->assertContains( 'user', $result, 'User should support user field type' );
+	}
+
+	/**
+	 * Test acf_get_valid_bidirectional_target_types for post object type.
+	 */
+	public function test_get_valid_bidirectional_target_types_post() {
+		$result = acf_get_valid_bidirectional_target_types( 'post' );
+
+		$this->assertIsArray( $result, 'Result should be an array' );
+		$this->assertContains( 'relationship', $result, 'Post should support relationship field type' );
+		$this->assertContains( 'post_object', $result, 'Post should support post_object field type' );
+	}
+
+	/**
+	 * Test acf_get_valid_bidirectional_target_types for unknown object type.
+	 */
+	public function test_get_valid_bidirectional_target_types_unknown() {
+		$result = acf_get_valid_bidirectional_target_types( 'unknown' );
+
+		$this->assertIsArray( $result, 'Result should be an array' );
+		$this->assertEmpty( $result, 'Unknown type should return empty array' );
+	}
+
+	/**
+	 * Test acf_get_valid_bidirectional_target_types applies filter.
+	 */
+	public function test_get_valid_bidirectional_target_types_applies_filter() {
+		add_filter(
+			'acf/bidirectional/supported_field_types_for_post',
+			function ( $types, $object_type ) {
+				if ( 'post' === $object_type ) {
+					$types[] = 'custom_field';
+				}
+				return $types;
+			},
+			10,
+			2
+		);
+
+		$result = acf_get_valid_bidirectional_target_types( 'post' );
+
+		$this->assertContains( 'custom_field', $result, 'Filter should add custom field type' );
+	}
+
+	/**
+	 * Data provider for valid bidirectional target types.
+	 *
+	 * @return array
+	 */
+	public function data_provider_bidirectional_target_types() {
+		return array(
+			'term returns taxonomy'                     => array( 'term', array( 'taxonomy' ) ),
+			'user returns user'                         => array( 'user', array( 'user' ) ),
+			'post returns relationship and post_object' => array( 'post', array( 'relationship', 'post_object' ) ),
+			'comment returns empty'                     => array( 'comment', array() ),
+			'option returns empty'                      => array( 'option', array() ),
+		);
+	}
+
+	/**
+	 * Test acf_get_valid_bidirectional_target_types with data provider.
+	 *
+	 * @dataProvider data_provider_bidirectional_target_types
+	 * @param string $object_type    The object type.
+	 * @param array  $expected_types The expected field types.
+	 */
+	public function test_get_valid_bidirectional_target_types_data_provider( $object_type, $expected_types ) {
+		$result = acf_get_valid_bidirectional_target_types( $object_type );
+
+		$this->assertSame( $expected_types, $result, "Object type '$object_type' should return expected types" );
+	}
+
+	/**
+	 * Test acf_build_bidirectional_target_current_choices with empty array.
+	 */
+	public function test_build_bidirectional_target_current_choices_empty() {
+		$result = acf_build_bidirectional_target_current_choices( array() );
+
+		$this->assertIsArray( $result, 'Result should be an array' );
+		$this->assertEmpty( $result, 'Empty input should return empty array' );
+	}
+
+	/**
+	 * Test acf_build_bidirectional_target_current_choices with null.
+	 */
+	public function test_build_bidirectional_target_current_choices_null() {
+		$result = acf_build_bidirectional_target_current_choices( null );
+
+		$this->assertIsArray( $result, 'Result should be an array' );
+		$this->assertEmpty( $result, 'Null input should return empty array' );
+	}
+
+	/**
+	 * Test acf_build_bidirectional_target_current_choices skips empty choices.
+	 */
+	public function test_build_bidirectional_target_current_choices_skips_empty() {
+		$result = acf_build_bidirectional_target_current_choices( array( '', null, false ) );
+
+		$this->assertEmpty( $result, 'Empty/null/false choices should be skipped' );
+	}
+
+	/**
+	 * Test acf_build_bidirectional_target_current_choices skips non-string choices.
+	 */
+	public function test_build_bidirectional_target_current_choices_skips_non_string() {
+		$result = acf_build_bidirectional_target_current_choices( array( 123, array( 'test' ), new stdClass() ) );
+
+		$this->assertEmpty( $result, 'Non-string choices should be skipped' );
+	}
+
+	/**
+	 * Test acf_build_bidirectional_target_current_choices uses key as fallback label.
+	 */
+	public function test_build_bidirectional_target_current_choices_key_fallback() {
+		// When the field object is not found, the key itself is used as the label.
+		$choices = array( 'field_nonexistent_123' );
+		$result  = acf_build_bidirectional_target_current_choices( $choices );
+
+		$this->assertArrayHasKey( 'field_nonexistent_123', $result, 'Key should be present' );
+		$this->assertSame( 'field_nonexistent_123', $result['field_nonexistent_123'], 'Key should be used as label when field not found' );
+	}
+
+	/**
+	 * Test acf_get_bidirectional_field_settings_instruction_text returns string.
+	 */
+	public function test_get_bidirectional_field_settings_instruction_text_returns_string() {
+		$result = acf_get_bidirectional_field_settings_instruction_text();
+
+		$this->assertIsString( $result, 'Result should be a string' );
+		$this->assertNotEmpty( $result, 'Result should not be empty' );
+	}
+
+	/**
+	 * Test acf_get_bidirectional_field_settings_instruction_text contains expected content.
+	 */
+	public function test_get_bidirectional_field_settings_instruction_text_content() {
+		$result = acf_get_bidirectional_field_settings_instruction_text();
+
+		$this->assertStringContainsString( 'bidirectional', $result, 'Should mention bidirectional' );
+		$this->assertStringContainsString( '<p', $result, 'Should contain HTML paragraph tag' );
+		$this->assertStringContainsString( 'acf-feature-notice', $result, 'Should have feature notice class' );
+	}
+
+	/**
+	 * Test acf_update_bidirectional_values returns early when already updating (recursion guard).
+	 *
+	 * When the recursion flag is already set, the function should return immediately
+	 * without modifying the flag or processing any updates.
+	 */
+	public function test_update_bidirectional_values_prevents_recursion() {
+		// Pre-set the recursion guard flag.
+		acf_set_data( 'acf_doing_bidirectional_update', true );
+
+		$field = array(
+			'type'                 => 'relationship',
+			'name'                 => 'test_field',
+			'bidirectional'        => true,
+			'bidirectional_target' => array( 'field_abc123' ),
+		);
+
+		// Call the function - it should return early without changing the flag.
+		acf_update_bidirectional_values( array( 1, 2, 3 ), 'post_123', $field );
+
+		// The flag should still be true (not reset to false), proving early return.
+		$this->assertTrue(
+			acf_get_data( 'acf_doing_bidirectional_update' ),
+			'Recursion guard flag should remain true when function returns early'
+		);
+	}
+
+	/**
+	 * Test acf_update_bidirectional_values returns early when bidirection disabled.
+	 *
+	 * When the enable_bidirection setting is false, the function should return
+	 * immediately without setting the recursion flag.
+	 */
+	public function test_update_bidirectional_values_disabled() {
+		acf_update_setting( 'enable_bidirection', false );
+
+		$field = array(
+			'type'                 => 'relationship',
+			'name'                 => 'test_field',
+			'bidirectional'        => true,
+			'bidirectional_target' => array( 'field_abc123' ),
+		);
+
+		// Call the function.
+		acf_update_bidirectional_values( array( 1, 2, 3 ), 'post_123', $field );
+
+		// The recursion flag should never have been set (early return before line 70).
+		$this->assertFalse(
+			acf_get_data( 'acf_doing_bidirectional_update' ),
+			'Recursion flag should not be set when bidirection is disabled'
+		);
+	}
+
+	/**
+	 * Test acf_update_bidirectional_values returns early without bidirectional config.
+	 *
+	 * When the field lacks bidirectional settings, the function should return
+	 * immediately without setting the recursion flag.
+	 */
+	public function test_update_bidirectional_values_no_config() {
+		acf_update_setting( 'enable_bidirection', true );
+
+		$field = array(
+			'type' => 'relationship',
+			'name' => 'test_field',
+			// Missing 'bidirectional' and 'bidirectional_target'.
+		);
+
+		acf_update_bidirectional_values( array( 1, 2, 3 ), 'post_123', $field );
+
+		// The recursion flag should never have been set (early return at line 33-34).
+		$this->assertFalse(
+			acf_get_data( 'acf_doing_bidirectional_update' ),
+			'Recursion flag should not be set when field lacks bidirectional config'
+		);
+	}
+
+	/**
+	 * Test acf_update_bidirectional_values returns early with empty bidirectional_target.
+	 *
+	 * When bidirectional_target is empty, the function should return immediately
+	 * without setting the recursion flag.
+	 */
+	public function test_update_bidirectional_values_empty_target() {
+		acf_update_setting( 'enable_bidirection', true );
+
+		$field = array(
+			'type'                 => 'relationship',
+			'name'                 => 'test_field',
+			'bidirectional'        => true,
+			'bidirectional_target' => array(),
+		);
+
+		acf_update_bidirectional_values( array( 1, 2, 3 ), 'post_123', $field );
+
+		// The recursion flag should never have been set (early return at line 33-34).
+		$this->assertFalse(
+			acf_get_data( 'acf_doing_bidirectional_update' ),
+			'Recursion flag should not be set when bidirectional_target is empty'
+		);
+	}
+
+	/**
+	 * Test acf_update_bidirectional_values sets flag during update.
+	 */
+	public function test_update_bidirectional_values_sets_flag() {
+		acf_update_setting( 'enable_bidirection', true );
+
+		// Verify flag is not set before.
+		$this->assertFalse(
+			acf_get_data( 'acf_doing_bidirectional_update' ),
+			'Flag should not be set initially'
+		);
+
+		// The flag is set internally during the update process.
+		// We can only verify the initial state and that no errors occur.
+		$field = array(
+			'type'                 => 'relationship',
+			'name'                 => 'test_field',
+			'bidirectional'        => true,
+			'bidirectional_target' => array( 'field_abc123' ),
+		);
+
+		// This will attempt to update but fail silently due to missing field objects.
+		acf_update_bidirectional_values( array(), 'post_123', $field );
+
+		// After the function completes, flag should be reset.
+		$this->assertFalse(
+			acf_get_data( 'acf_doing_bidirectional_update' ),
+			'Flag should be reset after update'
+		);
+	}
+
+	/**
+	 * Test acf_render_bidirectional_field_settings returns early when disabled.
+	 */
+	public function test_render_bidirectional_field_settings_disabled() {
+		acf_update_setting( 'enable_bidirection', false );
+
+		ob_start();
+		acf_render_bidirectional_field_settings( array( 'type' => 'relationship' ) );
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output, 'No output when bidirection is disabled' );
+	}
+
+	/**
+	 * Test acf_render_bidirectional_field_settings generates output when enabled.
+	 */
+	public function test_render_bidirectional_field_settings_enabled() {
+		acf_update_setting( 'enable_bidirection', true );
+
+		// Create a properly structured field with required properties.
+		$field = array(
+			'key'                  => 'field_test_123',
+			'type'                 => 'relationship',
+			'name'                 => 'test_field',
+			'label'                => 'Test Field',
+			'bidirectional'        => false,
+			'bidirectional_target' => array(),
+			'prefix'               => 'acf_field_group',
+		);
+
+		ob_start();
+		acf_render_bidirectional_field_settings( $field );
+		$output = ob_get_clean();
+
+		// The function calls acf_render_field_setting which produces HTML.
+		$this->assertStringContainsString( 'Bidirectional', $output, 'Should contain Bidirectional label' );
+	}
+
+	/**
+	 * Test acf_build_bidirectional_relationship_field_target_args returns correct structure.
+	 */
+	public function test_build_bidirectional_relationship_field_target_args_structure() {
+		$results = array( 'results' => array() );
+		$options = array();
+
+		$result = acf_build_bidirectional_relationship_field_target_args( $results, $options );
+
+		$this->assertIsArray( $result, 'Result should be an array' );
+		$this->assertArrayHasKey( 'results', $result, 'Result should have results key' );
+	}
+
+	/**
+	 * Test acf_build_bidirectional_relationship_field_target_args applies filter.
+	 */
+	public function test_build_bidirectional_relationship_field_target_args_filter() {
+		add_filter(
+			'acf/bidirectional/supported_target_field_types',
+			function ( $types ) {
+				$types[] = 'custom_type';
+				return $types;
+			}
+		);
+
+		$results = array( 'results' => array() );
+		$options = array();
+
+		$result = acf_build_bidirectional_relationship_field_target_args( $results, $options );
+
+		// The filter is applied, function should work.
+		$this->assertIsArray( $result, 'Result should be an array' );
+	}
+
+	/**
+	 * Test acf_build_bidirectional_relationship_field_target_args with parent_key option.
+	 */
+	public function test_build_bidirectional_relationship_field_target_args_with_parent_key() {
+		$results = array( 'results' => array() );
+		$options = array( 'parent_key' => 'field_123' );
+
+		$result = acf_build_bidirectional_relationship_field_target_args( $results, $options );
+
+		$this->assertIsArray( $result, 'Result should be an array' );
+		$this->assertArrayHasKey( 'results', $result, 'Result should have results key' );
+	}
+
+	/**
+	 * Test default field types for bidirectional relationship targets.
+	 */
+	public function test_default_bidirectional_target_field_types() {
+		// Test that the filter receives the expected default types.
+		$captured_types = null;
+		add_filter(
+			'acf/bidirectional/supported_target_field_types',
+			function ( $types ) use ( &$captured_types ) {
+				$captured_types = $types;
+				return $types;
+			}
+		);
+
+		$results = array( 'results' => array() );
+		acf_build_bidirectional_relationship_field_target_args( $results, array() );
+
+		$this->assertContains( 'relationship', $captured_types, 'Should include relationship type' );
+		$this->assertContains( 'post_object', $captured_types, 'Should include post_object type' );
+		$this->assertContains( 'user', $captured_types, 'Should include user type' );
+		$this->assertContains( 'taxonomy', $captured_types, 'Should include taxonomy type' );
+	}
+}

--- a/tests/php/includes/functions/test-acf-hook-functions.php
+++ b/tests/php/includes/functions/test-acf-hook-functions.php
@@ -1,0 +1,505 @@
+<?php
+/**
+ * Tests for hook functions in includes/acf-hook-functions.php
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for acf-hook-functions.php
+ *
+ * Tests cover:
+ * - Filter variations registration and application
+ * - Action variations registration and application
+ * - Deprecated hook registration and backward compatibility
+ */
+class Test_ACF_Hook_Functions extends BaseTestCase {
+
+	/**
+	 * Original deprecated-hooks store data.
+	 *
+	 * @var array
+	 */
+	private $original_deprecated_hooks;
+
+	/**
+	 * Set up before each test.
+	 *
+	 * Saves the initial state of the deprecated-hooks store so it can
+	 * be restored after each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Save the initial state of the deprecated-hooks store.
+		$deprecated_store = acf_get_store( 'deprecated-hooks' );
+		if ( $deprecated_store ) {
+			$this->original_deprecated_hooks = $deprecated_store->get_data();
+		}
+	}
+
+	/**
+	 * Clean up test hooks after each test.
+	 *
+	 * Note: We only remove test-specific hooks from variations store.
+	 * For deprecated-hooks, we restore the original state since it uses
+	 * append() without keys.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		// Remove test-specific entries from variations store (not reset).
+		$variations_store = acf_get_store( 'hook-variations' );
+		if ( $variations_store ) {
+			$variations_store->remove( 'test_filter' );
+			$variations_store->remove( 'test_action' );
+		}
+
+		// Restore the original deprecated-hooks store state.
+		// Note: ACF_Data has public $data property, not set_data() method.
+		$deprecated_store = acf_get_store( 'deprecated-hooks' );
+		if ( $deprecated_store && isset( $this->original_deprecated_hooks ) ) {
+			$deprecated_store->data = $this->original_deprecated_hooks;
+		}
+
+		// Remove all test filters and actions.
+		remove_all_filters( 'test_filter' );
+		remove_all_filters( 'test_filter/type=text' );
+		remove_all_filters( 'test_filter/name=my_field' );
+		remove_all_filters( 'test_filter/name=backup_field' );
+		remove_all_filters( 'test_filter/key=field_123' );
+		remove_all_filters( 'test_filter/type=' );
+		remove_all_filters( 'test_filter/type=123' );
+		remove_all_filters( 'test_action' );
+		remove_all_filters( 'test_action/type=text' );
+		remove_all_filters( 'new_replacement_hook' );
+		remove_all_filters( 'old_deprecated_hook' );
+		remove_all_filters( 'new_action' );
+		remove_all_filters( 'old_action' );
+		remove_all_filters( 'old_hook_1' );
+		remove_all_filters( 'old_hook_2' );
+	}
+
+	/**
+	 * Data provider for hook variation registration tests.
+	 *
+	 * @return array
+	 */
+	public function data_provider_hook_variation_registration() {
+		return array(
+			'filter with index 0'        => array( 'filter', array( 'type', 'name' ), 0 ),
+			'filter with custom index 2' => array( 'filter', array( 'type' ), 2 ),
+			'action with index 0'        => array( 'action', array( 'type', 'name' ), 0 ),
+			'action with custom index 1' => array( 'action', array( 'key' ), 1 ),
+		);
+	}
+
+	/**
+	 * Test that hook variation functions store correct data structure.
+	 *
+	 * @dataProvider data_provider_hook_variation_registration
+	 * @param string $hook_type   Either 'filter' or 'action'.
+	 * @param array  $variations  The variation keys.
+	 * @param int    $index       The argument index.
+	 */
+	public function test_add_hook_variations_stores_data( $hook_type, $variations, $index ) {
+		$hook_name = 'filter' === $hook_type ? 'test_filter' : 'test_action';
+
+		if ( 'filter' === $hook_type ) {
+			acf_add_filter_variations( $hook_name, $variations, $index );
+		} else {
+			acf_add_action_variations( $hook_name, $variations, $index );
+		}
+
+		$store = acf_get_store( 'hook-variations' );
+		$data  = $store->get( $hook_name );
+
+		$this->assertIsArray( $data, 'Stored data should be an array' );
+		$this->assertSame( $hook_type, $data['type'], "Type should be $hook_type" );
+		$this->assertSame( $variations, $data['variations'], 'Variations should match' );
+		$this->assertSame( $index, $data['index'], "Index should be $index" );
+	}
+
+	/**
+	 * Test that hook variation functions register handlers.
+	 *
+	 * @dataProvider data_provider_hook_variation_registration
+	 * @param string $hook_type   Either 'filter' or 'action'.
+	 * @param array  $variations  The variation keys.
+	 * @param int    $index       The argument index.
+	 */
+	public function test_add_hook_variations_registers_handler( $hook_type, $variations, $index ) {
+		$hook_name = 'filter' === $hook_type ? 'test_filter' : 'test_action';
+
+		if ( 'filter' === $hook_type ) {
+			acf_add_filter_variations( $hook_name, $variations, $index );
+			$has_handler = has_filter( $hook_name ) !== false;
+		} else {
+			acf_add_action_variations( $hook_name, $variations, $index );
+			$has_handler = has_action( $hook_name ) !== false;
+		}
+
+		$this->assertTrue( $has_handler, "Handler should be registered for $hook_type" );
+	}
+
+	/**
+	 * Test _acf_apply_hook_variations applies filter variations correctly.
+	 *
+	 * Uses index 1 because the filter signature is: apply_filters($hook, $value, $field)
+	 * where $field is at index 1 (second argument after the value).
+	 */
+	public function test_apply_hook_variations_applies_filter() {
+		// Index 1 means the field array is at position 1.
+		acf_add_filter_variations( 'test_filter', array( 'type' ), 1 );
+
+		// Add a specific variation handler.
+		add_filter(
+			'test_filter/type=text',
+			function ( $value ) {
+				return $value . '_modified';
+			}
+		);
+
+		$field  = array( 'type' => 'text' );
+		$result = apply_filters( 'test_filter', 'original', $field );
+
+		$this->assertSame( 'original_modified', $result, 'Filter variation should modify the value' );
+	}
+
+	/**
+	 * Test _acf_apply_hook_variations applies filter when field IS the value (index 0).
+	 *
+	 * This matches how acf/load_field works where the field itself is filtered.
+	 */
+	public function test_apply_hook_variations_with_field_as_value() {
+		// Index 0 means the filtered value itself is the field array.
+		acf_add_filter_variations( 'test_filter', array( 'type' ), 0 );
+
+		add_filter(
+			'test_filter/type=text',
+			function ( $field ) {
+				$field['modified'] = true;
+				return $field;
+			}
+		);
+
+		$field  = array( 'type' => 'text' );
+		$result = apply_filters( 'test_filter', $field );
+
+		$this->assertArrayHasKey( 'modified', $result, 'Field should be modified' );
+		$this->assertTrue( $result['modified'], 'Modified flag should be true' );
+	}
+
+	/**
+	 * Test _acf_apply_hook_variations applies multiple filter variations.
+	 */
+	public function test_apply_hook_variations_applies_multiple_filters() {
+		acf_add_filter_variations( 'test_filter', array( 'type', 'name' ), 1 );
+
+		// Add handlers for both variations.
+		add_filter(
+			'test_filter/type=text',
+			function ( $value ) {
+				return $value . '_type';
+			}
+		);
+
+		add_filter(
+			'test_filter/name=my_field',
+			function ( $value ) {
+				return $value . '_name';
+			}
+		);
+
+		$field  = array(
+			'type' => 'text',
+			'name' => 'my_field',
+		);
+		$result = apply_filters( 'test_filter', 'original', $field );
+
+		$this->assertSame( 'original_type_name', $result, 'Both filter variations should be applied in order' );
+	}
+
+	/**
+	 * Test _acf_apply_hook_variations uses backup value with underscore prefix.
+	 */
+	public function test_apply_hook_variations_uses_backup_value() {
+		acf_add_filter_variations( 'test_filter', array( 'name' ), 1 );
+
+		add_filter(
+			'test_filter/name=backup_field',
+			function ( $value ) {
+				return $value . '_backup';
+			}
+		);
+
+		// Field with both regular and backup value - backup should take precedence.
+		$field  = array(
+			'name'  => 'regular_field',
+			'_name' => 'backup_field',
+		);
+		$result = apply_filters( 'test_filter', 'original', $field );
+
+		$this->assertSame( 'original_backup', $result, 'Backup value with underscore prefix should be used' );
+	}
+
+	/**
+	 * Test _acf_apply_hook_variations skips missing variation values.
+	 */
+	public function test_apply_hook_variations_skips_missing_values() {
+		acf_add_filter_variations( 'test_filter', array( 'type', 'missing_key' ), 1 );
+
+		add_filter(
+			'test_filter/type=text',
+			function ( $value ) {
+				return $value . '_type';
+			}
+		);
+
+		// Field without 'missing_key'.
+		$field  = array( 'type' => 'text' );
+		$result = apply_filters( 'test_filter', 'original', $field );
+
+		$this->assertSame( 'original_type', $result, 'Only existing variation keys should be applied' );
+	}
+
+	/**
+	 * Test _acf_apply_hook_variations with field at index 2 (like acf/load_value).
+	 */
+	public function test_apply_hook_variations_with_index_2() {
+		// Index 2 means the field array is the 3rd argument (after hook, value, post_id).
+		acf_add_filter_variations( 'test_filter', array( 'type' ), 2 );
+
+		add_filter(
+			'test_filter/type=text',
+			function ( $value ) {
+				return $value . '_modified';
+			}
+		);
+
+		$field  = array( 'type' => 'text' );
+		$result = apply_filters( 'test_filter', 'original', 123, $field );
+
+		$this->assertSame( 'original_modified', $result, 'Filter should work with field at index 2' );
+	}
+
+	/**
+	 * Test _acf_apply_hook_variations triggers actions instead of filters.
+	 */
+	public function test_apply_hook_variations_triggers_actions() {
+		acf_add_action_variations( 'test_action', array( 'type' ), 0 );
+
+		$action_called = false;
+		add_action(
+			'test_action/type=text',
+			function () use ( &$action_called ) {
+				$action_called = true;
+			}
+		);
+
+		$field = array( 'type' => 'text' );
+		do_action( 'test_action', $field );
+
+		$this->assertTrue( $action_called, 'Action variation should be triggered' );
+	}
+
+	/**
+	 * Test acf_add_deprecated_filter stores deprecated hook data.
+	 */
+	public function test_add_deprecated_filter_stores_data() {
+		acf_add_deprecated_filter( 'old_deprecated_hook', '5.0.0', 'new_replacement_hook' );
+
+		$store = acf_get_store( 'deprecated-hooks' );
+		$data  = $store->get_data();
+
+		$this->assertNotEmpty( $data, 'Deprecated hooks store should have data' );
+
+		$found = false;
+		foreach ( $data as $hook ) {
+			if ( 'old_deprecated_hook' === $hook['deprecated'] ) {
+				$found = true;
+				$this->assertSame( 'filter', $hook['type'], 'Type should be filter' );
+				$this->assertSame( '5.0.0', $hook['version'], 'Version should match' );
+				$this->assertSame( 'new_replacement_hook', $hook['replacement'], 'Replacement should match' );
+				break;
+			}
+		}
+
+		$this->assertTrue( $found, 'Deprecated hook should be stored' );
+	}
+
+	/**
+	 * Test acf_add_deprecated_filter registers handler on replacement hook.
+	 */
+	public function test_add_deprecated_filter_registers_handler() {
+		acf_add_deprecated_filter( 'old_deprecated_hook', '5.0.0', 'new_replacement_hook' );
+
+		$this->assertTrue(
+			has_filter( 'new_replacement_hook' ) !== false,
+			'Handler should be registered on replacement hook'
+		);
+	}
+
+	/**
+	 * Test acf_add_deprecated_action stores deprecated action data.
+	 */
+	public function test_add_deprecated_action_stores_data() {
+		acf_add_deprecated_action( 'old_action', '5.0.0', 'new_action' );
+
+		$store = acf_get_store( 'deprecated-hooks' );
+		$data  = $store->get_data();
+
+		$found = false;
+		foreach ( $data as $hook ) {
+			if ( 'old_action' === $hook['deprecated'] ) {
+				$found = true;
+				$this->assertSame( 'action', $hook['type'], 'Type should be action' );
+				break;
+			}
+		}
+
+		$this->assertTrue( $found, 'Deprecated action should be stored' );
+	}
+
+	/**
+	 * Test _acf_apply_deprecated_hook applies deprecated filter.
+	 */
+	public function test_apply_deprecated_hook_applies_filter() {
+		acf_add_deprecated_filter( 'old_deprecated_hook', '5.0.0', 'new_replacement_hook' );
+
+		// Someone is still using the old hook.
+		add_filter(
+			'old_deprecated_hook',
+			function ( $value ) {
+				return $value . '_old_modified';
+			}
+		);
+
+		// Trigger the new hook.
+		$result = apply_filters( 'new_replacement_hook', 'original' );
+
+		$this->assertSame( 'original_old_modified', $result, 'Deprecated filter should be applied' );
+	}
+
+	/**
+	 * Test _acf_apply_deprecated_hook applies deprecated action.
+	 */
+	public function test_apply_deprecated_hook_applies_action() {
+		acf_add_deprecated_action( 'old_action', '5.0.0', 'new_action' );
+
+		$action_called = false;
+		add_action(
+			'old_action',
+			function () use ( &$action_called ) {
+				$action_called = true;
+			}
+		);
+
+		// Trigger the new action.
+		do_action( 'new_action' );
+
+		$this->assertTrue( $action_called, 'Deprecated action should be called' );
+	}
+
+	/**
+	 * Test _acf_apply_deprecated_hook does nothing when no one uses deprecated hook.
+	 */
+	public function test_apply_deprecated_hook_skips_unused() {
+		acf_add_deprecated_filter( 'old_deprecated_hook', '5.0.0', 'new_replacement_hook' );
+
+		// No one hooks into the old hook.
+		$result = apply_filters( 'new_replacement_hook', 'original' );
+
+		$this->assertSame( 'original', $result, 'Value should pass through unchanged when deprecated hook is unused' );
+	}
+
+	/**
+	 * Test multiple deprecated hooks can be registered for the same replacement.
+	 */
+	public function test_multiple_deprecated_hooks_for_same_replacement() {
+		acf_add_deprecated_filter( 'old_hook_1', '4.0.0', 'new_replacement_hook' );
+		acf_add_deprecated_filter( 'old_hook_2', '5.0.0', 'new_replacement_hook' );
+
+		add_filter(
+			'old_hook_1',
+			function ( $value ) {
+				return $value . '_v1';
+			}
+		);
+
+		add_filter(
+			'old_hook_2',
+			function ( $value ) {
+				return $value . '_v2';
+			}
+		);
+
+		$result = apply_filters( 'new_replacement_hook', 'original' );
+
+		$this->assertSame( 'original_v1_v2', $result, 'Both deprecated hooks should be applied' );
+	}
+
+	/**
+	 * Test deprecated hooks pass arguments correctly.
+	 */
+	public function test_deprecated_hook_passes_arguments() {
+		acf_add_deprecated_filter( 'old_deprecated_hook', '5.0.0', 'new_replacement_hook' );
+
+		add_filter(
+			'old_deprecated_hook',
+			function ( $value, $arg1, $arg2 ) {
+				return $value . '_' . $arg1 . '_' . $arg2;
+			},
+			10,
+			3
+		);
+
+		$result = apply_filters( 'new_replacement_hook', 'original', 'first', 'second' );
+
+		$this->assertSame( 'original_first_second', $result, 'Arguments should be passed to deprecated hook' );
+	}
+
+	/**
+	 * Data provider for filter variation keys.
+	 *
+	 * @return array
+	 */
+	public function data_provider_variation_keys() {
+		return array(
+			'type key'     => array( 'type', 'text', 'test_filter/type=text' ),
+			'name key'     => array( 'name', 'my_field', 'test_filter/name=my_field' ),
+			'key key'      => array( 'key', 'field_123', 'test_filter/key=field_123' ),
+			'empty string' => array( 'type', '', 'test_filter/type=' ),
+			'numeric'      => array( 'type', '123', 'test_filter/type=123' ),
+		);
+	}
+
+	/**
+	 * Test variation hook names are constructed correctly.
+	 *
+	 * @dataProvider data_provider_variation_keys
+	 * @param string $variation_key The variation key.
+	 * @param string $value         The value for the key.
+	 * @param string $expected_hook The expected hook name.
+	 */
+	public function test_variation_hook_name_construction( $variation_key, $value, $expected_hook ) {
+		// Index 1 because we pass: apply_filters($hook, $passthrough_value, $field).
+		acf_add_filter_variations( 'test_filter', array( $variation_key ), 1 );
+
+		$hook_called = false;
+		add_filter(
+			$expected_hook,
+			function ( $val ) use ( &$hook_called ) {
+				$hook_called = true;
+				return $val;
+			}
+		);
+
+		$field = array( $variation_key => $value );
+		apply_filters( 'test_filter', 'original', $field );
+
+		$this->assertTrue( $hook_called, "Hook '$expected_hook' should be called" );
+	}
+}

--- a/tests/php/includes/functions/test-acf-wp-functions.php
+++ b/tests/php/includes/functions/test-acf-wp-functions.php
@@ -1,0 +1,547 @@
+<?php
+/**
+ * Tests for WordPress wrapper functions in includes/acf-wp-functions.php
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for acf-wp-functions.php
+ *
+ * Tests cover:
+ * - acf_get_object_type() - WordPress object type resolution
+ * - acf_decode_post_id() - Post ID string decoding
+ * - acf_get_object_type_rest_base() - REST base extraction
+ * - acf_get_object_id() - Object ID extraction
+ */
+class Test_ACF_WP_Functions extends BaseTestCase {
+
+	/**
+	 * Test acf_get_object_type returns correct data for post type.
+	 */
+	public function test_get_object_type_post_without_subtype() {
+		$result = acf_get_object_type( 'post' );
+
+		$this->assertIsObject( $result, 'Result should be an object' );
+		$this->assertSame( 'post', $result->type, 'Type should be post' );
+		$this->assertSame( '', $result->subtype, 'Subtype should be empty' );
+		$this->assertSame( 'post', $result->name, 'Name should be post' );
+		$this->assertSame( 'dashicons-admin-post', $result->icon, 'Icon should be post icon' );
+	}
+
+	/**
+	 * Test acf_get_object_type returns correct data for post with subtype.
+	 */
+	public function test_get_object_type_post_with_subtype() {
+		$result = acf_get_object_type( 'post', 'post' );
+
+		$this->assertIsObject( $result, 'Result should be an object' );
+		$this->assertSame( 'post', $result->type, 'Type should be post' );
+		$this->assertSame( 'post', $result->subtype, 'Subtype should be post' );
+		$this->assertSame( 'post/post', $result->name, 'Name should be post/post' );
+		$this->assertSame( 'Posts', $result->label, 'Label should be Posts' );
+	}
+
+	/**
+	 * Test acf_get_object_type returns correct data for page subtype.
+	 */
+	public function test_get_object_type_post_page_subtype() {
+		$result = acf_get_object_type( 'post', 'page' );
+
+		$this->assertIsObject( $result, 'Result should be an object' );
+		$this->assertSame( 'post/page', $result->name, 'Name should be post/page' );
+		$this->assertSame( 'Pages', $result->label, 'Label should be Pages' );
+	}
+
+	/**
+	 * Test acf_get_object_type returns false for invalid post subtype.
+	 */
+	public function test_get_object_type_invalid_post_subtype() {
+		$result = acf_get_object_type( 'post', 'nonexistent_post_type' );
+
+		$this->assertFalse( $result, 'Should return false for invalid post type' );
+	}
+
+	/**
+	 * Test acf_get_object_type returns correct data for term type.
+	 */
+	public function test_get_object_type_term_without_subtype() {
+		$result = acf_get_object_type( 'term' );
+
+		$this->assertIsObject( $result, 'Result should be an object' );
+		$this->assertSame( 'term', $result->type, 'Type should be term' );
+		$this->assertSame( 'Taxonomies', $result->label, 'Label should be Taxonomies' );
+		$this->assertSame( 'dashicons-tag', $result->icon, 'Icon should be tag' );
+	}
+
+	/**
+	 * Test acf_get_object_type returns correct data for term with category subtype.
+	 */
+	public function test_get_object_type_term_with_subtype() {
+		$result = acf_get_object_type( 'term', 'category' );
+
+		$this->assertIsObject( $result, 'Result should be an object' );
+		$this->assertSame( 'term/category', $result->name, 'Name should be term/category' );
+		$this->assertSame( 'Categories', $result->label, 'Label should be Categories' );
+	}
+
+	/**
+	 * Test acf_get_object_type returns false for invalid taxonomy.
+	 */
+	public function test_get_object_type_invalid_taxonomy() {
+		$result = acf_get_object_type( 'term', 'nonexistent_taxonomy' );
+
+		$this->assertFalse( $result, 'Should return false for invalid taxonomy' );
+	}
+
+	/**
+	 * Data provider for object types without subtypes.
+	 *
+	 * @return array
+	 */
+	public function data_provider_object_types() {
+		return array(
+			'attachment' => array( 'attachment', 'Attachments', 'dashicons-admin-media' ),
+			'comment'    => array( 'comment', 'Comments', 'dashicons-admin-comments' ),
+			'widget'     => array( 'widget', 'Widgets', 'dashicons-screenoptions' ),
+			'menu'       => array( 'menu', 'Menus', 'dashicons-admin-appearance' ),
+			'menu_item'  => array( 'menu_item', 'Menu items', 'dashicons-admin-appearance' ),
+			'user'       => array( 'user', 'Users', 'dashicons-admin-users' ),
+			'option'     => array( 'option', 'Options', 'dashicons-admin-generic' ),
+			'block'      => array( 'block', 'Blocks', 'dashicons-block-default' ),
+		);
+	}
+
+	/**
+	 * Test acf_get_object_type for various object types.
+	 *
+	 * @dataProvider data_provider_object_types
+	 * @param string $type           The object type.
+	 * @param string $expected_label The expected label.
+	 * @param string $expected_icon  The expected icon.
+	 */
+	public function test_get_object_type_various_types( $type, $expected_label, $expected_icon ) {
+		$result = acf_get_object_type( $type );
+
+		$this->assertIsObject( $result, "Result for '$type' should be an object" );
+		$this->assertSame( $type, $result->type, "Type should be '$type'" );
+		$this->assertSame( $expected_label, $result->label, "Label should be '$expected_label'" );
+		$this->assertSame( $expected_icon, $result->icon, "Icon should be '$expected_icon'" );
+	}
+
+	/**
+	 * Test acf_get_object_type returns false for unknown type.
+	 */
+	public function test_get_object_type_unknown_type() {
+		$result = acf_get_object_type( 'unknown_type' );
+
+		$this->assertFalse( $result, 'Should return false for unknown object type' );
+	}
+
+	/**
+	 * Test acf_get_object_type applies filter.
+	 */
+	public function test_get_object_type_applies_filter() {
+		add_filter(
+			'acf/get_object_type',
+			function ( $object_type_result ) {
+				$object_type_result->custom = 'filtered';
+				return $object_type_result;
+			}
+		);
+
+		$result = acf_get_object_type( 'post' );
+
+		$this->assertSame( 'filtered', $result->custom, 'Filter should modify the object' );
+
+		remove_all_filters( 'acf/get_object_type' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with numeric ID.
+	 */
+	public function test_decode_post_id_numeric() {
+		$result = acf_decode_post_id( 123 );
+
+		$this->assertIsArray( $result, 'Result should be an array' );
+		$this->assertSame( 'post', $result['type'], 'Type should be post' );
+		$this->assertSame( 123, $result['id'], 'ID should be 123' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with string numeric ID.
+	 */
+	public function test_decode_post_id_string_numeric() {
+		$result = acf_decode_post_id( '456' );
+
+		$this->assertSame( 'post', $result['type'], 'Type should be post' );
+		$this->assertSame( 456, $result['id'], 'ID should be 456' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with user ID format.
+	 */
+	public function test_decode_post_id_user() {
+		$result = acf_decode_post_id( 'user_42' );
+
+		$this->assertSame( 'user', $result['type'], 'Type should be user' );
+		$this->assertSame( 42, $result['id'], 'ID should be 42' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with term ID format.
+	 */
+	public function test_decode_post_id_term() {
+		$result = acf_decode_post_id( 'term_99' );
+
+		$this->assertSame( 'term', $result['type'], 'Type should be term' );
+		$this->assertSame( 99, $result['id'], 'ID should be 99' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with comment ID format.
+	 */
+	public function test_decode_post_id_comment() {
+		$result = acf_decode_post_id( 'comment_15' );
+
+		$this->assertSame( 'comment', $result['type'], 'Type should be comment' );
+		$this->assertSame( 15, $result['id'], 'ID should be 15' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with attachment format (maps to post).
+	 */
+	public function test_decode_post_id_attachment() {
+		$result = acf_decode_post_id( 'attachment_200' );
+
+		$this->assertSame( 'post', $result['type'], 'Attachment should map to post type' );
+		$this->assertSame( 200, $result['id'], 'ID should be 200' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with menu format (maps to term).
+	 */
+	public function test_decode_post_id_menu() {
+		$result = acf_decode_post_id( 'menu_50' );
+
+		$this->assertSame( 'term', $result['type'], 'Menu should map to term type' );
+		$this->assertSame( 50, $result['id'], 'ID should be 50' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with menu_item format (maps to post).
+	 */
+	public function test_decode_post_id_menu_item() {
+		$result = acf_decode_post_id( 'menu_item_75' );
+
+		$this->assertSame( 'post', $result['type'], 'Menu item should map to post type' );
+		$this->assertSame( 75, $result['id'], 'ID should be 75' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with widget format (maps to option).
+	 */
+	public function test_decode_post_id_widget_string() {
+		$result = acf_decode_post_id( 'widget_text_2' );
+
+		$this->assertSame( 'option', $result['type'], 'Widget should map to option type' );
+		$this->assertSame( 'widget_text_2', $result['id'], 'ID should be the full widget string' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with block format.
+	 */
+	public function test_decode_post_id_block() {
+		$result = acf_decode_post_id( 'block_abc123' );
+
+		$this->assertSame( 'block', $result['type'], 'Type should be block' );
+		$this->assertSame( 'block_abc123', $result['id'], 'ID should be the full block string' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with option format.
+	 */
+	public function test_decode_post_id_option() {
+		$result = acf_decode_post_id( 'option_my_settings' );
+
+		$this->assertSame( 'option', $result['type'], 'Type should be option' );
+		$this->assertSame( 'option_my_settings', $result['id'], 'ID should be the full option string' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with simple option string.
+	 */
+	public function test_decode_post_id_options() {
+		$result = acf_decode_post_id( 'options' );
+
+		$this->assertSame( 'option', $result['type'], 'Type should be option' );
+		$this->assertSame( 'options', $result['id'], 'ID should be options' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with woo_order format.
+	 */
+	public function test_decode_post_id_woo_order() {
+		$result = acf_decode_post_id( 'woo_order_1001' );
+
+		$this->assertSame( 'woo_order', $result['type'], 'Type should be woo_order' );
+		$this->assertSame( 1001, $result['id'], 'ID should be 1001' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with taxonomy term format.
+	 */
+	public function test_decode_post_id_category_taxonomy() {
+		$result = acf_decode_post_id( 'category_5' );
+
+		$this->assertSame( 'term', $result['type'], 'Category should map to term type' );
+		$this->assertSame( 5, $result['id'], 'ID should be 5' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with invalid param type.
+	 */
+	public function test_decode_post_id_invalid_type() {
+		$result = acf_decode_post_id( array( 'invalid' ) );
+
+		$this->assertSame( '', $result['type'], 'Type should be empty' );
+		$this->assertSame( 0, $result['id'], 'ID should be 0' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with null.
+	 */
+	public function test_decode_post_id_null() {
+		$result = acf_decode_post_id( null );
+
+		$this->assertSame( '', $result['type'], 'Type should be empty' );
+		$this->assertSame( 0, $result['id'], 'ID should be 0' );
+	}
+
+	/**
+	 * Test acf_decode_post_id with zero.
+	 */
+	public function test_decode_post_id_zero() {
+		$result = acf_decode_post_id( 0 );
+
+		$this->assertSame( 'post', $result['type'], 'Type should be post' );
+		$this->assertSame( 0, $result['id'], 'ID should be 0' );
+	}
+
+	/**
+	 * Test acf_decode_post_id applies filter.
+	 */
+	public function test_decode_post_id_applies_filter() {
+		add_filter(
+			'acf/decode_post_id',
+			function ( $props ) {
+				$props['custom'] = 'filtered';
+				return $props;
+			}
+		);
+
+		$result = acf_decode_post_id( 123 );
+
+		$this->assertSame( 'filtered', $result['custom'], 'Filter should add custom property' );
+
+		remove_all_filters( 'acf/decode_post_id' );
+	}
+
+	/**
+	 * Test acf_get_object_type_rest_base with WP_Post_Type.
+	 */
+	public function test_get_object_type_rest_base_post_type() {
+		$post_type = get_post_type_object( 'post' );
+
+		$result = acf_get_object_type_rest_base( $post_type );
+
+		$this->assertSame( 'posts', $result, 'REST base for post type should be posts' );
+	}
+
+	/**
+	 * Test acf_get_object_type_rest_base with WP_Post_Type with custom rest_base.
+	 */
+	public function test_get_object_type_rest_base_custom() {
+		$post_type = get_post_type_object( 'page' );
+
+		$result = acf_get_object_type_rest_base( $post_type );
+
+		$this->assertSame( 'pages', $result, 'REST base for page type should be pages' );
+	}
+
+	/**
+	 * Test acf_get_object_type_rest_base with WP_Taxonomy.
+	 */
+	public function test_get_object_type_rest_base_taxonomy() {
+		$taxonomy = get_taxonomy( 'category' );
+
+		$result = acf_get_object_type_rest_base( $taxonomy );
+
+		$this->assertSame( 'categories', $result, 'REST base for category should be categories' );
+	}
+
+	/**
+	 * Test acf_get_object_type_rest_base with invalid object.
+	 */
+	public function test_get_object_type_rest_base_invalid() {
+		$result = acf_get_object_type_rest_base( new stdClass() );
+
+		$this->assertNull( $result, 'Should return null for invalid object type' );
+	}
+
+	/**
+	 * Test acf_get_object_type_rest_base with null.
+	 */
+	public function test_get_object_type_rest_base_null() {
+		$result = acf_get_object_type_rest_base( null );
+
+		$this->assertNull( $result, 'Should return null for null input' );
+	}
+
+	/**
+	 * Test acf_get_object_type_rest_base with string.
+	 */
+	public function test_get_object_type_rest_base_string() {
+		$result = acf_get_object_type_rest_base( 'not_an_object' );
+
+		$this->assertNull( $result, 'Should return null for string input' );
+	}
+
+	/**
+	 * Test acf_get_object_id with WP_Post.
+	 */
+	public function test_get_object_id_wp_post() {
+		$post     = new WP_Post( (object) array( 'ID' => 42 ) );
+		$post->ID = 42;
+
+		$result = acf_get_object_id( $post );
+
+		$this->assertSame( 42, $result, 'Should extract ID from WP_Post' );
+	}
+
+	/**
+	 * Test acf_get_object_id with WP_User.
+	 */
+	public function test_get_object_id_wp_user() {
+		$user     = new WP_User();
+		$user->ID = 99;
+
+		$result = acf_get_object_id( $user );
+
+		$this->assertSame( 99, $result, 'Should extract ID from WP_User' );
+	}
+
+	/**
+	 * Test acf_get_object_id with WP_Term.
+	 */
+	public function test_get_object_id_wp_term() {
+		$term          = new WP_Term( (object) array( 'term_id' => 15 ) );
+		$term->term_id = 15;
+
+		$result = acf_get_object_id( $term );
+
+		$this->assertSame( 15, $result, 'Should extract term_id from WP_Term' );
+	}
+
+	/**
+	 * Test acf_get_object_id with WP_Comment.
+	 */
+	public function test_get_object_id_wp_comment() {
+		$comment             = new WP_Comment( (object) array( 'comment_ID' => 77 ) );
+		$comment->comment_ID = '77';
+
+		$result = acf_get_object_id( $comment );
+
+		$this->assertSame( 77, $result, 'Should extract comment_ID from WP_Comment' );
+	}
+
+	/**
+	 * Test acf_get_object_id with array containing lowercase 'id'.
+	 */
+	public function test_get_object_id_array_lowercase_id() {
+		$object = array( 'id' => 123 );
+
+		$result = acf_get_object_id( $object );
+
+		$this->assertSame( 123, $result, 'Should extract id from array' );
+	}
+
+	/**
+	 * Test acf_get_object_id with array containing uppercase 'ID'.
+	 */
+	public function test_get_object_id_array_uppercase_id() {
+		$object = array( 'ID' => 456 );
+
+		$result = acf_get_object_id( $object );
+
+		$this->assertSame( 456, $result, 'Should extract ID from array' );
+	}
+
+	/**
+	 * Test acf_get_object_id with array containing both id and ID (id takes precedence).
+	 */
+	public function test_get_object_id_array_both_ids() {
+		$object = array(
+			'id' => 111,
+			'ID' => 222,
+		);
+
+		$result = acf_get_object_id( $object );
+
+		$this->assertSame( 111, $result, 'Lowercase id should take precedence' );
+	}
+
+	/**
+	 * Test acf_get_object_id with unknown object type.
+	 */
+	public function test_get_object_id_unknown_object() {
+		$object = new stdClass();
+
+		$result = acf_get_object_id( $object );
+
+		$this->assertNull( $result, 'Should return null for unknown object type' );
+	}
+
+	/**
+	 * Test acf_get_object_id with array without id.
+	 */
+	public function test_get_object_id_array_no_id() {
+		$object = array( 'name' => 'test' );
+
+		$result = acf_get_object_id( $object );
+
+		$this->assertNull( $result, 'Should return null for array without id' );
+	}
+
+	/**
+	 * Test acf_get_object_id casts string ID to integer.
+	 */
+	public function test_get_object_id_casts_to_int() {
+		$object = array( 'id' => '789' );
+
+		$result = acf_get_object_id( $object );
+
+		$this->assertSame( 789, $result, 'String ID should be cast to integer' );
+		$this->assertIsInt( $result, 'Result should be integer type' );
+	}
+
+	/**
+	 * Test acf_get_object_id with empty array.
+	 */
+	public function test_get_object_id_empty_array() {
+		$result = acf_get_object_id( array() );
+
+		$this->assertNull( $result, 'Should return null for empty array' );
+	}
+
+	/**
+	 * Test acf_get_object_id with null.
+	 */
+	public function test_get_object_id_null() {
+		$result = acf_get_object_id( null );
+
+		$this->assertNull( $result, 'Should return null for null input' );
+	}
+}


### PR DESCRIPTION
## What
Part of #315.

Adds PHPUnit test coverage for hook, WordPress wrapper, and bidirectional functions.

## Why

These functions handle critical WordPress hook management (filter/action variations, deprecated hook bridging), object type resolution, and bidirectional field relationships.

## How

Adding 109 tests covering:
- Filter and action variations registration and application
- Deprecated hook registration and backward compatibility bridging
- Object type resolution for post, term, user, comment, block, option, menu
- Post ID decoding for various formats (numeric, user_X, term_X, etc.)
- REST base resolution for post types and taxonomies
- Object ID extraction from WP_Post, WP_User, WP_Term, WP_Comment
- Bidirectional relationship target types and choice building
- Bidirectional value update recursion prevention
- Field settings rendering for bidirectional fields

## Testing Instructions

Run the test suite: `./vendor/bin/phpunit --filter "Test_ACF_Hook_Functions|Test_ACF_WP_Functions|Test_ACF_Bidirectional_Functions"`