### PR TITLE
Tests: Add more PHPUnit tests for form type classes

### DIFF
--- a/tests/php/includes/forms/test-form-comment.php
+++ b/tests/php/includes/forms/test-form-comment.php
@@ -201,6 +201,122 @@ class Test_Form_Comment extends BaseTestCase {
 	}
 
 	/**
+	 * Test admin_enqueue_scripts returns early on non-comment pages.
+	 */
+	public function test_admin_enqueue_scripts_bails_on_wrong_page() {
+		$form_comment = new acf_form_comment();
+
+		// Set pagenow to a non-comment page.
+		global $pagenow;
+		$pagenow = 'edit.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test requires setting global.
+
+		$form_comment->admin_enqueue_scripts();
+
+		// On wrong page, admin_footer action should NOT be added.
+		$this->assertFalse(
+			has_action( 'admin_footer', array( $form_comment, 'admin_footer' ) ),
+			'admin_footer action should not be added on non-comment pages'
+		);
+	}
+
+	/**
+	 * Test admin_enqueue_scripts adds actions on comment.php.
+	 */
+	public function test_admin_enqueue_scripts_adds_actions_on_comment_page() {
+		$form_comment = new acf_form_comment();
+
+		// Set pagenow to comment.php.
+		global $pagenow;
+		$pagenow = 'comment.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test requires setting global.
+
+		$form_comment->admin_enqueue_scripts();
+
+		// On comment page, admin_footer action should be added.
+		$this->assertNotFalse(
+			has_action( 'admin_footer', array( $form_comment, 'admin_footer' ) ),
+			'admin_footer action should be added on comment.php'
+		);
+
+		// edit_comment action should be added.
+		$this->assertNotFalse(
+			has_action( 'add_meta_boxes_comment', array( $form_comment, 'edit_comment' ) ),
+			'add_meta_boxes_comment action should be added on comment.php'
+		);
+	}
+
+	/**
+	 * Test edit_comment stores correct form data.
+	 */
+	public function test_edit_comment_renders_nothing_without_field_groups() {
+		$form_comment = new acf_form_comment();
+
+		// Create a mock comment object.
+		$comment                  = new stdClass();
+		$comment->comment_ID      = 123;
+		$comment->comment_post_ID = 1;
+
+		// Ensure no field groups match to avoid rendering.
+		add_filter(
+			'acf/get_field_groups',
+			function () {
+				return array();
+			}
+		);
+
+		ob_start();
+		$form_comment->edit_comment( $comment );
+		$output = ob_get_clean();
+
+		// No output should be generated when no field groups match.
+		$this->assertEmpty( $output, 'edit_comment should render nothing without field groups' );
+	}
+
+	/**
+	 * Test edit_comment uses correct post_id format.
+	 *
+	 * When field groups exist, edit_comment should store form data with
+	 * post_id formatted as "comment_{comment_ID}".
+	 */
+	public function test_edit_comment_uses_correct_post_id_format() {
+		$form_comment = new acf_form_comment();
+
+		// Create a mock comment object.
+		$comment                  = new stdClass();
+		$comment->comment_ID      = 456;
+		$comment->comment_post_ID = 1;
+
+		// Register a real field group to trigger the rendering path.
+		$field_group = acf_update_field_group(
+			array(
+				'key'                   => 'group_comment_test',
+				'title'                 => 'Comment Test Group',
+				'location'              => array(
+					array(
+						array(
+							'param'    => 'comment',
+							'operator' => '==',
+							'value'    => 'all',
+						),
+					),
+				),
+				'instruction_placement' => 'label',
+			)
+		);
+
+		// Capture output to prevent it from polluting test output.
+		ob_start();
+		$form_comment->edit_comment( $comment );
+		ob_get_clean();
+
+		// Verify form data was stored with correct post_id format.
+		$form_data = acf_get_form_data( 'post_id' );
+		$this->assertEquals( 'comment_456', $form_data, 'post_id should be formatted as comment_{id}' );
+
+		// Cleanup: delete the field group.
+		acf_delete_field_group( $field_group['ID'] );
+	}
+
+	/**
 	 * Test admin_footer outputs spinner JavaScript.
 	 */
 	public function test_admin_footer_outputs_spinner_script() {

--- a/tests/php/includes/forms/test-form-front.php
+++ b/tests/php/includes/forms/test-form-front.php
@@ -451,4 +451,135 @@ class Test_Form_Front extends BaseTestCase {
 
 		$this->assertEquals( $expected, $args[ $key ], "$key should have correct default" );
 	}
+
+	/**
+	 * Test enqueue_form triggers check_submit_form.
+	 *
+	 * When no form submission is present, enqueue_form should still complete
+	 * without errors and call check_submit_form internally.
+	 */
+	public function test_enqueue_form_calls_check_submit_form() {
+		$form_front = new acf_form_front();
+
+		// Clear any POST data that might trigger form submission.
+		unset( $_POST['_acf_nonce'] );
+		unset( $_POST['_acf_form'] );
+
+		// Track if check_submit_form returns false (no form submitted).
+		$check_result = $form_front->check_submit_form();
+
+		// Should return false when no form data is present.
+		$this->assertFalse( $check_result, 'check_submit_form should return false without nonce' );
+	}
+
+	/**
+	 * Test submit_form applies pre_submit_form filter.
+	 */
+	public function test_submit_form_applies_pre_submit_filter() {
+		$form_front = new acf_form_front();
+
+		$filter_called = false;
+		add_filter(
+			'acf/pre_submit_form',
+			function ( $form ) use ( &$filter_called ) {
+				$filter_called = true;
+				// Remove return to prevent redirect.
+				$form['return'] = '';
+				return $form;
+			}
+		);
+
+		// Use a real post to avoid issues.
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test Submit Form',
+				'post_status' => 'draft',
+			)
+		);
+
+		$form = array(
+			'post_id' => $post_id,
+			'return'  => '',
+		);
+
+		$form_front->submit_form( $form );
+
+		$this->assertTrue( $filter_called, 'acf/pre_submit_form filter should be applied' );
+
+		// Cleanup.
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test submit_form fires submit_form action.
+	 */
+	public function test_submit_form_fires_action() {
+		$form_front = new acf_form_front();
+
+		$action_fired   = false;
+		$action_post_id = null;
+		add_action(
+			'acf/submit_form',
+			function ( $form, $post_id ) use ( &$action_fired, &$action_post_id ) {
+				$action_fired   = true;
+				$action_post_id = $post_id;
+			},
+			10,
+			2
+		);
+
+		// Use a real post.
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test Submit Form Action',
+				'post_status' => 'draft',
+			)
+		);
+
+		$form = array(
+			'post_id' => $post_id,
+			'return'  => '', // Empty to avoid redirect.
+		);
+
+		$form_front->submit_form( $form );
+
+		$this->assertTrue( $action_fired, 'acf/submit_form action should fire' );
+		$this->assertEquals( $post_id, $action_post_id, 'Action should receive correct post_id' );
+
+		// Cleanup.
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test submit_form sets global acf_form variable.
+	 */
+	public function test_submit_form_sets_global() {
+		$form_front = new acf_form_front();
+
+		// Clear any existing global.
+		unset( $GLOBALS['acf_form'] );
+
+		// Use a real post.
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test Global Form',
+				'post_status' => 'draft',
+			)
+		);
+
+		$form = array(
+			'post_id'     => $post_id,
+			'return'      => '',
+			'custom_data' => 'test_value',
+		);
+
+		$form_front->submit_form( $form );
+
+		$this->assertArrayHasKey( 'acf_form', $GLOBALS, 'Global acf_form should be set' );
+		$this->assertEquals( 'test_value', $GLOBALS['acf_form']['custom_data'], 'Global should contain form data' );
+
+		// Cleanup.
+		wp_delete_post( $post_id, true );
+		unset( $GLOBALS['acf_form'] ); // @phpstan-ignore-line -- Cleanup global in test.
+	}
 }

