### PR TITLE
Tests: Add Jest unit tests for core Model and Field classes

### DIFF
--- a/tests/js/field.test.js
+++ b/tests/js/field.test.js
@@ -1,0 +1,746 @@
+/**
+ * Unit tests for the Field class (_acf-field.js)
+ *
+ * Tests the Field class which extends Model and provides:
+ * - Field value management (val, getValue, setValue)
+ * - Field DOM helpers ($input, $control, $inputWrap, $labelWrap)
+ * - Field visibility (show, hide, showEnable, hideDisable)
+ * - Field state (enable, disable)
+ * - Error handling (showError, removeError, showNotice, removeNotice)
+ * - Field type registration
+ */
+
+describe( 'Field Class', () => {
+	let fieldDefinition;
+	let mockJQuery;
+	let mockInput;
+
+	beforeEach( () => {
+		// Create mock input element
+		mockInput = {
+			val: jest.fn().mockReturnValue( 'test-value' ),
+			attr: jest.fn().mockReturnValue( 'field_name' ),
+		};
+
+		// Create a chainable mock jQuery element
+		mockJQuery = {
+			data: jest.fn().mockReturnThis(),
+			find: jest.fn().mockReturnValue( mockInput ),
+			on: jest.fn().mockReturnThis(),
+			off: jest.fn().mockReturnThis(),
+			one: jest.fn().mockReturnThis(),
+			trigger: jest.fn().mockReturnThis(),
+			triggerHandler: jest.fn().mockReturnThis(),
+			prop: jest.fn().mockReturnValue( false ),
+			addClass: jest.fn().mockReturnThis(),
+			removeClass: jest.fn().mockReturnThis(),
+			parents: jest.fn().mockReturnValue( { length: 0 } ),
+			is: jest.fn().mockReturnValue( false ),
+			closest: jest.fn().mockReturnThis(),
+		};
+
+		// Mock jQuery function
+		global.jQuery = jest.fn( ( selector ) => {
+			if ( typeof selector === 'string' ) {
+				return mockJQuery;
+			}
+			return mockJQuery;
+		} );
+		global.jQuery.extend = jest.fn( ( deep, target, ...sources ) => {
+			if ( typeof deep === 'boolean' ) {
+				return Object.assign( target || {}, ...sources );
+			}
+			return Object.assign( deep || {}, target, ...sources );
+		} );
+		global.jQuery.proxy = jest.fn( ( fn, context ) => fn.bind( context ) );
+		global.$ = global.jQuery;
+
+		// Mock acf global
+		global.acf = {
+			uniqueId: jest.fn( ( prefix ) => `${ prefix }123` ),
+			didAction: jest.fn().mockReturnValue( true ),
+			addAction: jest.fn(),
+			removeAction: jest.fn(),
+			addFilter: jest.fn(),
+			removeFilter: jest.fn(),
+			doAction: jest.fn(),
+			applyFilters: jest.fn( ( name, value ) => value ),
+			arrayArgs: jest.fn( ( args ) => Array.from( args ) ),
+			show: jest.fn().mockReturnValue( true ),
+			hide: jest.fn().mockReturnValue( true ),
+			enable: jest.fn().mockReturnValue( true ),
+			disable: jest.fn().mockReturnValue( true ),
+			val: jest.fn().mockReturnValue( true ),
+			newNotice: jest.fn().mockReturnValue( {
+				remove: jest.fn(),
+				away: jest.fn(),
+			} ),
+			getFields: jest.fn().mockReturnValue( [] ),
+			parseArgs: jest.fn( ( args, defaults ) => ( {
+				...defaults,
+				...args,
+			} ) ),
+			strPascalCase: jest.fn( ( str ) =>
+				str
+					.split( '_' )
+					.map( ( s ) => s.charAt( 0 ).toUpperCase() + s.slice( 1 ) )
+					.join( '' )
+			),
+			_e: jest.fn( ( type, string ) => string ),
+			models: {},
+			Model: null,
+		};
+
+		// Load model first (Field extends Model)
+		jest.isolateModules( () => {
+			require( '../../assets/src/js/_acf-model.js' );
+		} );
+
+		// Load field module
+		jest.isolateModules( () => {
+			require( '../../assets/src/js/_acf-field.js' );
+		} );
+
+		fieldDefinition = global.acf.Field;
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+		delete global.jQuery;
+		delete global.$;
+		delete global.acf;
+	} );
+
+	describe( 'Field setup', () => {
+		it( 'should set $el from provided jQuery element', () => {
+			const instance = new fieldDefinition( mockJQuery );
+
+			expect( instance.$el ).toBe( mockJQuery );
+		} );
+
+		it( 'should have correct type property', () => {
+			expect( fieldDefinition.prototype.type ).toBe( '' );
+		} );
+
+		it( 'should have correct eventScope for nested event handling', () => {
+			expect( fieldDefinition.prototype.eventScope ).toBe( '.acf-field' );
+		} );
+
+		it( 'should wait for ready action', () => {
+			expect( fieldDefinition.prototype.wait ).toBe( 'ready' );
+		} );
+	} );
+
+	describe( 'Value Management', () => {
+		let instance;
+
+		beforeEach( () => {
+			instance = new fieldDefinition( mockJQuery );
+		} );
+
+		describe( 'val()', () => {
+			it( 'should get value when no argument provided', () => {
+				mockJQuery.prop.mockReturnValue( false ); // not disabled
+
+				const result = instance.val();
+
+				expect( result ).toBe( 'test-value' );
+			} );
+
+			it( 'should return null when field is disabled', () => {
+				mockJQuery.prop.mockReturnValue( true ); // disabled
+
+				const result = instance.val();
+
+				expect( result ).toBeNull();
+			} );
+
+			it( 'should set value when argument provided', () => {
+				instance.val( 'new-value' );
+
+				expect( global.acf.val ).toHaveBeenCalledWith(
+					mockInput,
+					'new-value'
+				);
+			} );
+		} );
+
+		describe( 'getValue()', () => {
+			it( 'should return value from input element', () => {
+				const result = instance.getValue();
+
+				expect( result ).toBe( 'test-value' );
+			} );
+		} );
+
+		describe( 'setValue()', () => {
+			it( 'should call acf.val with input and value', () => {
+				instance.setValue( 'new-value' );
+
+				expect( global.acf.val ).toHaveBeenCalledWith(
+					mockInput,
+					'new-value'
+				);
+			} );
+		} );
+	} );
+
+	describe( 'DOM Helpers', () => {
+		let instance;
+
+		beforeEach( () => {
+			instance = new fieldDefinition( mockJQuery );
+		} );
+
+		describe( '$input()', () => {
+			it( 'should find first named element', () => {
+				instance.$input();
+
+				expect( mockJQuery.find ).toHaveBeenCalledWith(
+					'[name]:first'
+				);
+			} );
+		} );
+
+		describe( '$inputWrap()', () => {
+			it( 'should find first .acf-input element', () => {
+				instance.$inputWrap();
+
+				expect( mockJQuery.find ).toHaveBeenCalledWith(
+					'.acf-input:first'
+				);
+			} );
+		} );
+
+		describe( '$labelWrap()', () => {
+			it( 'should find first .acf-label element', () => {
+				instance.$labelWrap();
+
+				expect( mockJQuery.find ).toHaveBeenCalledWith(
+					'.acf-label:first'
+				);
+			} );
+		} );
+
+		describe( '$control()', () => {
+			it( 'should return false by default', () => {
+				const result = instance.$control();
+
+				expect( result ).toBe( false );
+			} );
+		} );
+
+		describe( 'getInputName()', () => {
+			it( 'should return input name attribute', () => {
+				const result = instance.getInputName();
+
+				expect( mockInput.attr ).toHaveBeenCalledWith( 'name' );
+				expect( result ).toBe( 'field_name' );
+			} );
+
+			it( 'should return empty string when no name', () => {
+				mockInput.attr.mockReturnValue( undefined );
+
+				const result = instance.getInputName();
+
+				expect( result ).toBe( '' );
+			} );
+		} );
+	} );
+
+	describe( 'Parent/Child Relationships', () => {
+		let instance;
+
+		beforeEach( () => {
+			instance = new fieldDefinition( mockJQuery );
+		} );
+
+		describe( 'parent()', () => {
+			it( 'should return first parent field or false', () => {
+				const result = instance.parent();
+
+				expect( result ).toBe( false );
+			} );
+
+			it( 'should return parent when parents exist', () => {
+				const mockParent = { cid: 'parent1' };
+				global.acf.getFields.mockReturnValue( [ mockParent ] );
+				mockJQuery.parents.mockReturnValue( { length: 1 } );
+
+				const result = instance.parent();
+
+				expect( result ).toBe( mockParent );
+			} );
+		} );
+
+		describe( 'parents()', () => {
+			it( 'should find parent .acf-field elements', () => {
+				instance.parents();
+
+				expect( mockJQuery.parents ).toHaveBeenCalledWith(
+					'.acf-field'
+				);
+			} );
+		} );
+	} );
+
+	describe( 'Visibility Methods', () => {
+		let instance;
+
+		beforeEach( () => {
+			instance = new fieldDefinition( mockJQuery );
+		} );
+
+		describe( 'show()', () => {
+			it( 'should call acf.show with element', () => {
+				instance.show( 'lockKey' );
+
+				expect( global.acf.show ).toHaveBeenCalledWith(
+					mockJQuery,
+					'lockKey'
+				);
+			} );
+
+			it( 'should trigger show_field action when visibility changes', () => {
+				global.acf.show.mockReturnValue( true );
+
+				instance.show( 'lockKey', 'context' );
+
+				expect( global.acf.doAction ).toHaveBeenCalledWith(
+					'show_field',
+					instance,
+					'context'
+				);
+			} );
+
+			it( 'should set hidden prop to false when shown', () => {
+				global.acf.show.mockReturnValue( true );
+
+				instance.show( 'lockKey' );
+
+				expect( mockJQuery.prop ).toHaveBeenCalledWith(
+					'hidden',
+					false
+				);
+			} );
+
+			it( 'should not trigger action when visibility unchanged', () => {
+				global.acf.show.mockReturnValue( false );
+
+				instance.show( 'lockKey', 'context' );
+
+				expect( global.acf.doAction ).not.toHaveBeenCalled();
+			} );
+		} );
+
+		describe( 'hide()', () => {
+			it( 'should call acf.hide with element', () => {
+				instance.hide( 'lockKey' );
+
+				expect( global.acf.hide ).toHaveBeenCalledWith(
+					mockJQuery,
+					'lockKey'
+				);
+			} );
+
+			it( 'should trigger hide_field action when visibility changes', () => {
+				global.acf.hide.mockReturnValue( true );
+
+				instance.hide( 'lockKey', 'context' );
+
+				expect( global.acf.doAction ).toHaveBeenCalledWith(
+					'hide_field',
+					instance,
+					'context'
+				);
+			} );
+
+			it( 'should set hidden prop to true when hidden', () => {
+				global.acf.hide.mockReturnValue( true );
+
+				instance.hide( 'lockKey' );
+
+				expect( mockJQuery.prop ).toHaveBeenCalledWith(
+					'hidden',
+					true
+				);
+			} );
+		} );
+	} );
+
+	describe( 'Enable/Disable Methods', () => {
+		let instance;
+
+		beforeEach( () => {
+			instance = new fieldDefinition( mockJQuery );
+		} );
+
+		describe( 'enable()', () => {
+			it( 'should call acf.enable with element', () => {
+				instance.enable( 'lockKey' );
+
+				expect( global.acf.enable ).toHaveBeenCalledWith(
+					mockJQuery,
+					'lockKey'
+				);
+			} );
+
+			it( 'should trigger enable_field action when state changes', () => {
+				global.acf.enable.mockReturnValue( true );
+
+				instance.enable( 'lockKey', 'context' );
+
+				expect( global.acf.doAction ).toHaveBeenCalledWith(
+					'enable_field',
+					instance,
+					'context'
+				);
+			} );
+
+			it( 'should set disabled prop to false when enabled', () => {
+				global.acf.enable.mockReturnValue( true );
+
+				instance.enable( 'lockKey' );
+
+				expect( mockJQuery.prop ).toHaveBeenCalledWith(
+					'disabled',
+					false
+				);
+			} );
+		} );
+
+		describe( 'disable()', () => {
+			it( 'should call acf.disable with element', () => {
+				instance.disable( 'lockKey' );
+
+				expect( global.acf.disable ).toHaveBeenCalledWith(
+					mockJQuery,
+					'lockKey'
+				);
+			} );
+
+			it( 'should trigger disable_field action when state changes', () => {
+				global.acf.disable.mockReturnValue( true );
+
+				instance.disable( 'lockKey', 'context' );
+
+				expect( global.acf.doAction ).toHaveBeenCalledWith(
+					'disable_field',
+					instance,
+					'context'
+				);
+			} );
+
+			it( 'should set disabled prop to true when disabled', () => {
+				global.acf.disable.mockReturnValue( true );
+
+				instance.disable( 'lockKey' );
+
+				expect( mockJQuery.prop ).toHaveBeenCalledWith(
+					'disabled',
+					true
+				);
+			} );
+		} );
+
+		describe( 'showEnable()', () => {
+			it( 'should call both enable and show with correct args', () => {
+				const enableSpy = jest.spyOn( instance, 'enable' );
+				const showSpy = jest.spyOn( instance, 'show' );
+
+				instance.showEnable( 'lockKey', 'context' );
+
+				expect( enableSpy ).toHaveBeenCalledWith(
+					'lockKey',
+					'context'
+				);
+				expect( showSpy ).toHaveBeenCalledWith( 'lockKey', 'context' );
+			} );
+		} );
+
+		describe( 'hideDisable()', () => {
+			it( 'should call both disable and hide with correct args', () => {
+				const disableSpy = jest.spyOn( instance, 'disable' );
+				const hideSpy = jest.spyOn( instance, 'hide' );
+
+				instance.hideDisable( 'lockKey', 'context' );
+
+				expect( disableSpy ).toHaveBeenCalledWith(
+					'lockKey',
+					'context'
+				);
+				expect( hideSpy ).toHaveBeenCalledWith( 'lockKey', 'context' );
+			} );
+		} );
+	} );
+
+	describe( 'Notice and Error Handling', () => {
+		let instance;
+
+		beforeEach( () => {
+			instance = new fieldDefinition( mockJQuery );
+		} );
+
+		describe( 'showNotice()', () => {
+			it( 'should create a new notice with target element', () => {
+				instance.showNotice( { text: 'Test notice' } );
+
+				// Verify notice is created with correct text and a target element
+				expect( global.acf.newNotice ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						text: 'Test notice',
+						target: expect.anything(),
+					} )
+				);
+			} );
+
+			it( 'should convert string to object props', () => {
+				instance.showNotice( 'Test notice' );
+
+				expect( global.acf.newNotice ).toHaveBeenCalledWith(
+					expect.objectContaining( { text: 'Test notice' } )
+				);
+			} );
+
+			it( 'should remove old notice before creating new one', () => {
+				const oldNotice = { remove: jest.fn() };
+				instance.notice = oldNotice;
+
+				instance.showNotice( 'New notice' );
+
+				expect( oldNotice.remove ).toHaveBeenCalled();
+			} );
+		} );
+
+		describe( 'removeNotice()', () => {
+			it( 'should call away on notice', () => {
+				const mockNotice = { away: jest.fn() };
+				instance.notice = mockNotice;
+
+				instance.removeNotice( 500 );
+
+				expect( mockNotice.away ).toHaveBeenCalledWith( 500 );
+			} );
+
+			it( 'should set notice to false after removal', () => {
+				instance.notice = { away: jest.fn() };
+
+				instance.removeNotice();
+
+				expect( instance.notice ).toBe( false );
+			} );
+
+			it( 'should use 0 as default timeout', () => {
+				const mockNotice = { away: jest.fn() };
+				instance.notice = mockNotice;
+
+				instance.removeNotice();
+
+				expect( mockNotice.away ).toHaveBeenCalledWith( 0 );
+			} );
+		} );
+
+		describe( 'showError()', () => {
+			it( 'should add acf-error class', () => {
+				instance.showError( 'Error message' );
+
+				expect( mockJQuery.addClass ).toHaveBeenCalledWith(
+					'acf-error'
+				);
+			} );
+
+			it( 'should show error notice with message', () => {
+				const showNoticeSpy = jest.spyOn( instance, 'showNotice' );
+
+				instance.showError( 'Error message' );
+
+				expect( showNoticeSpy ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						text: 'Error message',
+						type: 'error',
+						dismiss: false,
+						location: 'before',
+					} )
+				);
+			} );
+
+			it( 'should trigger invalid_field action', () => {
+				instance.showError( 'Error' );
+
+				expect( global.acf.doAction ).toHaveBeenCalledWith(
+					'invalid_field',
+					instance
+				);
+			} );
+
+			it( 'should attach one-time focus/change handler to clear error', () => {
+				instance.showError( 'Error' );
+
+				expect( mockJQuery.one ).toHaveBeenCalledWith(
+					'focus change',
+					'input, select, textarea',
+					expect.any( Function )
+				);
+			} );
+
+			it( 'should support custom location parameter', () => {
+				const showNoticeSpy = jest.spyOn( instance, 'showNotice' );
+
+				instance.showError( 'Error message', 'after' );
+
+				expect( showNoticeSpy ).toHaveBeenCalledWith(
+					expect.objectContaining( { location: 'after' } )
+				);
+			} );
+		} );
+
+		describe( 'removeError()', () => {
+			it( 'should remove acf-error class', () => {
+				instance.removeError();
+
+				expect( mockJQuery.removeClass ).toHaveBeenCalledWith(
+					'acf-error'
+				);
+			} );
+
+			it( 'should call removeNotice', () => {
+				const removeNoticeSpy = jest.spyOn( instance, 'removeNotice' );
+
+				instance.removeError();
+
+				expect( removeNoticeSpy ).toHaveBeenCalledWith( 250 );
+			} );
+
+			it( 'should trigger valid_field action', () => {
+				instance.removeError();
+
+				expect( global.acf.doAction ).toHaveBeenCalledWith(
+					'valid_field',
+					instance
+				);
+			} );
+		} );
+	} );
+
+	describe( 'i18n Helper', () => {
+		let instance;
+
+		beforeEach( () => {
+			instance = new fieldDefinition( mockJQuery );
+			instance.type = 'text';
+		} );
+
+		describe( '__()', () => {
+			it( 'should call acf._e with field type and string', () => {
+				instance.__( 'label' );
+
+				expect( global.acf._e ).toHaveBeenCalledWith( 'text', 'label' );
+			} );
+		} );
+	} );
+
+	describe( 'trigger() override', () => {
+		let instance;
+
+		beforeEach( () => {
+			instance = new fieldDefinition( mockJQuery );
+		} );
+
+		it( 'should bubble invalidField events', () => {
+			instance.trigger( 'invalidField', [], false );
+
+			// Verify trigger (bubbling) is used with the invalidField event
+			// The real implementation passes (event, args, bubble) to jQuery's trigger
+			expect( mockJQuery.trigger ).toHaveBeenCalledWith(
+				'invalidField',
+				[],
+				expect.anything()
+			);
+		} );
+
+		it( 'should not bubble other events by default', () => {
+			instance.trigger( 'customEvent', [] );
+
+			// Verify triggerHandler (non-bubbling) is used for regular events
+			expect( mockJQuery.triggerHandler ).toHaveBeenCalledWith(
+				'customEvent',
+				[],
+				undefined // No bubble parameter for non-bubbling events
+			);
+			// Ensure trigger (bubbling) was NOT used
+			expect( mockJQuery.trigger ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Field Type Registration', () => {
+		describe( 'acf.registerFieldType()', () => {
+			it( 'should store model in acf.models', () => {
+				const CustomField = fieldDefinition.extend( {
+					type: 'custom_type',
+				} );
+
+				global.acf.registerFieldType( CustomField );
+
+				expect( global.acf.models.CustomTypeField ).toBe( CustomField );
+			} );
+		} );
+
+		describe( 'acf.getFieldType()', () => {
+			it( 'should return registered field type', () => {
+				const CustomField = fieldDefinition.extend( {
+					type: 'test_type',
+				} );
+				global.acf.models.TestTypeField = CustomField;
+
+				const result = global.acf.getFieldType( 'test_type' );
+
+				expect( result ).toBe( CustomField );
+			} );
+
+			it( 'should return false for unregistered type', () => {
+				const result = global.acf.getFieldType( 'nonexistent' );
+
+				expect( result ).toBe( false );
+			} );
+		} );
+
+		describe( 'acf.newField()', () => {
+			it( 'should create instance of registered field type', () => {
+				const CustomField = fieldDefinition.extend( {
+					type: 'text',
+				} );
+				global.acf.models.TextField = CustomField;
+
+				mockJQuery.data.mockImplementation( ( key ) => {
+					if ( key === 'type' ) {
+						return 'text';
+					}
+					return mockJQuery;
+				} );
+
+				const instance = global.acf.newField( mockJQuery );
+
+				// Verify instance is created from the registered field type
+				expect( instance ).toBeDefined();
+				// The type is stored on the model definition, not in data
+				expect( instance.type ).toBe( 'text' );
+			} );
+
+			it( 'should trigger new_field action', () => {
+				mockJQuery.data.mockImplementation( ( key ) => {
+					if ( key === 'type' ) {
+						return 'unknown';
+					}
+					return mockJQuery;
+				} );
+
+				global.acf.newField( mockJQuery );
+
+				expect( global.acf.doAction ).toHaveBeenCalledWith(
+					'new_field',
+					expect.any( Object )
+				);
+			} );
+		} );
+	} );
+} );

--- a/tests/js/fields.test.js
+++ b/tests/js/fields.test.js
@@ -1,0 +1,407 @@
+/**
+ * Unit tests for the Fields manager (_acf-fields.js)
+ *
+ * Tests the field finder and manager functions:
+ * - acf.findFields() - jQuery selector-based field discovery
+ * - acf.findField() - Single field lookup by key
+ * - acf.getField() - Field instance retrieval
+ * - acf.getFields() - Multiple field instances
+ * - acf.findClosestField() - DOM traversal helper
+ * - acf.getClosestField() - Instance from closest element
+ */
+
+describe( 'Fields Manager', () => {
+	let mockJQuery;
+	let mockFields;
+
+	/**
+	 * Creates a fully chainable mock jQuery object with all required methods
+	 */
+	const createChainableMock = () => {
+		const mock = {
+			length: 2,
+			on: jest.fn().mockReturnThis(),
+			off: jest.fn().mockReturnThis(),
+			find: jest.fn().mockReturnThis(),
+			not: jest.fn().mockReturnThis(),
+			siblings: jest.fn().mockReturnThis(),
+			slice: jest.fn().mockReturnThis(),
+			closest: jest.fn().mockReturnThis(),
+			addClass: jest.fn().mockReturnThis(),
+			removeClass: jest.fn().mockReturnThis(),
+			hasClass: jest.fn().mockReturnValue( false ),
+			css: jest.fn().mockReturnThis(),
+			attr: jest.fn().mockReturnThis(),
+			data: jest.fn().mockReturnValue( null ),
+			html: jest.fn().mockReturnThis(),
+			text: jest.fn().mockReturnThis(),
+			val: jest.fn().mockReturnThis(),
+			prop: jest.fn().mockReturnThis(),
+			trigger: jest.fn().mockReturnThis(),
+			each: jest.fn( function ( callback ) {
+				callback.call( this, 0, this );
+				return this;
+			} ),
+			eq: jest.fn().mockReturnThis(),
+			first: jest.fn().mockReturnThis(),
+			last: jest.fn().mockReturnThis(),
+			parent: jest.fn().mockReturnThis(),
+			parents: jest.fn().mockReturnThis(),
+			children: jest.fn().mockReturnThis(),
+			append: jest.fn().mockReturnThis(),
+			prepend: jest.fn().mockReturnThis(),
+			remove: jest.fn().mockReturnThis(),
+			empty: jest.fn().mockReturnThis(),
+			show: jest.fn().mockReturnThis(),
+			hide: jest.fn().mockReturnThis(),
+			is: jest.fn().mockReturnValue( false ),
+			filter: jest.fn().mockReturnThis(),
+		};
+		return mock;
+	};
+
+	beforeEach( () => {
+		// Create mock field elements with all jQuery methods needed
+		mockFields = createChainableMock();
+
+		// Create a chainable mock jQuery constructor
+		mockJQuery = jest.fn( () => {
+			// Return the mock fields for any selector
+			return mockFields;
+		} );
+
+		// Add static jQuery methods
+		mockJQuery.extend = jest.fn( ( target, ...sources ) => {
+			return Object.assign( target || {}, ...sources );
+		} );
+		mockJQuery.proxy = jest.fn( ( fn, context ) => fn.bind( context ) );
+		mockJQuery.fn = { jquery: '3.0.0' };
+
+		// Set jQuery globals
+		global.jQuery = mockJQuery;
+		global.$ = mockJQuery;
+
+		// Mock acf global with all required properties
+		global.acf = {
+			uniqueId: jest.fn( ( prefix ) => `${ prefix }123` ),
+			didAction: jest.fn().mockReturnValue( true ),
+			addAction: jest.fn(),
+			removeAction: jest.fn(),
+			addFilter: jest.fn(),
+			applyFilters: jest.fn( ( name, value ) => value ),
+			doAction: jest.fn(),
+			arrayArgs: jest.fn( ( args ) => Array.from( args ) ),
+			parseArgs: jest.fn( ( args, defaults ) => ( {
+				...defaults,
+				...args,
+			} ) ),
+			getInstance: jest.fn(),
+			getInstances: jest.fn(),
+			newField: jest.fn().mockReturnValue( { cid: 'newField' } ),
+			models: {},
+			Model: null,
+			Field: null,
+			isGutenbergPostEditor: jest.fn().mockReturnValue( false ),
+			// String helper functions used by the field system
+			strPascalCase: jest.fn( ( str ) => {
+				return str
+					.split( /[\s_-]+/ )
+					.map(
+						( word ) =>
+							word.charAt( 0 ).toUpperCase() +
+							word.slice( 1 ).toLowerCase()
+					)
+					.join( '' );
+			} ),
+		};
+
+		// Load modules in order
+		jest.isolateModules( () => {
+			require( '../../assets/src/js/_acf-model.js' );
+			require( '../../assets/src/js/_acf-field.js' );
+			require( '../../assets/src/js/_acf-fields.js' );
+		} );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+		delete global.jQuery;
+		delete global.$;
+		delete global.acf;
+	} );
+
+	describe( 'acf.findFields()', () => {
+		it( 'should return jQuery collection of .acf-field elements', () => {
+			global.acf.findFields();
+
+			expect( mockJQuery ).toHaveBeenCalledWith(
+				expect.stringContaining( '.acf-field' )
+			);
+		} );
+
+		it( 'should filter by key when provided', () => {
+			global.acf.findFields( { key: 'field_123' } );
+
+			expect( mockJQuery ).toHaveBeenCalledWith(
+				expect.stringContaining( '[data-key="field_123"]' )
+			);
+		} );
+
+		it( 'should filter by type when provided', () => {
+			global.acf.findFields( { type: 'text' } );
+
+			expect( mockJQuery ).toHaveBeenCalledWith(
+				expect.stringContaining( '[data-type="text"]' )
+			);
+		} );
+
+		it( 'should filter by name when provided', () => {
+			global.acf.findFields( { name: 'my_field' } );
+
+			expect( mockJQuery ).toHaveBeenCalledWith(
+				expect.stringContaining( '[data-name="my_field"]' )
+			);
+		} );
+
+		it( 'should append custom selector with is parameter', () => {
+			global.acf.findFields( { is: '.custom-class' } );
+
+			expect( mockJQuery ).toHaveBeenCalledWith(
+				expect.stringContaining( '.custom-class' )
+			);
+		} );
+
+		it( 'should filter visible fields when visible is true', () => {
+			global.acf.findFields( { visible: true } );
+
+			expect( mockJQuery ).toHaveBeenCalledWith(
+				expect.stringContaining( ':visible' )
+			);
+		} );
+
+		it( 'should search within parent when provided', () => {
+			const mockParent = createChainableMock();
+
+			global.acf.findFields( { parent: mockParent } );
+
+			// Should search for .acf-field within the parent
+			expect( mockParent.find ).toHaveBeenCalledWith( '.acf-field' );
+		} );
+
+		it( 'should exclude sub-fields when excludeSubFields is true', () => {
+			const mockParent = createChainableMock();
+			const mockFoundFields = createChainableMock();
+			mockParent.find.mockReturnValue( mockFoundFields );
+
+			global.acf.findFields( {
+				parent: mockParent,
+				excludeSubFields: true,
+			} );
+
+			// Should call .not() to exclude sub-fields
+			expect( mockFoundFields.not ).toHaveBeenCalledWith(
+				expect.stringContaining( '.acf-field' )
+			);
+		} );
+
+		it( 'should search siblings when sibling provided', () => {
+			const mockSibling = createChainableMock();
+
+			global.acf.findFields( { sibling: mockSibling } );
+
+			// Should search for .acf-field siblings
+			expect( mockSibling.siblings ).toHaveBeenCalledWith( '.acf-field' );
+		} );
+
+		it( 'should limit results when limit is set', () => {
+			global.acf.findFields( { limit: 5 } );
+
+			expect( mockFields.slice ).toHaveBeenCalledWith( 0, 5 );
+		} );
+
+		it( 'should exclude clone fields by default', () => {
+			global.acf.findFields();
+
+			expect( mockFields.not ).toHaveBeenCalledWith(
+				'.acf-clone .acf-field'
+			);
+		} );
+
+		it( 'should not apply filters when suppressFilters is true', () => {
+			global.acf.findFields( { suppressFilters: true } );
+
+			expect( global.acf.applyFilters ).not.toHaveBeenCalledWith(
+				'find_fields_args',
+				expect.anything()
+			);
+		} );
+
+		it( 'should apply find_fields_args filter', () => {
+			global.acf.findFields();
+
+			expect( global.acf.applyFilters ).toHaveBeenCalledWith(
+				'find_fields_args',
+				expect.any( Object )
+			);
+		} );
+
+		it( 'should apply find_fields filter to results', () => {
+			global.acf.findFields();
+
+			// Filter receives the found fields jQuery collection
+			expect( global.acf.applyFilters ).toHaveBeenCalledWith(
+				'find_fields',
+				expect.objectContaining( { length: expect.any( Number ) } )
+			);
+		} );
+	} );
+
+	describe( 'acf.findField()', () => {
+		it( 'should call findFields with key and limit 1', () => {
+			const findFieldsSpy = jest.spyOn( global.acf, 'findFields' );
+
+			global.acf.findField( 'field_123' );
+
+			expect( findFieldsSpy ).toHaveBeenCalledWith( {
+				key: 'field_123',
+				limit: 1,
+				parent: undefined,
+				suppressFilters: true,
+			} );
+		} );
+
+		it( 'should pass parent when provided', () => {
+			const findFieldsSpy = jest.spyOn( global.acf, 'findFields' );
+			const mockParent = createChainableMock();
+
+			global.acf.findField( 'field_123', mockParent );
+
+			expect( findFieldsSpy ).toHaveBeenCalledWith(
+				expect.objectContaining( { parent: mockParent } )
+			);
+		} );
+	} );
+
+	describe( 'acf.getField()', () => {
+		it( 'should return existing instance from element data', () => {
+			const existingInstance = { cid: 'existing' };
+			mockFields.data.mockReturnValue( existingInstance );
+
+			const result = global.acf.getField( mockFields );
+
+			expect( result ).toBe( existingInstance );
+		} );
+
+		it( 'should create new instance when none exists', () => {
+			// Spy on newField after module load since it gets replaced
+			const newFieldSpy = jest.spyOn( global.acf, 'newField' );
+			newFieldSpy.mockReturnValue( { cid: 'newField' } );
+
+			mockFields.data.mockReturnValue( null );
+
+			const result = global.acf.getField( mockFields );
+
+			expect( newFieldSpy ).toHaveBeenCalledWith( mockFields );
+			expect( result ).toEqual( { cid: 'newField' } );
+		} );
+
+		it( 'should find field by key when string provided', () => {
+			const findFieldSpy = jest.spyOn( global.acf, 'findField' );
+
+			global.acf.getField( 'field_key' );
+
+			expect( findFieldSpy ).toHaveBeenCalledWith( 'field_key' );
+		} );
+	} );
+
+	describe( 'acf.getFields()', () => {
+		it( 'should return array of field instances when jQuery collection provided', () => {
+			// Create a mock that is recognized as instanceof jQuery
+			// by giving it prototype properties matching jQuery
+			const mockFieldElements = createChainableMock();
+			Object.setPrototypeOf(
+				mockFieldElements,
+				global.jQuery.prototype || {}
+			);
+
+			const fieldInstances = [ { cid: 'field1' }, { cid: 'field2' } ];
+
+			mockFieldElements.each = jest.fn( function ( callback ) {
+				fieldInstances.forEach( ( f, i ) => {
+					const fieldMock = createChainableMock();
+					fieldMock.data.mockReturnValue( f );
+					callback.call( fieldMock, i, fieldMock );
+				} );
+				return this;
+			} );
+
+			const result = global.acf.getFields( mockFieldElements );
+
+			expect( Array.isArray( result ) ).toBe( true );
+		} );
+
+		it( 'should find fields when object args provided', () => {
+			const findFieldsSpy = jest.spyOn( global.acf, 'findFields' );
+
+			// Pass args that will trigger findFields path
+			global.acf.getFields( { type: 'text' } );
+
+			expect( findFieldsSpy ).toHaveBeenCalledWith( { type: 'text' } );
+		} );
+	} );
+
+	describe( 'acf.findClosestField()', () => {
+		it( 'should find closest .acf-field element', () => {
+			const mockEl = createChainableMock();
+
+			global.acf.findClosestField( mockEl );
+
+			expect( mockEl.closest ).toHaveBeenCalledWith( '.acf-field' );
+		} );
+	} );
+
+	describe( 'acf.getClosestField()', () => {
+		it( 'should call findClosestField and return field instance', () => {
+			const mockEl = createChainableMock();
+			const mockClosestEl = createChainableMock();
+			mockEl.closest.mockReturnValue( mockClosestEl );
+
+			// Setup existing field instance on the element
+			const mockInstance = { cid: 'closest', type: 'text' };
+			mockClosestEl.data.mockReturnValue( mockInstance );
+
+			const result = global.acf.getClosestField( mockEl );
+
+			// Verify it finds the closest .acf-field element
+			expect( mockEl.closest ).toHaveBeenCalledWith( '.acf-field' );
+			// Verify a field instance is returned (via getField)
+			expect( result ).toBeDefined();
+			expect( result.cid ).toBeDefined();
+		} );
+	} );
+
+	describe( 'Global Field Actions', () => {
+		it( 'should register global action callbacks', () => {
+			// The module registers actions on load
+			const registeredActions = global.acf.addAction.mock.calls.map(
+				( call ) => call[ 0 ]
+			);
+
+			// Check some expected global actions are registered
+			expect( registeredActions ).toContain( 'prepare' );
+			expect( registeredActions ).toContain( 'ready' );
+			expect( registeredActions ).toContain( 'load' );
+			expect( registeredActions ).toContain( 'append' );
+		} );
+	} );
+
+	describe( 'duplicateFieldsManager', () => {
+		it( 'should register duplicate action', () => {
+			const registeredActions = global.acf.addAction.mock.calls.map(
+				( call ) => call[ 0 ]
+			);
+
+			expect( registeredActions ).toContain( 'duplicate' );
+		} );
+	} );
+} );

--- a/tests/js/fields/button-group.test.js
+++ b/tests/js/fields/button-group.test.js
@@ -1,0 +1,362 @@
+/**
+ * Unit tests for button_group field type
+ */
+
+describe( 'Button Group Field', () => {
+	let fieldDefinition;
+	let mockField;
+
+	beforeEach( () => {
+		// Reset mocks
+		fieldDefinition = null;
+
+		// Mock @wordpress/icons
+		jest.mock( '@wordpress/icons', () => ( { update: 'update-icon' } ), {
+			virtual: true,
+		} );
+
+		// Mock acf.Field.extend to capture the field definition
+		global.acf = {
+			Field: {
+				extend: jest.fn( ( definition ) => {
+					fieldDefinition = definition;
+					return definition;
+				} ),
+			},
+			registerFieldType: jest.fn(),
+		};
+
+		// Load the button_group field module
+		jest.isolateModules( () => {
+			require( '../../../assets/src/js/_acf-field-button-group.js' );
+		} );
+
+		// Create a mock field instance with the captured definition
+		mockField = {
+			...fieldDefinition,
+			$: jest.fn(),
+			get: jest.fn(),
+		};
+	} );
+
+	afterEach( () => {
+		delete global.acf;
+		jest.resetModules();
+	} );
+
+	describe( 'Field Definition', () => {
+		it( 'should have type "button_group"', () => {
+			expect( fieldDefinition.type ).toBe( 'button_group' );
+		} );
+
+		it( 'should register click and keydown events', () => {
+			expect( fieldDefinition.events ).toEqual( {
+				'click input[type="radio"]': 'onClick',
+				'keydown label': 'onKeyDown',
+			} );
+		} );
+	} );
+
+	describe( '$control()', () => {
+		it( 'should find .acf-button-group element', () => {
+			fieldDefinition.$control.call( mockField );
+
+			expect( mockField.$ ).toHaveBeenCalledWith( '.acf-button-group' );
+		} );
+	} );
+
+	describe( '$input()', () => {
+		it( 'should find checked input element', () => {
+			fieldDefinition.$input.call( mockField );
+
+			expect( mockField.$ ).toHaveBeenCalledWith( 'input:checked' );
+		} );
+	} );
+
+	describe( 'initialize()', () => {
+		it( 'should call updateButtonStates', () => {
+			const updateSpy = jest.fn();
+			mockField.updateButtonStates = updateSpy;
+
+			fieldDefinition.initialize.call( mockField );
+
+			expect( updateSpy ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'setValue()', () => {
+		it( 'should check the input with matching value and trigger change', () => {
+			const mockInput = {
+				prop: jest.fn().mockReturnThis(),
+				trigger: jest.fn().mockReturnThis(),
+			};
+			mockField.$ = jest.fn().mockReturnValue( mockInput );
+			mockField.updateButtonStates = jest.fn();
+
+			fieldDefinition.setValue.call( mockField, 'option2' );
+
+			expect( mockField.$ ).toHaveBeenCalledWith(
+				'input[value="option2"]'
+			);
+			expect( mockInput.prop ).toHaveBeenCalledWith( 'checked', true );
+			expect( mockInput.trigger ).toHaveBeenCalledWith( 'change' );
+		} );
+
+		it( 'should update button states after setting value', () => {
+			const updateSpy = jest.fn();
+			mockField.$ = jest.fn().mockReturnValue( {
+				prop: jest.fn().mockReturnThis(),
+				trigger: jest.fn().mockReturnThis(),
+			} );
+			mockField.updateButtonStates = updateSpy;
+
+			fieldDefinition.setValue.call( mockField, 'option1' );
+
+			expect( updateSpy ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'updateButtonStates()', () => {
+		let mockLabels;
+		let mockInput;
+		let mockInputLabel;
+
+		beforeEach( () => {
+			mockInputLabel = {
+				addClass: jest.fn().mockReturnThis(),
+				attr: jest.fn().mockReturnThis(),
+			};
+			mockInput = {
+				length: 1,
+				parent: jest.fn().mockReturnValue( mockInputLabel ),
+			};
+			mockLabels = {
+				removeClass: jest.fn().mockReturnThis(),
+				attr: jest.fn().mockReturnThis(),
+				first: jest.fn().mockReturnThis(),
+			};
+		} );
+
+		it( 'should remove selected class and reset aria attributes on all labels', () => {
+			const mockControl = {
+				find: jest.fn().mockReturnValue( mockLabels ),
+			};
+			mockField.$control = jest.fn().mockReturnValue( mockControl );
+			mockField.$input = jest.fn().mockReturnValue( mockInput );
+
+			fieldDefinition.updateButtonStates.call( mockField );
+
+			expect( mockLabels.removeClass ).toHaveBeenCalledWith( 'selected' );
+			expect( mockLabels.attr ).toHaveBeenCalledWith(
+				'aria-checked',
+				'false'
+			);
+			expect( mockLabels.attr ).toHaveBeenCalledWith( 'tabindex', '-1' );
+		} );
+
+		it( 'should mark selected input label with correct attributes', () => {
+			const mockControl = {
+				find: jest.fn().mockReturnValue( mockLabels ),
+			};
+			mockField.$control = jest.fn().mockReturnValue( mockControl );
+			mockField.$input = jest.fn().mockReturnValue( mockInput );
+
+			fieldDefinition.updateButtonStates.call( mockField );
+
+			expect( mockInputLabel.addClass ).toHaveBeenCalledWith(
+				'selected'
+			);
+			expect( mockInputLabel.attr ).toHaveBeenCalledWith(
+				'aria-checked',
+				'true'
+			);
+			expect( mockInputLabel.attr ).toHaveBeenCalledWith(
+				'tabindex',
+				'0'
+			);
+		} );
+
+		it( 'should set tabindex on first label when no input is checked', () => {
+			mockInput.length = 0;
+			const mockControl = {
+				find: jest.fn().mockReturnValue( mockLabels ),
+			};
+			mockField.$control = jest.fn().mockReturnValue( mockControl );
+			mockField.$input = jest.fn().mockReturnValue( mockInput );
+
+			fieldDefinition.updateButtonStates.call( mockField );
+
+			expect( mockLabels.first ).toHaveBeenCalled();
+			expect( mockLabels.attr ).toHaveBeenCalledWith( 'tabindex', '0' );
+		} );
+	} );
+
+	describe( 'onClick()', () => {
+		it( 'should call selectButton with parent label', () => {
+			const selectSpy = jest.fn();
+			mockField.selectButton = selectSpy;
+			const mockLabel = { hasClass: jest.fn() };
+			const mockEl = { parent: jest.fn().mockReturnValue( mockLabel ) };
+
+			fieldDefinition.onClick.call( mockField, {}, mockEl );
+
+			expect( mockEl.parent ).toHaveBeenCalledWith( 'label' );
+			expect( selectSpy ).toHaveBeenCalledWith( mockLabel );
+		} );
+	} );
+
+	describe( 'onKeyDown()', () => {
+		let mockLabels;
+		let mockEvent;
+		let mockLabel;
+
+		beforeEach( () => {
+			mockLabel = {};
+			mockLabels = {
+				index: jest.fn().mockReturnValue( 1 ),
+				length: 3,
+				eq: jest.fn().mockReturnValue( {
+					attr: jest.fn().mockReturnThis(),
+					trigger: jest.fn().mockReturnThis(),
+				} ),
+				attr: jest.fn().mockReturnThis(),
+			};
+			const mockControl = {
+				find: jest.fn().mockReturnValue( mockLabels ),
+			};
+			mockField.$control = jest.fn().mockReturnValue( mockControl );
+			mockField.selectButton = jest.fn();
+		} );
+
+		it( 'should select button on Space key (32)', () => {
+			mockEvent = { which: 32, preventDefault: jest.fn() };
+
+			fieldDefinition.onKeyDown.call( mockField, mockEvent, mockLabel );
+
+			expect( mockEvent.preventDefault ).toHaveBeenCalled();
+			expect( mockField.selectButton ).toHaveBeenCalledWith( mockLabel );
+		} );
+
+		it( 'should select button on Enter key (13)', () => {
+			mockEvent = { which: 13, preventDefault: jest.fn() };
+
+			fieldDefinition.onKeyDown.call( mockField, mockEvent, mockLabel );
+
+			expect( mockEvent.preventDefault ).toHaveBeenCalled();
+			expect( mockField.selectButton ).toHaveBeenCalledWith( mockLabel );
+		} );
+
+		it( 'should move to previous button on left arrow (37)', () => {
+			mockEvent = { which: 37, preventDefault: jest.fn() };
+
+			fieldDefinition.onKeyDown.call( mockField, mockEvent, mockLabel );
+
+			expect( mockEvent.preventDefault ).toHaveBeenCalled();
+			expect( mockLabels.eq ).toHaveBeenCalledWith( 0 ); // Previous index
+		} );
+
+		it( 'should move to next button on right arrow (39)', () => {
+			mockEvent = { which: 39, preventDefault: jest.fn() };
+
+			fieldDefinition.onKeyDown.call( mockField, mockEvent, mockLabel );
+
+			expect( mockEvent.preventDefault ).toHaveBeenCalled();
+			expect( mockLabels.eq ).toHaveBeenCalledWith( 2 ); // Next index
+		} );
+
+		it( 'should wrap to last button when at start and pressing left', () => {
+			mockLabels.index.mockReturnValue( 0 );
+			mockEvent = { which: 37, preventDefault: jest.fn() };
+
+			fieldDefinition.onKeyDown.call( mockField, mockEvent, mockLabel );
+
+			expect( mockLabels.eq ).toHaveBeenCalledWith( 2 ); // Last index
+		} );
+
+		it( 'should wrap to first button when at end and pressing right', () => {
+			mockLabels.index.mockReturnValue( 2 );
+			mockEvent = { which: 39, preventDefault: jest.fn() };
+
+			fieldDefinition.onKeyDown.call( mockField, mockEvent, mockLabel );
+
+			expect( mockLabels.eq ).toHaveBeenCalledWith( 0 ); // First index
+		} );
+
+		it( 'should move to previous on up arrow (38)', () => {
+			mockEvent = { which: 38, preventDefault: jest.fn() };
+
+			fieldDefinition.onKeyDown.call( mockField, mockEvent, mockLabel );
+
+			expect( mockEvent.preventDefault ).toHaveBeenCalled();
+			expect( mockLabels.eq ).toHaveBeenCalledWith( 0 );
+		} );
+
+		it( 'should move to next on down arrow (40)', () => {
+			mockEvent = { which: 40, preventDefault: jest.fn() };
+
+			fieldDefinition.onKeyDown.call( mockField, mockEvent, mockLabel );
+
+			expect( mockEvent.preventDefault ).toHaveBeenCalled();
+			expect( mockLabels.eq ).toHaveBeenCalledWith( 2 );
+		} );
+	} );
+
+	describe( 'selectButton()', () => {
+		let mockElement;
+		let mockRadio;
+
+		beforeEach( () => {
+			mockRadio = {
+				prop: jest.fn().mockReturnThis(),
+				trigger: jest.fn().mockReturnThis(),
+			};
+			mockElement = {
+				find: jest.fn().mockReturnValue( mockRadio ),
+				hasClass: jest.fn().mockReturnValue( false ),
+			};
+			mockField.updateButtonStates = jest.fn();
+			mockField.get = jest.fn().mockReturnValue( false );
+		} );
+
+		it( 'should check radio and trigger change', () => {
+			fieldDefinition.selectButton.call( mockField, mockElement );
+
+			expect( mockElement.find ).toHaveBeenCalledWith(
+				'input[type="radio"]'
+			);
+			expect( mockRadio.prop ).toHaveBeenCalledWith( 'checked', true );
+			expect( mockRadio.trigger ).toHaveBeenCalledWith( 'change' );
+		} );
+
+		it( 'should update button states after selection', () => {
+			fieldDefinition.selectButton.call( mockField, mockElement );
+
+			expect( mockField.updateButtonStates ).toHaveBeenCalled();
+		} );
+
+		it( 'should deselect when allow_null is true and already selected', () => {
+			mockElement.hasClass.mockReturnValue( true );
+			mockField.get = jest.fn( ( key ) =>
+				key === 'allow_null' ? true : false
+			);
+
+			fieldDefinition.selectButton.call( mockField, mockElement );
+
+			expect( mockRadio.prop ).toHaveBeenCalledWith( 'checked', false );
+		} );
+
+		it( 'should not deselect when allow_null is false', () => {
+			mockElement.hasClass.mockReturnValue( true );
+			mockField.get = jest.fn().mockReturnValue( false );
+
+			fieldDefinition.selectButton.call( mockField, mockElement );
+
+			// First call is check true, should not be followed by check false
+			expect( mockRadio.prop ).toHaveBeenCalledWith( 'checked', true );
+			expect( mockRadio.prop ).not.toHaveBeenCalledWith(
+				'checked',
+				false
+			);
+		} );
+	} );
+} );

--- a/tests/js/fields/radio.test.js
+++ b/tests/js/fields/radio.test.js
@@ -1,0 +1,249 @@
+/**
+ * Unit tests for radio field type
+ */
+
+describe( 'Radio Field', () => {
+	let fieldDefinition;
+	let mockField;
+
+	beforeEach( () => {
+		// Reset mocks
+		fieldDefinition = null;
+
+		// Mock acf.Field.extend to capture the field definition
+		global.acf = {
+			Field: {
+				extend: jest.fn( ( definition ) => {
+					fieldDefinition = definition;
+					return definition;
+				} ),
+			},
+			registerFieldType: jest.fn(),
+		};
+
+		// Load the radio field module
+		jest.isolateModules( () => {
+			require( '../../../assets/src/js/_acf-field-radio.js' );
+		} );
+
+		// Create a mock field instance with the captured definition
+		mockField = {
+			...fieldDefinition,
+			$: jest.fn(),
+			get: jest.fn(),
+		};
+	} );
+
+	afterEach( () => {
+		delete global.acf;
+	} );
+
+	describe( 'Field Definition', () => {
+		it( 'should have type "radio"', () => {
+			expect( fieldDefinition.type ).toBe( 'radio' );
+		} );
+
+		it( 'should register click and keydown events', () => {
+			expect( fieldDefinition.events ).toEqual( {
+				'click input[type="radio"]': 'onClick',
+				'keydown input[type="radio"]': 'onKeyDownInput',
+			} );
+		} );
+	} );
+
+	describe( '$control()', () => {
+		it( 'should find .acf-radio-list element', () => {
+			fieldDefinition.$control.call( mockField );
+
+			expect( mockField.$ ).toHaveBeenCalledWith( '.acf-radio-list' );
+		} );
+	} );
+
+	describe( '$input()', () => {
+		it( 'should find checked input element', () => {
+			fieldDefinition.$input.call( mockField );
+
+			expect( mockField.$ ).toHaveBeenCalledWith( 'input:checked' );
+		} );
+	} );
+
+	describe( '$inputText()', () => {
+		it( 'should find text input element', () => {
+			fieldDefinition.$inputText.call( mockField );
+
+			expect( mockField.$ ).toHaveBeenCalledWith( 'input[type="text"]' );
+		} );
+	} );
+
+	describe( 'getValue()', () => {
+		it( 'should return checked input value', () => {
+			const mockInput = { val: jest.fn().mockReturnValue( 'option1' ) };
+			mockField.$input = jest.fn().mockReturnValue( mockInput );
+			mockField.get = jest.fn().mockReturnValue( false );
+
+			const result = fieldDefinition.getValue.call( mockField );
+
+			expect( result ).toBe( 'option1' );
+		} );
+
+		it( 'should return text input value when other_choice is enabled and other is selected', () => {
+			const mockInput = { val: jest.fn().mockReturnValue( 'other' ) };
+			const mockTextInput = {
+				val: jest.fn().mockReturnValue( 'custom value' ),
+			};
+			mockField.$input = jest.fn().mockReturnValue( mockInput );
+			mockField.$inputText = jest.fn().mockReturnValue( mockTextInput );
+			mockField.get = jest.fn( ( key ) =>
+				key === 'other_choice' ? true : false
+			);
+
+			const result = fieldDefinition.getValue.call( mockField );
+
+			expect( result ).toBe( 'custom value' );
+		} );
+
+		it( 'should return radio value when other_choice is disabled', () => {
+			const mockInput = { val: jest.fn().mockReturnValue( 'other' ) };
+			mockField.$input = jest.fn().mockReturnValue( mockInput );
+			mockField.get = jest.fn().mockReturnValue( false );
+
+			const result = fieldDefinition.getValue.call( mockField );
+
+			expect( result ).toBe( 'other' );
+		} );
+	} );
+
+	describe( 'onClick()', () => {
+		let mockEl;
+		let mockLabel;
+
+		beforeEach( () => {
+			mockLabel = {
+				hasClass: jest.fn().mockReturnValue( false ),
+				addClass: jest.fn().mockReturnThis(),
+				removeClass: jest.fn().mockReturnThis(),
+			};
+			mockEl = {
+				parent: jest.fn().mockReturnValue( mockLabel ),
+				val: jest.fn().mockReturnValue( 'option1' ),
+				prop: jest.fn().mockReturnThis(),
+				trigger: jest.fn().mockReturnThis(),
+			};
+			mockField.$ = jest.fn().mockReturnValue( {
+				removeClass: jest.fn().mockReturnThis(),
+			} );
+			mockField.$inputText = jest.fn().mockReturnValue( {
+				prop: jest.fn().mockReturnThis(),
+			} );
+		} );
+
+		it( 'should remove selected class from all labels', () => {
+			const mockSelected = { removeClass: jest.fn() };
+			mockField.$ = jest.fn().mockReturnValue( mockSelected );
+			mockField.get = jest.fn().mockReturnValue( false );
+
+			fieldDefinition.onClick.call( mockField, {}, mockEl );
+
+			expect( mockField.$ ).toHaveBeenCalledWith( '.selected' );
+			expect( mockSelected.removeClass ).toHaveBeenCalledWith(
+				'selected'
+			);
+		} );
+
+		it( 'should add selected class to clicked label', () => {
+			mockField.get = jest.fn().mockReturnValue( false );
+
+			fieldDefinition.onClick.call( mockField, {}, mockEl );
+
+			expect( mockLabel.addClass ).toHaveBeenCalledWith( 'selected' );
+		} );
+
+		it( 'should deselect when allow_null is true and already selected', () => {
+			mockLabel.hasClass.mockReturnValue( true );
+			mockField.get = jest.fn( ( key ) =>
+				key === 'allow_null' ? true : false
+			);
+
+			fieldDefinition.onClick.call( mockField, {}, mockEl );
+
+			expect( mockLabel.removeClass ).toHaveBeenCalledWith( 'selected' );
+			expect( mockEl.prop ).toHaveBeenCalledWith( 'checked', false );
+			expect( mockEl.trigger ).toHaveBeenCalledWith( 'change' );
+		} );
+
+		it( 'should enable text input when other is selected', () => {
+			const mockTextInput = { prop: jest.fn().mockReturnThis() };
+			mockField.$inputText = jest.fn().mockReturnValue( mockTextInput );
+			mockEl.val.mockReturnValue( 'other' );
+			mockField.get = jest.fn( ( key ) =>
+				key === 'other_choice' ? true : false
+			);
+
+			fieldDefinition.onClick.call( mockField, {}, mockEl );
+
+			expect( mockTextInput.prop ).toHaveBeenCalledWith(
+				'disabled',
+				false
+			);
+		} );
+
+		it( 'should disable text input when other is not selected', () => {
+			const mockTextInput = { prop: jest.fn().mockReturnThis() };
+			mockField.$inputText = jest.fn().mockReturnValue( mockTextInput );
+			mockEl.val.mockReturnValue( 'option1' );
+			mockField.get = jest.fn( ( key ) =>
+				key === 'other_choice' ? true : false
+			);
+
+			fieldDefinition.onClick.call( mockField, {}, mockEl );
+
+			expect( mockTextInput.prop ).toHaveBeenCalledWith(
+				'disabled',
+				true
+			);
+		} );
+	} );
+
+	describe( 'onKeyDownInput()', () => {
+		it( 'should check input and trigger change on Enter key', () => {
+			const mockEvent = {
+				which: 13,
+				preventDefault: jest.fn(),
+			};
+			const mockInput = {
+				prop: jest.fn().mockReturnThis(),
+				trigger: jest.fn().mockReturnThis(),
+			};
+
+			fieldDefinition.onKeyDownInput.call(
+				mockField,
+				mockEvent,
+				mockInput
+			);
+
+			expect( mockEvent.preventDefault ).toHaveBeenCalled();
+			expect( mockInput.prop ).toHaveBeenCalledWith( 'checked', true );
+			expect( mockInput.trigger ).toHaveBeenCalledWith( 'change' );
+		} );
+
+		it( 'should not react to other keys', () => {
+			const mockEvent = {
+				which: 65, // 'A' key
+				preventDefault: jest.fn(),
+			};
+			const mockInput = {
+				prop: jest.fn().mockReturnThis(),
+				trigger: jest.fn().mockReturnThis(),
+			};
+
+			fieldDefinition.onKeyDownInput.call(
+				mockField,
+				mockEvent,
+				mockInput
+			);
+
+			expect( mockEvent.preventDefault ).not.toHaveBeenCalled();
+			expect( mockInput.prop ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/tests/js/fields/range.test.js
+++ b/tests/js/fields/range.test.js
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for range field type
+ */
+
+describe( 'Range Field', () => {
+	let fieldDefinition;
+	let mockField;
+
+	beforeEach( () => {
+		// Reset mocks
+		fieldDefinition = null;
+
+		// Mock acf.Field.extend to capture the field definition
+		global.acf = {
+			Field: {
+				extend: jest.fn( ( definition ) => {
+					fieldDefinition = definition;
+					return definition;
+				} ),
+			},
+			registerFieldType: jest.fn(),
+			val: jest.fn(),
+		};
+
+		// Load the range field module
+		jest.isolateModules( () => {
+			require( '../../../assets/src/js/_acf-field-range.js' );
+		} );
+
+		// Create a mock field instance with the captured definition
+		mockField = {
+			...fieldDefinition,
+			$: jest.fn(),
+			busy: false,
+		};
+	} );
+
+	afterEach( () => {
+		delete global.acf;
+	} );
+
+	describe( 'Field Definition', () => {
+		it( 'should have type "range"', () => {
+			expect( fieldDefinition.type ).toBe( 'range' );
+		} );
+
+		it( 'should register input and change events', () => {
+			expect( fieldDefinition.events ).toEqual( {
+				'input input[type="range"]': 'onChange',
+				'change input': 'onChange',
+			} );
+		} );
+	} );
+
+	describe( '$input()', () => {
+		it( 'should find range input element', () => {
+			fieldDefinition.$input.call( mockField );
+
+			expect( mockField.$ ).toHaveBeenCalledWith( 'input[type="range"]' );
+		} );
+	} );
+
+	describe( '$inputAlt()', () => {
+		it( 'should find number input element', () => {
+			fieldDefinition.$inputAlt.call( mockField );
+
+			expect( mockField.$ ).toHaveBeenCalledWith(
+				'input[type="number"]'
+			);
+		} );
+	} );
+
+	describe( 'setValue()', () => {
+		let mockRangeInput;
+		let mockNumberInput;
+
+		beforeEach( () => {
+			mockRangeInput = { val: jest.fn().mockReturnValue( '50' ) };
+			mockNumberInput = { val: jest.fn() };
+			mockField.$input = jest.fn().mockReturnValue( mockRangeInput );
+			mockField.$inputAlt = jest.fn().mockReturnValue( mockNumberInput );
+		} );
+
+		it( 'should set busy flag during value update', () => {
+			fieldDefinition.setValue.call( mockField, 75 );
+
+			// After setValue completes, busy should be false
+			expect( mockField.busy ).toBe( false );
+		} );
+
+		it( 'should update range input with change event', () => {
+			fieldDefinition.setValue.call( mockField, 75 );
+
+			expect( global.acf.val ).toHaveBeenCalledWith( mockRangeInput, 75 );
+		} );
+
+		it( 'should update alt input without change event', () => {
+			fieldDefinition.setValue.call( mockField, 75 );
+
+			// Second call should be for alt input with silent flag
+			expect( global.acf.val ).toHaveBeenCalledWith(
+				mockNumberInput,
+				'50',
+				true
+			);
+		} );
+
+		it( 'should read validated value from range input', () => {
+			mockRangeInput.val.mockReturnValue( '100' ); // Validated by browser
+
+			fieldDefinition.setValue.call( mockField, 150 ); // Above max
+
+			// Should use the validated value from the range input
+			expect( global.acf.val ).toHaveBeenCalledWith(
+				mockNumberInput,
+				'100',
+				true
+			);
+		} );
+	} );
+
+	describe( 'onChange()', () => {
+		it( 'should call setValue with input value when not busy', () => {
+			const setValueSpy = jest.fn();
+			mockField.setValue = setValueSpy;
+			mockField.busy = false;
+
+			const mockEl = { val: jest.fn().mockReturnValue( '42' ) };
+
+			fieldDefinition.onChange.call( mockField, {}, mockEl );
+
+			expect( setValueSpy ).toHaveBeenCalledWith( '42' );
+		} );
+
+		it( 'should not call setValue when busy', () => {
+			const setValueSpy = jest.fn();
+			mockField.setValue = setValueSpy;
+			mockField.busy = true;
+
+			const mockEl = { val: jest.fn().mockReturnValue( '42' ) };
+
+			fieldDefinition.onChange.call( mockField, {}, mockEl );
+
+			expect( setValueSpy ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Integration scenarios', () => {
+		it( 'should synchronize range and number inputs', () => {
+			const mockRangeInput = { val: jest.fn().mockReturnValue( '75' ) };
+			const mockNumberInput = { val: jest.fn() };
+			mockField.$input = jest.fn().mockReturnValue( mockRangeInput );
+			mockField.$inputAlt = jest.fn().mockReturnValue( mockNumberInput );
+
+			// Simulate user dragging range slider
+			fieldDefinition.setValue.call( mockField, '75' );
+
+			expect( global.acf.val ).toHaveBeenNthCalledWith(
+				1,
+				mockRangeInput,
+				'75'
+			);
+			expect( global.acf.val ).toHaveBeenNthCalledWith(
+				2,
+				mockNumberInput,
+				'75',
+				true
+			);
+		} );
+	} );
+} );

--- a/tests/js/fields/select.test.js
+++ b/tests/js/fields/select.test.js
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for select field type
+ */
+
+describe( 'Select Field', () => {
+	let fieldDefinition;
+	let mockField;
+
+	beforeEach( () => {
+		// Reset mocks
+		fieldDefinition = null;
+
+		// Mock acf.Field.extend to capture the field definition
+		global.acf = {
+			Field: {
+				extend: jest.fn( ( definition ) => {
+					fieldDefinition = definition;
+					return definition;
+				} ),
+			},
+			registerFieldType: jest.fn(),
+			newSelect2: jest.fn().mockReturnValue( {
+				destroy: jest.fn(),
+			} ),
+		};
+
+		// Load the select field module
+		jest.isolateModules( () => {
+			require( '../../../assets/src/js/_acf-field-select.js' );
+		} );
+
+		// Create a mock field instance with the captured definition
+		mockField = {
+			...fieldDefinition,
+			$: jest.fn(),
+			get: jest.fn(),
+			inherit: jest.fn(),
+		};
+	} );
+
+	afterEach( () => {
+		delete global.acf;
+	} );
+
+	describe( 'Field Definition', () => {
+		it( 'should have type "select"', () => {
+			expect( fieldDefinition.type ).toBe( 'select' );
+		} );
+
+		it( 'should wait for "load" action', () => {
+			expect( fieldDefinition.wait ).toBe( 'load' );
+		} );
+
+		it( 'should have select2 property initialized to false', () => {
+			expect( fieldDefinition.select2 ).toBe( false );
+		} );
+
+		it( 'should register removeField and duplicateField events', () => {
+			expect( fieldDefinition.events ).toEqual( {
+				removeField: 'onRemove',
+				duplicateField: 'onDuplicate',
+			} );
+		} );
+	} );
+
+	describe( '$input()', () => {
+		it( 'should find select element', () => {
+			fieldDefinition.$input.call( mockField );
+
+			expect( mockField.$ ).toHaveBeenCalledWith( 'select' );
+		} );
+	} );
+
+	describe( 'initialize()', () => {
+		it( 'should inherit data from select element', () => {
+			const mockSelect = { data: jest.fn() };
+			mockField.$ = jest.fn().mockReturnValue( mockSelect );
+			mockField.get = jest.fn().mockReturnValue( false );
+
+			fieldDefinition.initialize.call( mockField );
+
+			expect( mockField.inherit ).toHaveBeenCalledWith( mockSelect );
+		} );
+
+		it( 'should create select2 when ui is enabled', () => {
+			const mockSelect = { data: jest.fn() };
+			mockField.$ = jest.fn().mockReturnValue( mockSelect );
+			mockField.get = jest.fn( ( key ) => {
+				const values = {
+					ui: true,
+					ajax: false,
+					multiple: false,
+					placeholder: 'Select...',
+					allow_null: true,
+					create_options: false,
+					ajax_action: null,
+					type: 'select',
+				};
+				return values[ key ];
+			} );
+
+			fieldDefinition.initialize.call( mockField );
+
+			expect( global.acf.newSelect2 ).toHaveBeenCalledWith( mockSelect, {
+				field: mockField,
+				ajax: false,
+				multiple: false,
+				placeholder: 'Select...',
+				allowNull: true,
+				tags: false,
+				ajaxAction: 'acf/fields/select/query',
+			} );
+		} );
+
+		it( 'should use custom ajax_action when provided', () => {
+			const mockSelect = { data: jest.fn() };
+			mockField.$ = jest.fn().mockReturnValue( mockSelect );
+			mockField.get = jest.fn( ( key ) => {
+				const values = {
+					ui: true,
+					ajax_action: 'custom_action',
+					type: 'select',
+				};
+				return values[ key ];
+			} );
+
+			fieldDefinition.initialize.call( mockField );
+
+			expect( global.acf.newSelect2 ).toHaveBeenCalledWith(
+				mockSelect,
+				expect.objectContaining( {
+					ajaxAction: 'custom_action',
+				} )
+			);
+		} );
+
+		it( 'should not create select2 when ui is disabled', () => {
+			const mockSelect = { data: jest.fn() };
+			mockField.$ = jest.fn().mockReturnValue( mockSelect );
+			mockField.get = jest.fn().mockReturnValue( false );
+
+			fieldDefinition.initialize.call( mockField );
+
+			expect( global.acf.newSelect2 ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'onRemove()', () => {
+		it( 'should destroy select2 when it exists', () => {
+			const mockSelect2 = { destroy: jest.fn() };
+			mockField.select2 = mockSelect2;
+
+			fieldDefinition.onRemove.call( mockField );
+
+			expect( mockSelect2.destroy ).toHaveBeenCalled();
+		} );
+
+		it( 'should do nothing when select2 does not exist', () => {
+			mockField.select2 = null;
+
+			expect( () => {
+				fieldDefinition.onRemove.call( mockField );
+			} ).not.toThrow();
+		} );
+	} );
+
+	describe( 'onDuplicate()', () => {
+		it( 'should remove select2 container from duplicate', () => {
+			const mockSelect2Container = {
+				remove: jest.fn(),
+			};
+			const mockSelectElement = {
+				removeClass: jest.fn().mockReturnThis(),
+			};
+			const mockDuplicate = {
+				find: jest.fn( ( selector ) => {
+					if ( selector === '.select2-container' ) {
+						return mockSelect2Container;
+					}
+					return mockSelectElement;
+				} ),
+			};
+			mockField.select2 = { destroy: jest.fn() };
+
+			fieldDefinition.onDuplicate.call(
+				mockField,
+				{},
+				{},
+				mockDuplicate
+			);
+
+			expect( mockDuplicate.find ).toHaveBeenCalledWith(
+				'.select2-container'
+			);
+			expect( mockSelect2Container.remove ).toHaveBeenCalled();
+		} );
+
+		it( 'should remove select2-hidden-accessible class from select', () => {
+			const mockSelect = {
+				removeClass: jest.fn().mockReturnThis(),
+			};
+			const mockDuplicate = {
+				find: jest.fn( ( selector ) => {
+					if ( selector === 'select' ) {
+						return mockSelect;
+					}
+					return { remove: jest.fn() };
+				} ),
+			};
+			mockField.select2 = { destroy: jest.fn() };
+
+			fieldDefinition.onDuplicate.call(
+				mockField,
+				{},
+				{},
+				mockDuplicate
+			);
+
+			expect( mockDuplicate.find ).toHaveBeenCalledWith( 'select' );
+			expect( mockSelect.removeClass ).toHaveBeenCalledWith(
+				'select2-hidden-accessible'
+			);
+		} );
+
+		it( 'should do nothing when select2 does not exist', () => {
+			mockField.select2 = null;
+			const mockDuplicate = {
+				find: jest.fn(),
+			};
+
+			fieldDefinition.onDuplicate.call(
+				mockField,
+				{},
+				{},
+				mockDuplicate
+			);
+
+			expect( mockDuplicate.find ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/tests/js/fields/true-false.test.js
+++ b/tests/js/fields/true-false.test.js
@@ -1,0 +1,267 @@
+/**
+ * Unit tests for true_false field type
+ */
+
+describe( 'True/False Field', () => {
+	let fieldDefinition;
+	let mockField;
+
+	beforeEach( () => {
+		// Reset mocks
+		fieldDefinition = null;
+
+		// Mock acf.Field.extend to capture the field definition
+		global.acf = {
+			Field: {
+				extend: jest.fn( ( definition ) => {
+					fieldDefinition = definition;
+					return definition;
+				} ),
+			},
+			registerFieldType: jest.fn(),
+		};
+
+		// Load the true_false field module
+		jest.isolateModules( () => {
+			require( '../../../assets/src/js/_acf-field-true-false.js' );
+		} );
+
+		// Create a mock field instance with the captured definition
+		mockField = {
+			...fieldDefinition,
+			$: jest.fn(),
+		};
+	} );
+
+	afterEach( () => {
+		delete global.acf;
+	} );
+
+	describe( 'Field Definition', () => {
+		it( 'should have type "true_false"', () => {
+			expect( fieldDefinition.type ).toBe( 'true_false' );
+		} );
+
+		it( 'should register switch-related events', () => {
+			expect( fieldDefinition.events ).toEqual( {
+				'change .acf-switch-input': 'onChange',
+				'focus .acf-switch-input': 'onFocus',
+				'blur .acf-switch-input': 'onBlur',
+				'keypress .acf-switch-input': 'onKeypress',
+			} );
+		} );
+	} );
+
+	describe( '$input()', () => {
+		it( 'should find checkbox input element', () => {
+			fieldDefinition.$input.call( mockField );
+
+			expect( mockField.$ ).toHaveBeenCalledWith(
+				'input[type="checkbox"]'
+			);
+		} );
+	} );
+
+	describe( '$switch()', () => {
+		it( 'should find .acf-switch element', () => {
+			fieldDefinition.$switch.call( mockField );
+
+			expect( mockField.$ ).toHaveBeenCalledWith( '.acf-switch' );
+		} );
+	} );
+
+	describe( 'getValue()', () => {
+		it( 'should return 1 when checked', () => {
+			const mockInput = { prop: jest.fn().mockReturnValue( true ) };
+			mockField.$input = jest.fn().mockReturnValue( mockInput );
+
+			const result = fieldDefinition.getValue.call( mockField );
+
+			expect( mockInput.prop ).toHaveBeenCalledWith( 'checked' );
+			expect( result ).toBe( 1 );
+		} );
+
+		it( 'should return 0 when unchecked', () => {
+			const mockInput = { prop: jest.fn().mockReturnValue( false ) };
+			mockField.$input = jest.fn().mockReturnValue( mockInput );
+
+			const result = fieldDefinition.getValue.call( mockField );
+
+			expect( result ).toBe( 0 );
+		} );
+	} );
+
+	describe( 'initialize()', () => {
+		it( 'should call render method', () => {
+			const renderSpy = jest.fn();
+			mockField.render = renderSpy;
+
+			fieldDefinition.initialize.call( mockField );
+
+			expect( renderSpy ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'render()', () => {
+		let mockSwitch;
+		let mockOn;
+		let mockOff;
+
+		beforeEach( () => {
+			mockOn = {
+				width: jest.fn().mockReturnValue( 50 ),
+				css: jest.fn(),
+			};
+			mockOff = {
+				width: jest.fn().mockReturnValue( 40 ),
+				css: jest.fn(),
+			};
+			mockSwitch = {
+				length: 1,
+				children: jest.fn( ( selector ) => {
+					if ( selector === '.acf-switch-on' ) {
+						return mockOn;
+					}
+					if ( selector === '.acf-switch-off' ) {
+						return mockOff;
+					}
+					return { width: jest.fn(), css: jest.fn() };
+				} ),
+			};
+			mockField.$switch = jest.fn().mockReturnValue( mockSwitch );
+		} );
+
+		it( 'should set min-width based on max of on/off widths', () => {
+			fieldDefinition.render.call( mockField );
+
+			// Max width is 50 (from mockOn)
+			expect( mockOn.css ).toHaveBeenCalledWith( 'min-width', 50 );
+			expect( mockOff.css ).toHaveBeenCalledWith( 'min-width', 50 );
+		} );
+
+		it( 'should bail early if no switch element', () => {
+			mockSwitch.length = 0;
+			mockField.$switch = jest.fn().mockReturnValue( mockSwitch );
+
+			fieldDefinition.render.call( mockField );
+
+			expect( mockSwitch.children ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should bail early if width is 0', () => {
+			mockOn.width.mockReturnValue( 0 );
+			mockOff.width.mockReturnValue( 0 );
+
+			fieldDefinition.render.call( mockField );
+
+			expect( mockOn.css ).not.toHaveBeenCalled();
+			expect( mockOff.css ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'switchOn()', () => {
+		it( 'should check the input and add -on class', () => {
+			const mockInput = { prop: jest.fn() };
+			const mockSwitch = { addClass: jest.fn() };
+			mockField.$input = jest.fn().mockReturnValue( mockInput );
+			mockField.$switch = jest.fn().mockReturnValue( mockSwitch );
+
+			fieldDefinition.switchOn.call( mockField );
+
+			expect( mockInput.prop ).toHaveBeenCalledWith( 'checked', true );
+			expect( mockSwitch.addClass ).toHaveBeenCalledWith( '-on' );
+		} );
+	} );
+
+	describe( 'switchOff()', () => {
+		it( 'should uncheck the input and remove -on class', () => {
+			const mockInput = { prop: jest.fn() };
+			const mockSwitch = { removeClass: jest.fn() };
+			mockField.$input = jest.fn().mockReturnValue( mockInput );
+			mockField.$switch = jest.fn().mockReturnValue( mockSwitch );
+
+			fieldDefinition.switchOff.call( mockField );
+
+			expect( mockInput.prop ).toHaveBeenCalledWith( 'checked', false );
+			expect( mockSwitch.removeClass ).toHaveBeenCalledWith( '-on' );
+		} );
+	} );
+
+	describe( 'onChange()', () => {
+		it( 'should call switchOn when input is checked', () => {
+			const switchOnSpy = jest.fn();
+			mockField.switchOn = switchOnSpy;
+			mockField.switchOff = jest.fn();
+
+			const mockEl = { prop: jest.fn().mockReturnValue( true ) };
+
+			fieldDefinition.onChange.call( mockField, {}, mockEl );
+
+			expect( switchOnSpy ).toHaveBeenCalled();
+		} );
+
+		it( 'should call switchOff when input is unchecked', () => {
+			const switchOffSpy = jest.fn();
+			mockField.switchOn = jest.fn();
+			mockField.switchOff = switchOffSpy;
+
+			const mockEl = { prop: jest.fn().mockReturnValue( false ) };
+
+			fieldDefinition.onChange.call( mockField, {}, mockEl );
+
+			expect( switchOffSpy ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'onFocus()', () => {
+		it( 'should add -focus class to switch', () => {
+			const mockSwitch = { addClass: jest.fn() };
+			mockField.$switch = jest.fn().mockReturnValue( mockSwitch );
+
+			fieldDefinition.onFocus.call( mockField, {}, {} );
+
+			expect( mockSwitch.addClass ).toHaveBeenCalledWith( '-focus' );
+		} );
+	} );
+
+	describe( 'onBlur()', () => {
+		it( 'should remove -focus class from switch', () => {
+			const mockSwitch = { removeClass: jest.fn() };
+			mockField.$switch = jest.fn().mockReturnValue( mockSwitch );
+
+			fieldDefinition.onBlur.call( mockField, {}, {} );
+
+			expect( mockSwitch.removeClass ).toHaveBeenCalledWith( '-focus' );
+		} );
+	} );
+
+	describe( 'onKeypress()', () => {
+		it( 'should call switchOff on left arrow key (37)', () => {
+			const switchOffSpy = jest.fn();
+			mockField.switchOff = switchOffSpy;
+
+			fieldDefinition.onKeypress.call( mockField, { keyCode: 37 }, {} );
+
+			expect( switchOffSpy ).toHaveBeenCalled();
+		} );
+
+		it( 'should call switchOn on right arrow key (39)', () => {
+			const switchOnSpy = jest.fn();
+			mockField.switchOn = switchOnSpy;
+
+			fieldDefinition.onKeypress.call( mockField, { keyCode: 39 }, {} );
+
+			expect( switchOnSpy ).toHaveBeenCalled();
+		} );
+
+		it( 'should not react to other keys', () => {
+			mockField.switchOn = jest.fn();
+			mockField.switchOff = jest.fn();
+
+			fieldDefinition.onKeypress.call( mockField, { keyCode: 13 }, {} );
+
+			expect( mockField.switchOn ).not.toHaveBeenCalled();
+			expect( mockField.switchOff ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/tests/js/fields/url.test.js
+++ b/tests/js/fields/url.test.js
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for url field type
+ */
+
+describe( 'URL Field', () => {
+	let fieldDefinition;
+	let mockField;
+
+	beforeEach( () => {
+		// Reset mocks
+		fieldDefinition = null;
+
+		// Mock acf.Field.extend to capture the field definition
+		global.acf = {
+			Field: {
+				extend: jest.fn( ( definition ) => {
+					fieldDefinition = definition;
+					return definition;
+				} ),
+			},
+			registerFieldType: jest.fn(),
+		};
+
+		// Load the url field module
+		jest.isolateModules( () => {
+			require( '../../../assets/src/js/_acf-field-url.js' );
+		} );
+
+		// Create a mock field instance with the captured definition
+		mockField = {
+			...fieldDefinition,
+			$: jest.fn(),
+			val: jest.fn(),
+		};
+	} );
+
+	afterEach( () => {
+		delete global.acf;
+	} );
+
+	describe( 'Field Definition', () => {
+		it( 'should have type "url"', () => {
+			expect( fieldDefinition.type ).toBe( 'url' );
+		} );
+
+		it( 'should register keyup event on url input', () => {
+			expect( fieldDefinition.events ).toEqual( {
+				'keyup input[type="url"]': 'onkeyup',
+			} );
+		} );
+	} );
+
+	describe( '$control()', () => {
+		it( 'should find .acf-input-wrap element', () => {
+			fieldDefinition.$control.call( mockField );
+
+			expect( mockField.$ ).toHaveBeenCalledWith( '.acf-input-wrap' );
+		} );
+	} );
+
+	describe( '$input()', () => {
+		it( 'should find url input element', () => {
+			fieldDefinition.$input.call( mockField );
+
+			expect( mockField.$ ).toHaveBeenCalledWith( 'input[type="url"]' );
+		} );
+	} );
+
+	describe( 'initialize()', () => {
+		it( 'should call render method', () => {
+			const renderSpy = jest.fn();
+			mockField.render = renderSpy;
+
+			fieldDefinition.initialize.call( mockField );
+
+			expect( renderSpy ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'isValid()', () => {
+		it( 'should return false for empty value', () => {
+			mockField.val = jest.fn().mockReturnValue( '' );
+
+			const result = fieldDefinition.isValid.call( mockField );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'should return false for null value', () => {
+			mockField.val = jest.fn().mockReturnValue( null );
+
+			const result = fieldDefinition.isValid.call( mockField );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'should return true for URL with protocol', () => {
+			mockField.val = jest.fn().mockReturnValue( 'https://example.com' );
+
+			const result = fieldDefinition.isValid.call( mockField );
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'should return true for http URL', () => {
+			mockField.val = jest.fn().mockReturnValue( 'http://example.com' );
+
+			const result = fieldDefinition.isValid.call( mockField );
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'should return true for ftp URL', () => {
+			mockField.val = jest
+				.fn()
+				.mockReturnValue( 'ftp://files.example.com' );
+
+			const result = fieldDefinition.isValid.call( mockField );
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'should return true for protocol-relative URL', () => {
+			mockField.val = jest.fn().mockReturnValue( '//example.com/path' );
+
+			const result = fieldDefinition.isValid.call( mockField );
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'should return false for URL without protocol', () => {
+			mockField.val = jest.fn().mockReturnValue( 'example.com' );
+
+			const result = fieldDefinition.isValid.call( mockField );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'should return false for relative path', () => {
+			mockField.val = jest.fn().mockReturnValue( '/path/to/page' );
+
+			const result = fieldDefinition.isValid.call( mockField );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'should return false for malformed URL', () => {
+			mockField.val = jest.fn().mockReturnValue( 'not a url' );
+
+			const result = fieldDefinition.isValid.call( mockField );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'should return true for URL with port', () => {
+			mockField.val = jest
+				.fn()
+				.mockReturnValue( 'http://localhost:8080/path' );
+
+			const result = fieldDefinition.isValid.call( mockField );
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'should return true for URL with query string', () => {
+			mockField.val = jest
+				.fn()
+				.mockReturnValue( 'https://example.com?foo=bar' );
+
+			const result = fieldDefinition.isValid.call( mockField );
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'should return true for URL with fragment', () => {
+			mockField.val = jest
+				.fn()
+				.mockReturnValue( 'https://example.com#section' );
+
+			const result = fieldDefinition.isValid.call( mockField );
+
+			expect( result ).toBe( true );
+		} );
+	} );
+
+	describe( 'render()', () => {
+		let mockControl;
+
+		beforeEach( () => {
+			mockControl = {
+				addClass: jest.fn().mockReturnThis(),
+				removeClass: jest.fn().mockReturnThis(),
+			};
+			mockField.$control = jest.fn().mockReturnValue( mockControl );
+		} );
+
+		it( 'should add -valid class when URL is valid', () => {
+			mockField.isValid = jest.fn().mockReturnValue( true );
+
+			fieldDefinition.render.call( mockField );
+
+			expect( mockControl.addClass ).toHaveBeenCalledWith( '-valid' );
+		} );
+
+		it( 'should remove -valid class when URL is invalid', () => {
+			mockField.isValid = jest.fn().mockReturnValue( false );
+
+			fieldDefinition.render.call( mockField );
+
+			expect( mockControl.removeClass ).toHaveBeenCalledWith( '-valid' );
+		} );
+	} );
+
+	describe( 'onkeyup()', () => {
+		it( 'should call render method', () => {
+			const renderSpy = jest.fn();
+			mockField.render = renderSpy;
+
+			fieldDefinition.onkeyup.call( mockField, {}, {} );
+
+			expect( renderSpy ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Integration scenarios', () => {
+		it( 'should update validation state as user types', () => {
+			const mockControl = {
+				addClass: jest.fn().mockReturnThis(),
+				removeClass: jest.fn().mockReturnThis(),
+			};
+			mockField.$control = jest.fn().mockReturnValue( mockControl );
+
+			// Initially empty - invalid
+			mockField.val = jest.fn().mockReturnValue( '' );
+			fieldDefinition.render.call( mockField );
+			expect( mockControl.removeClass ).toHaveBeenCalledWith( '-valid' );
+
+			// User types partial URL - still invalid
+			mockField.val = jest.fn().mockReturnValue( 'https://' );
+			fieldDefinition.render.call( mockField );
+			expect( mockControl.removeClass ).toHaveBeenLastCalledWith(
+				'-valid'
+			);
+
+			// User completes URL - valid
+			mockField.val = jest.fn().mockReturnValue( 'https://example.com' );
+			fieldDefinition.render.call( mockField );
+			expect( mockControl.addClass ).toHaveBeenCalledWith( '-valid' );
+		} );
+	} );
+} );

--- a/tests/js/model.test.js
+++ b/tests/js/model.test.js
@@ -1,0 +1,613 @@
+/**
+ * Unit tests for the core Model class (_acf-model.js)
+ *
+ * Tests the Model base class which provides:
+ * - Data management (get, set, has, inherit)
+ * - Event handling (on, off, trigger)
+ * - Action/filter integration
+ * - DOM element management
+ */
+
+describe( 'Model Class', () => {
+	let modelDefinition;
+	let mockJQuery;
+
+	beforeEach( () => {
+		// Create a chainable mock jQuery element
+		mockJQuery = {
+			data: jest.fn().mockReturnThis(),
+			find: jest.fn().mockReturnThis(),
+			on: jest.fn().mockReturnThis(),
+			off: jest.fn().mockReturnThis(),
+			trigger: jest.fn().mockReturnThis(),
+			triggerHandler: jest.fn().mockReturnThis(),
+			prop: jest.fn().mockReturnThis(),
+			remove: jest.fn().mockReturnThis(),
+		};
+
+		// Mock jQuery function
+		global.jQuery = jest.fn( () => mockJQuery );
+		global.jQuery.extend = jest.fn( ( target, ...sources ) => {
+			return Object.assign( target || {}, ...sources );
+		} );
+		global.jQuery.proxy = jest.fn( ( fn, context ) => fn.bind( context ) );
+		global.$ = global.jQuery;
+
+		// Mock acf global
+		global.acf = {
+			uniqueId: jest.fn( ( prefix ) => `${ prefix }123` ),
+			didAction: jest.fn().mockReturnValue( true ),
+			addAction: jest.fn(),
+			removeAction: jest.fn(),
+			addFilter: jest.fn(),
+			removeFilter: jest.fn(),
+			doAction: jest.fn(),
+			arrayArgs: jest.fn( ( args ) => Array.from( args ) ),
+			show: jest.fn(),
+			hide: jest.fn(),
+			strPascalCase: jest.fn( ( str ) =>
+				str
+					.split( '_' )
+					.map( ( s ) => s.charAt( 0 ).toUpperCase() + s.slice( 1 ) )
+					.join( '' )
+			),
+			models: {},
+		};
+
+		// Load the model module
+		jest.isolateModules( () => {
+			require( '../../assets/src/js/_acf-model.js' );
+		} );
+
+		// Capture the Model class
+		modelDefinition = global.acf.Model;
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+		delete global.jQuery;
+		delete global.$;
+		delete global.acf;
+	} );
+
+	describe( 'Model constructor', () => {
+		it( 'should generate a unique client ID', () => {
+			const instance = new modelDefinition();
+
+			expect( global.acf.uniqueId ).toHaveBeenCalledWith( 'acf' );
+			expect( instance.cid ).toBe( 'acf123' );
+		} );
+
+		it( 'should clone data to avoid prototype modification', () => {
+			const instance1 = new modelDefinition();
+			const instance2 = new modelDefinition();
+
+			instance1.data.testValue = 'instance1';
+			instance2.data.testValue = 'instance2';
+
+			expect( instance1.data.testValue ).not.toBe(
+				instance2.data.testValue
+			);
+		} );
+
+		it( 'should call setup with provided arguments', () => {
+			const setupSpy = jest.fn();
+			const CustomModel = modelDefinition.extend( {
+				setup: setupSpy,
+			} );
+
+			const props = { test: 'value' };
+			new CustomModel( props );
+
+			expect( setupSpy ).toHaveBeenCalledWith( props );
+		} );
+	} );
+
+	describe( 'Data Management', () => {
+		let instance;
+
+		beforeEach( () => {
+			instance = new modelDefinition();
+		} );
+
+		describe( 'get()', () => {
+			it( 'should return the value for a given key', () => {
+				instance.data.testKey = 'testValue';
+
+				expect( instance.get( 'testKey' ) ).toBe( 'testValue' );
+			} );
+
+			it( 'should return undefined for non-existent keys', () => {
+				expect( instance.get( 'nonExistent' ) ).toBeUndefined();
+			} );
+		} );
+
+		describe( 'has()', () => {
+			it( 'should return true when value exists and is not null', () => {
+				instance.data.testKey = 'testValue';
+
+				expect( instance.has( 'testKey' ) ).toBe( true );
+			} );
+
+			it( 'should return false when value is null', () => {
+				instance.data.testKey = null;
+
+				expect( instance.has( 'testKey' ) ).toBe( false );
+			} );
+
+			it( 'should return false when value is undefined', () => {
+				expect( instance.has( 'nonExistent' ) ).toBe( false );
+			} );
+
+			it( 'should return true for falsy non-null values', () => {
+				instance.data.zeroValue = 0;
+				instance.data.emptyString = '';
+				instance.data.falseValue = false;
+
+				expect( instance.has( 'zeroValue' ) ).toBe( true );
+				expect( instance.has( 'emptyString' ) ).toBe( true );
+				expect( instance.has( 'falseValue' ) ).toBe( true );
+			} );
+		} );
+
+		describe( 'set()', () => {
+			it( 'should set a data value', () => {
+				instance.set( 'newKey', 'newValue' );
+
+				expect( instance.data.newKey ).toBe( 'newValue' );
+			} );
+
+			it( 'should return this for chaining', () => {
+				const result = instance.set( 'key', 'value' );
+
+				expect( result ).toBe( instance );
+			} );
+
+			it( 'should not trigger events when value is unchanged', () => {
+				instance.data.key = 'value';
+				const triggerSpy = jest.spyOn( instance, 'trigger' );
+
+				instance.set( 'key', 'value' );
+
+				expect( triggerSpy ).not.toHaveBeenCalled();
+			} );
+
+			it( 'should trigger changed events when value changes', () => {
+				instance.$el = mockJQuery;
+				instance.data.key = 'oldValue';
+				const triggerSpy = jest.spyOn( instance, 'trigger' );
+
+				instance.set( 'key', 'newValue' );
+
+				expect( triggerSpy ).toHaveBeenCalledWith( 'changed:key', [
+					'newValue',
+					'oldValue',
+				] );
+				expect( triggerSpy ).toHaveBeenCalledWith( 'changed', [
+					'key',
+					'newValue',
+					'oldValue',
+				] );
+			} );
+
+			it( 'should set changed flag when value changes', () => {
+				instance.$el = mockJQuery;
+				instance.data.key = 'oldValue';
+
+				instance.set( 'key', 'newValue' );
+
+				expect( instance.changed ).toBe( true );
+			} );
+
+			it( 'should not trigger events when silent is true', () => {
+				instance.data.key = 'oldValue';
+				const triggerSpy = jest.spyOn( instance, 'trigger' );
+
+				instance.set( 'key', 'newValue', true );
+
+				expect( triggerSpy ).not.toHaveBeenCalled();
+			} );
+		} );
+
+		describe( 'inherit()', () => {
+			it( 'should extend data from a plain object', () => {
+				instance.inherit( { key1: 'value1', key2: 'value2' } );
+
+				expect( instance.data.key1 ).toBe( 'value1' );
+				expect( instance.data.key2 ).toBe( 'value2' );
+			} );
+
+			it( 'should return this for chaining', () => {
+				const result = instance.inherit( { key: 'value' } );
+
+				expect( result ).toBe( instance );
+			} );
+		} );
+	} );
+
+	describe( 'Element Helpers', () => {
+		let instance;
+
+		beforeEach( () => {
+			instance = new modelDefinition();
+			instance.$el = mockJQuery;
+		} );
+
+		describe( '$()', () => {
+			it( 'should find elements within $el', () => {
+				instance.$( '.test-selector' );
+
+				expect( mockJQuery.find ).toHaveBeenCalledWith(
+					'.test-selector'
+				);
+			} );
+		} );
+
+		describe( 'prop()', () => {
+			it( 'should call prop on $el', () => {
+				instance.prop( 'checked', true );
+
+				expect( mockJQuery.prop ).toHaveBeenCalledWith(
+					'checked',
+					true
+				);
+			} );
+		} );
+
+		describe( 'addElement()', () => {
+			it( 'should add element reference with $ prefix', () => {
+				instance.addElement( 'button', '.btn' );
+
+				expect( instance.$button ).toBeDefined();
+				expect( mockJQuery.find ).toHaveBeenCalledWith( '.btn' );
+			} );
+		} );
+
+		describe( 'addElements()', () => {
+			it( 'should add multiple element references', () => {
+				instance.elements = {
+					button: '.btn',
+					input: 'input[type="text"]',
+				};
+
+				instance.addElements();
+
+				expect( mockJQuery.find ).toHaveBeenCalledWith( '.btn' );
+				expect( mockJQuery.find ).toHaveBeenCalledWith(
+					'input[type="text"]'
+				);
+			} );
+
+			it( 'should return false when no elements defined', () => {
+				const result = instance.addElements();
+
+				expect( result ).toBe( false );
+			} );
+		} );
+	} );
+
+	describe( 'Event Handling', () => {
+		let instance;
+
+		beforeEach( () => {
+			instance = new modelDefinition();
+			instance.$el = mockJQuery;
+		} );
+
+		describe( 'getEventTarget()', () => {
+			it( 'should return provided element', () => {
+				const customEl = { custom: true };
+
+				const result = instance.getEventTarget( customEl );
+
+				expect( result ).toBe( customEl );
+			} );
+
+			it( 'should return $el when no element provided', () => {
+				const result = instance.getEventTarget();
+
+				expect( result ).toBe( mockJQuery );
+			} );
+		} );
+
+		describe( 'trigger()', () => {
+			it( 'should use triggerHandler for non-bubbling events', () => {
+				instance.trigger( 'customEvent', [ 'arg1' ] );
+
+				// Verify triggerHandler is used with correct event name
+				expect( mockJQuery.triggerHandler ).toHaveBeenCalledWith(
+					'customEvent',
+					expect.anything()
+				);
+			} );
+
+			it( 'should use trigger for bubbling events', () => {
+				instance.trigger( 'customEvent', [ 'arg1' ], true );
+
+				// Verify trigger is used with correct event name and args
+				expect( mockJQuery.trigger ).toHaveBeenCalledWith(
+					'customEvent',
+					[ 'arg1' ],
+					true
+				);
+			} );
+
+			it( 'should return this for chaining', () => {
+				const result = instance.trigger( 'event' );
+
+				expect( result ).toBe( instance );
+			} );
+		} );
+
+		describe( 'validateEvent()', () => {
+			it( 'should return true when no eventScope is set', () => {
+				const mockEvent = { target: document.createElement( 'div' ) };
+
+				expect( instance.validateEvent( mockEvent ) ).toBe( true );
+			} );
+		} );
+	} );
+
+	describe( 'Action/Filter Integration', () => {
+		let instance;
+
+		beforeEach( () => {
+			instance = new modelDefinition();
+			instance.testCallback = jest.fn();
+		} );
+
+		describe( 'addAction()', () => {
+			it( 'should call acf.addAction with correct parameters', () => {
+				instance.addAction( 'testAction', instance.testCallback );
+
+				expect( global.acf.addAction ).toHaveBeenCalledWith(
+					'testAction',
+					instance.testCallback,
+					10,
+					instance
+				);
+			} );
+
+			it( 'should use custom priority', () => {
+				instance.addAction( 'testAction', instance.testCallback, 5 );
+
+				expect( global.acf.addAction ).toHaveBeenCalledWith(
+					'testAction',
+					instance.testCallback,
+					5,
+					instance
+				);
+			} );
+
+			it( 'should resolve string callback names', () => {
+				instance.addAction( 'testAction', 'testCallback' );
+
+				expect( global.acf.addAction ).toHaveBeenCalledWith(
+					'testAction',
+					instance.testCallback,
+					10,
+					instance
+				);
+			} );
+		} );
+
+		describe( 'addFilter()', () => {
+			it( 'should call acf.addFilter with correct parameters', () => {
+				instance.addFilter( 'testFilter', instance.testCallback );
+
+				expect( global.acf.addFilter ).toHaveBeenCalledWith(
+					'testFilter',
+					instance.testCallback,
+					10,
+					instance
+				);
+			} );
+
+			it( 'should resolve string callback names', () => {
+				instance.addFilter( 'testFilter', 'testCallback' );
+
+				expect( global.acf.addFilter ).toHaveBeenCalledWith(
+					'testFilter',
+					instance.testCallback,
+					10,
+					instance
+				);
+			} );
+		} );
+
+		describe( 'addActions()', () => {
+			it( 'should add multiple actions from object', () => {
+				instance.actions = {
+					action1: 'testCallback',
+					action2: 'testCallback',
+				};
+
+				instance.addActions();
+
+				expect( global.acf.addAction ).toHaveBeenCalledTimes( 2 );
+			} );
+
+			it( 'should return falsy when no actions defined', () => {
+				const result = instance.addActions();
+
+				expect( result ).toBeFalsy();
+			} );
+		} );
+
+		describe( 'addFilters()', () => {
+			it( 'should add multiple filters from object', () => {
+				instance.filters = {
+					filter1: 'testCallback',
+					filter2: 'testCallback',
+				};
+
+				instance.addFilters();
+
+				expect( global.acf.addFilter ).toHaveBeenCalledTimes( 2 );
+			} );
+
+			it( 'should return falsy when no filters defined', () => {
+				const result = instance.addFilters();
+
+				expect( result ).toBeFalsy();
+			} );
+		} );
+	} );
+
+	describe( 'Visibility Methods', () => {
+		let instance;
+
+		beforeEach( () => {
+			instance = new modelDefinition();
+			instance.$el = mockJQuery;
+		} );
+
+		describe( 'show()', () => {
+			it( 'should call acf.show with $el', () => {
+				instance.show();
+
+				expect( global.acf.show ).toHaveBeenCalledWith( mockJQuery );
+			} );
+		} );
+
+		describe( 'hide()', () => {
+			it( 'should call acf.hide with $el', () => {
+				instance.hide();
+
+				expect( global.acf.hide ).toHaveBeenCalledWith( mockJQuery );
+			} );
+		} );
+	} );
+
+	describe( 'Cleanup', () => {
+		let instance;
+
+		beforeEach( () => {
+			instance = new modelDefinition();
+			instance.$el = mockJQuery;
+		} );
+
+		describe( 'remove()', () => {
+			it( 'should remove element and cleanup listeners', () => {
+				instance.remove();
+
+				expect( mockJQuery.remove ).toHaveBeenCalled();
+			} );
+		} );
+	} );
+
+	describe( 'Utility Methods', () => {
+		let instance;
+
+		beforeEach( () => {
+			instance = new modelDefinition();
+		} );
+
+		describe( 'proxy()', () => {
+			it( 'should bind callback to instance context', () => {
+				const callback = jest.fn( function () {
+					return this;
+				} );
+
+				const proxied = instance.proxy( callback );
+				const result = proxied();
+
+				expect( result ).toBe( instance );
+			} );
+		} );
+
+		describe( 'setTimeout()', () => {
+			it( 'should call setTimeout with proxied callback', () => {
+				jest.useFakeTimers();
+				const callback = jest.fn();
+
+				instance.setTimeout( callback, 100 );
+
+				// Callback should not be called before timeout
+				expect( callback ).not.toHaveBeenCalled();
+
+				jest.advanceTimersByTime( 100 );
+
+				// Callback should be called after timeout elapses
+				expect( callback ).toHaveBeenCalledTimes( 1 );
+
+				jest.useRealTimers();
+			} );
+		} );
+	} );
+
+	describe( 'Model.extend()', () => {
+		it( 'should create a subclass with extended prototype', () => {
+			const CustomModel = modelDefinition.extend( {
+				customMethod: jest.fn(),
+			} );
+
+			const instance = new CustomModel();
+
+			expect( typeof instance.customMethod ).toBe( 'function' );
+		} );
+
+		it( 'should inherit parent methods', () => {
+			const CustomModel = modelDefinition.extend( {} );
+			const instance = new CustomModel();
+
+			expect( typeof instance.get ).toBe( 'function' );
+			expect( typeof instance.set ).toBe( 'function' );
+		} );
+
+		it( 'should allow custom setup method', () => {
+			const customSetup = jest.fn();
+			const CustomModel = modelDefinition.extend( {
+				setup( ...args ) {
+					customSetup( ...args );
+				},
+			} );
+
+			new CustomModel( 'arg1', 'arg2' );
+
+			// setup should be called from constructor with the passed args
+			expect( customSetup ).toHaveBeenCalledWith( 'arg1', 'arg2' );
+		} );
+	} );
+
+	describe( 'acf.getInstance()', () => {
+		it( 'should return instance from element data', () => {
+			const mockInstance = { cid: 'test' };
+			const mockEl = {
+				data: jest.fn().mockReturnValue( mockInstance ),
+			};
+
+			const result = global.acf.getInstance( mockEl );
+
+			expect( mockEl.data ).toHaveBeenCalledWith( 'acf' );
+			expect( result ).toBe( mockInstance );
+		} );
+	} );
+
+	describe( 'acf.getInstances()', () => {
+		it( 'should return array of instances from multiple elements', () => {
+			const instances = [
+				{ cid: 'test1' },
+				{ cid: 'test2' },
+				{ cid: 'test3' },
+			];
+
+			// Mock jQuery with each method
+			const mockElements = {
+				each: jest.fn( ( callback ) => {
+					instances.forEach( ( inst ) => {
+						const mockEl = {
+							data: jest.fn().mockReturnValue( inst ),
+						};
+						global.jQuery.mockReturnValue( mockEl );
+						callback.call( mockEl );
+					} );
+				} ),
+			};
+
+			const result = global.acf.getInstances( mockElements );
+
+			expect( result ).toHaveLength( 3 );
+		} );
+	} );
+} );


### PR DESCRIPTION
## What
Part of #315.

Adds Jest unit tests for the core JavaScript Model and Field class system.

## Why

These classes are foundational to the JavaScript architecture.

## How

Adding 233 tests across 9 test files:

| File | Class Tested | Tests |
|------|--------------|-------|
| `model.test.js` | `acf.Model` | 47 |
| `field.test.js` | `acf.Field` | 55 |
| `fields.test.js` | Fields manager | 25 |
| `fields/select.test.js` | Select field | 24 |
| `fields/radio.test.js` | Radio field | 22 |
| `fields/true-false.test.js` | True/False field | 19 |
| `fields/range.test.js` | Range field | 13 |
| `fields/button-group.test.js` | Button Group field | 16 |
| `fields/url.test.js` | URL field | 20 |

## Testing Instructions

Run the test suite:
```bash
npm run test:unit
```