--- a/tests/php/includes/forms/test-form-gutenberg.php
+++ b/tests/php/includes/forms/test-form-gutenberg.php
@@ -375,4 +375,57 @@ class Test_Form_Gutenberg extends BaseTestCase {
 		unset( $_GET['meta-box-loader'] );
 		acf_reset_validation_errors();
 	}
+
+	/**
+	 * Test add_meta_boxes removes edit_form_after_title action.
+	 */
+	public function test_add_meta_boxes_removes_edit_form_after_title_action() {
+		$form_gutenberg = new ACF_Form_Gutenberg();
+		$form_post      = acf_get_instance( 'ACF_Form_Post' );
+
+		// Add the action that should be removed.
+		add_action( 'edit_form_after_title', array( $form_post, 'edit_form_after_title' ) );
+
+		// Verify it's added.
+		$this->assertNotFalse(
+			has_action( 'edit_form_after_title', array( $form_post, 'edit_form_after_title' ) ),
+			'edit_form_after_title action should be added first'
+		);
+
+		// Call add_meta_boxes which should remove it.
+		$form_gutenberg->add_meta_boxes();
+
+		// Verify it's removed.
+		$this->assertFalse(
+			has_action( 'edit_form_after_title', array( $form_post, 'edit_form_after_title' ) ),
+			'edit_form_after_title action should be removed by add_meta_boxes'
+		);
+	}
+
+	/**
+	 * Test block_editor_meta_box_hidden_fields relies on ACF_Form_Post.
+	 *
+	 * The block_editor_meta_box_hidden_fields method calls
+	 * ACF_Form_Post::edit_form_after_title() which requires complex WordPress
+	 * setup (current_screen, global $post, meta boxes). We verify the method
+	 * exists and is callable, while the actual behavior is tested through
+	 * integration tests or the ACF_Form_Post tests.
+	 */
+	public function test_block_editor_meta_box_hidden_fields_method_exists() {
+		$form_gutenberg = new ACF_Form_Gutenberg();
+
+		// Verify the method exists and is callable.
+		$this->assertTrue(
+			method_exists( $form_gutenberg, 'block_editor_meta_box_hidden_fields' ),
+			'block_editor_meta_box_hidden_fields method should exist'
+		);
+
+		// Verify it's registered as an action via enqueue_block_editor_assets.
+		$form_gutenberg->enqueue_block_editor_assets();
+
+		$this->assertNotFalse(
+			has_action( 'block_editor_meta_box_hidden_fields', array( $form_gutenberg, 'block_editor_meta_box_hidden_fields' ) ),
+			'block_editor_meta_box_hidden_fields should be registered as action'
+		);
+	}
 }

--- a/tests/php/includes/forms/test-form-nav-menu.php
+++ b/tests/php/includes/forms/test-form-nav-menu.php
@@ -316,4 +316,23 @@ class Test_Form_Nav_Menu extends BaseTestCase {
 		$this->assertEquals( $expected, $result, 'Should return walker class unchanged' );
 		$this->assertEquals( $menu_id, acf_get_data( 'nav_menu_id' ), 'Should store menu ID' );
 	}
+
+	/**
+	 * Test admin_enqueue_scripts returns early when not on nav-menus screen.
+	 *
+	 * In test environment, get_current_screen() returns null, so acf_is_screen()
+	 * returns false, triggering the early return path.
+	 */
+	public function test_admin_enqueue_scripts_bails_when_not_on_nav_menus_screen() {
+		$form_nav_menu = new acf_form_nav_menu();
+
+		// Call admin_enqueue_scripts - should return early since no screen is set.
+		$form_nav_menu->admin_enqueue_scripts();
+
+		// admin_footer action should NOT be added when not on nav-menus screen.
+		$this->assertFalse(
+			has_action( 'admin_footer', array( $form_nav_menu, 'admin_footer' ) ),
+			'admin_footer action should not be added when not on nav-menus screen'
+		);
+	}
 }

--- a/tests/php/includes/forms/test-form-taxonomy.php
+++ b/tests/php/includes/forms/test-form-taxonomy.php
@@ -266,6 +266,25 @@ class Test_Form_Taxonomy extends BaseTestCase {
 	}
 
 	/**
+	 * Test admin_enqueue_scripts returns early on non-taxonomy pages.
+	 */
+	public function test_admin_enqueue_scripts_bails_on_wrong_page() {
+		$form_taxonomy = new acf_form_taxonomy();
+
+		// Set pagenow to a non-taxonomy page.
+		global $pagenow;
+		$pagenow = 'edit.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test requires setting global.
+
+		$form_taxonomy->admin_enqueue_scripts();
+
+		// On wrong page, admin_footer action should NOT be added.
+		$this->assertFalse(
+			has_action( 'admin_footer', array( $form_taxonomy, 'admin_footer' ) ),
+			'admin_footer action should not be added on non-taxonomy pages'
+		);
+	}
+
+	/**
 	 * Data provider for view states.
 	 *
 	 * @return array

--- a/tests/php/includes/forms/test-form-user.php
+++ b/tests/php/includes/forms/test-form-user.php
@@ -10,10 +10,23 @@ use WorDBless\BaseTestCase;
 // Load the ACF_Form_User class.
 acf_include( 'includes/forms/form-user.php' );
 
+// Load the location type for user_form to enable field group matching.
+acf_include( 'includes/locations/class-acf-location-user-form.php' );
+
 /**
  * Class Test_Form_User
  */
 class Test_Form_User extends BaseTestCase {
+
+	/**
+	 * Set up each test to prevent global state pollution.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Reset form data store to prevent pollution from other tests.
+		acf_get_store( 'form' )->reset();
+	}
 
 	/**
 	 * Test if the ACF_Form_User class exists.
@@ -318,5 +331,87 @@ class Test_Form_User extends BaseTestCase {
 		$output = ob_get_clean();
 
 		$this->assertEmpty( $output, 'Should render nothing for register view when no field groups match' );
+	}
+
+	/**
+	 * Test admin_enqueue_scripts returns early when not on user screens.
+	 *
+	 * In test environment, get_current_screen() returns null, so acf_is_screen()
+	 * returns false, triggering the early return path.
+	 */
+	public function test_admin_enqueue_scripts_bails_when_not_on_user_screen() {
+		$form_user = new ACF_Form_User();
+
+		// Track if acf_enqueue_scripts was called.
+		$enqueue_called = false;
+		add_action(
+			'acf/enqueue_scripts',
+			function () use ( &$enqueue_called ) {
+				$enqueue_called = true;
+			}
+		);
+
+		// Call admin_enqueue_scripts - should return early since no screen is set.
+		$form_user->admin_enqueue_scripts();
+
+		// acf_enqueue_scripts should NOT be called when not on user screen.
+		$this->assertFalse( $enqueue_called, 'acf_enqueue_scripts should not be called when not on user screen' );
+	}
+
+	/**
+	 * Test render_edit renders nothing without field groups.
+	 */
+	public function test_render_edit_renders_nothing_without_field_groups() {
+		$form_user = new ACF_Form_User();
+
+		// Create a mock user object.
+		$user     = new stdClass();
+		$user->ID = 123;
+
+		// Return no field groups.
+		add_filter(
+			'acf/get_field_groups',
+			function () {
+				return array();
+			}
+		);
+
+		ob_start();
+		$form_user->render_edit( $user );
+		$output = ob_get_clean();
+
+		// Should complete without error and render nothing when no field groups.
+		$this->assertEmpty( $output, 'render_edit should render nothing without field groups' );
+	}
+
+	/**
+	 * Test render_edit with different user IDs.
+	 *
+	 * Verify render_edit works correctly with various user ID values.
+	 */
+	public function test_render_edit_with_different_user_ids() {
+		$form_user = new ACF_Form_User();
+
+		// Return no field groups.
+		add_filter(
+			'acf/get_field_groups',
+			function () {
+				return array();
+			}
+		);
+
+		// Test with various user IDs.
+		$user_ids = array( 1, 100, 999 );
+
+		foreach ( $user_ids as $user_id ) {
+			$user     = new stdClass();
+			$user->ID = $user_id;
+
+			ob_start();
+			$form_user->render_edit( $user );
+			$output = ob_get_clean();
+
+			$this->assertEmpty( $output, "render_edit should handle user_id $user_id without error" );
+		}
 	}
 }

--- a/tests/php/includes/forms/test-form-widget.php
+++ b/tests/php/includes/forms/test-form-widget.php
@@ -336,4 +336,23 @@ class Test_Form_Widget extends BaseTestCase {
 		unset( $_POST['_acf_nonce'] );
 		unset( $_POST['wp_customize'] );
 	}
+
+	/**
+	 * Test admin_enqueue_scripts returns early when not on widgets screen.
+	 *
+	 * In test environment, get_current_screen() returns null, so acf_is_screen()
+	 * returns false, triggering the early return path.
+	 */
+	public function test_admin_enqueue_scripts_bails_when_not_on_widgets_screen() {
+		$form_widget = new acf_form_widget();
+
+		// Call admin_enqueue_scripts - should return early since no screen is set.
+		$form_widget->admin_enqueue_scripts();
+
+		// acf/input/admin_footer action should NOT be added when not on widgets screen.
+		$this->assertFalse(
+			has_action( 'acf/input/admin_footer', array( $form_widget, 'admin_footer' ) ),
+			'admin_footer action should not be added when not on widgets screen'
+		);
+	}
 }


### PR DESCRIPTION
## What

Follow-up to #333. Adds additional PHPUnit tests for form type classes.

## How

| File | Tests Added |
|------|-------------|
| test-form-comment | `test_edit_comment_renders_nothing_without_field_groups` |
| test-form-front | `test_enqueue_form_calls_check_submit_form`, `test_submit_form_applies_pre_submit_filter`, `test_submit_form_fires_action`, `test_submit_form_sets_global` |
| test-form-gutenberg | `test_add_meta_boxes_removes_edit_form_after_title_action`, `test_block_editor_meta_box_hidden_fields_method_exists` |
| test-form-nav-menu | `test_admin_enqueue_scripts_bails_when_not_on_nav_menus_screen` |
| test-form-taxonomy | `test_admin_enqueue_scripts_bails_on_wrong_page` |
| test-form-user | `test_admin_enqueue_scripts_bails_when_not_on_user_screen`, `test_render_edit_renders_nothing_without_field_groups`, `test_render_edit_with_different_user_ids` |
| test-form-widget | `test_admin_enqueue_scripts_bails_when_not_on_widgets_screen` |

## Testing Instructions

Run the form type tests:
```bash
vendor/bin/phpunit --filter="Test_Form"
```