### PR TITLE
E2E CI polishing: add sharding and fix coverage accuracy

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,12 +2,7 @@
 # Reference: https://docs.codecov.com/docs/codecovyml-reference
 
 codecov:
-    # Wait for CI to pass before posting coverage status
     require_ci_to_pass: true
-    notify:
-        # Wait for all CI jobs to complete before computing coverage
-        # This ensures all shards have uploaded before status is reported
-        wait_for_ci: true
 
 flags:
     e2e-js:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,11 +1,21 @@
 # Codecov Configuration
 # Reference: https://docs.codecov.com/docs/codecovyml-reference
 
+codecov:
+    # Wait for CI to pass before posting coverage status
+    require_ci_to_pass: true
+    notify:
+        # Wait for all CI jobs to complete before computing coverage
+        # This ensures all shards have uploaded before status is reported
+        wait_for_ci: true
+
 flags:
     e2e-js:
         carryforward: true
         paths:
             - 'assets/src/'
+        # Some shards may not have JS coverage (REST API tests only)
+        # Carryforward handles missing uploads from those shards
     e2e-php:
         carryforward: true
         paths:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,15 +78,6 @@ jobs:
                   PHP_COVERAGE_ENABLED: true
               run: npm run test:e2e:coverage -- --shard=${{ matrix.shard }}/4
 
-            - name: Debug coverage directories
-              if: always()
-              run: |
-                  echo "Current directory: $(pwd)"
-                  echo "=== .nyc_output/ ==="
-                  ls -la .nyc_output/ 2>/dev/null || echo "Directory not found"
-                  echo "=== .php-coverage/ ==="
-                  ls -la .php-coverage/ 2>/dev/null || echo "Directory not found"
-
             - name: Upload E2E JS coverage artifact
               if: always()
               uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -163,6 +163,7 @@ jobs:
                   flags: e2e-js
                   slug: WordPress/secure-custom-fields
                   name: e2e-js-merged
+                  disable_search: true
 
             - name: Upload E2E PHP Coverage to Codecov
               if: ${{ hashFiles('./coverage/php-e2e/lcov.info') != '' }}
@@ -173,3 +174,4 @@ jobs:
                   flags: e2e-php
                   slug: WordPress/secure-custom-fields
                   name: e2e-php-merged
+                  disable_search: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,13 +90,7 @@ jobs:
 
             - name: Generate E2E PHP coverage report
               if: always()
-              run: |
-                  if [ -d ".php-coverage" ] && [ "$(ls -A .php-coverage 2>/dev/null)" ]; then
-                    echo "Generating PHP coverage report with baseline"
-                    npm run test:e2e:php-coverage:report
-                  else
-                    echo "No PHP coverage data found"
-                  fi
+              run: npm run test:e2e:php-coverage:report
 
             - name: Upload E2E JS Coverage to Codecov
               if: always() && hashFiles('./coverage/e2e/lcov.info') != ''

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ permissions: {}
 
 jobs:
     test:
-        name: Node ${{ matrix.node }} / WP ${{ matrix.wp }}
+        name: E2E - Node ${{ matrix.node }} / WP ${{ matrix.wp }} / Shard ${{ matrix.shard }}/4
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -27,6 +27,7 @@ jobs:
             fail-fast: false
             matrix:
                 event: ['${{ github.event_name }}']
+                shard: [1, 2, 3, 4]
                 node: ['22', '24']
                 wp: ['6.2', 'latest', 'trunk']
                 exclude:
@@ -75,7 +76,7 @@ jobs:
             - name: Run e2e tests with coverage
               env:
                   PHP_COVERAGE_ENABLED: true
-              run: npm run test:e2e:coverage
+              run: npm run test:e2e:coverage -- --shard=${{ matrix.shard }}/4
 
             - name: Generate LCOV report from Istanbul coverage
               if: always()
@@ -93,7 +94,7 @@ jobs:
                   files: ./coverage/e2e/lcov.info
                   flags: e2e-js
                   slug: WordPress/secure-custom-fields
-                  name: e2e-js-coverage
+                  name: e2e-js-node${{ matrix.node }}-wp${{ matrix.wp }}-shard${{ matrix.shard }}
 
             - name: Upload E2E PHP Coverage to Codecov
               if: always()
@@ -103,7 +104,7 @@ jobs:
                   files: ./coverage/php-e2e/lcov.info
                   flags: e2e-php
                   slug: WordPress/secure-custom-fields
-                  name: e2e-php-coverage
+                  name: e2e-php-node${{ matrix.node }}-wp${{ matrix.wp }}-shard${{ matrix.shard }}
 
             - name: Stop wp-env
               if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
                 node: ['22', '24']
                 wp: ['6.2', 'latest', 'trunk']
                 exclude:
-                    # On PRs: only test Node 22 + WP trunk for fast feedback
+                    # On PRs: only test Node 22 + WP latest for fast feedback
                     # On trunk: full matrix with minimum and latest WP versions
                     - event: 'pull_request'
                       node: '24'
@@ -78,100 +78,48 @@ jobs:
                   PHP_COVERAGE_ENABLED: true
               run: npm run test:e2e:coverage -- --shard=${{ matrix.shard }}/4
 
-            - name: Upload E2E JS coverage artifact
+            - name: Generate E2E JS coverage report
               if: always()
-              uses: actions/upload-artifact@v4
-              with:
-                  name: e2e-js-coverage-node${{ matrix.node }}-wp${{ matrix.wp }}-shard${{ matrix.shard }}
-                  path: .nyc_output/
-                  if-no-files-found: ignore
-                  include-hidden-files: true
-                  retention-days: 1
-
-            - name: Upload E2E PHP coverage artifact
-              if: always()
-              uses: actions/upload-artifact@v4
-              with:
-                  name: e2e-php-coverage-node${{ matrix.node }}-wp${{ matrix.wp }}-shard${{ matrix.shard }}
-                  path: .php-coverage/
-                  if-no-files-found: ignore
-                  include-hidden-files: true
-                  retention-days: 1
-
-            - name: Stop wp-env
-              if: always()
-              run: wp-env stop
-
-    coverage:
-        name: Merge and Upload Coverage
-        runs-on: ubuntu-latest
-        needs: test
-        if: always()
-        permissions:
-            contents: read
-
-        steps:
-            - uses: actions/checkout@v4
-
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: '22'
-                  cache: 'npm'
-
-            - name: Install dependencies
-              run: npm ci
-
-            - name: Download all E2E JS coverage artifacts
-              uses: actions/download-artifact@v4
-              with:
-                  pattern: e2e-js-coverage-*
-                  path: .nyc_output/
-                  merge-multiple: true
-
-            - name: Download all E2E PHP coverage artifacts
-              uses: actions/download-artifact@v4
-              with:
-                  pattern: e2e-php-coverage-*
-                  path: .php-coverage/
-                  merge-multiple: true
-
-            - name: Merge E2E JS coverage and generate report
               run: |
                   if [ -d ".nyc_output" ] && [ "$(ls -A .nyc_output 2>/dev/null)" ]; then
-                    echo "Merging E2E JS coverage from $(ls .nyc_output | wc -l) files"
+                    echo "Generating JS coverage report"
                     npm run test:e2e:coverage:report
                   else
-                    echo "No E2E JS coverage data found"
+                    echo "No JS coverage data found"
                   fi
 
-            - name: Merge E2E PHP coverage and generate report
+            - name: Generate E2E PHP coverage report
+              if: always()
               run: |
                   if [ -d ".php-coverage" ] && [ "$(ls -A .php-coverage 2>/dev/null)" ]; then
-                    echo "Merging E2E PHP coverage from $(ls .php-coverage | wc -l) files"
+                    echo "Generating PHP coverage report with baseline"
                     npm run test:e2e:php-coverage:report
                   else
-                    echo "No E2E PHP coverage data found"
+                    echo "No PHP coverage data found"
                   fi
 
             - name: Upload E2E JS Coverage to Codecov
-              if: ${{ hashFiles('./coverage/e2e/lcov.info') != '' }}
+              if: always() && hashFiles('./coverage/e2e/lcov.info') != ''
               uses: codecov/codecov-action@v5
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   files: ./coverage/e2e/lcov.info
                   flags: e2e-js
                   slug: WordPress/secure-custom-fields
-                  name: e2e-js-merged
+                  name: e2e-js-shard${{ matrix.shard }}
                   disable_search: true
 
             - name: Upload E2E PHP Coverage to Codecov
-              if: ${{ hashFiles('./coverage/php-e2e/lcov.info') != '' }}
+              if: always() && hashFiles('./coverage/php-e2e/lcov.info') != ''
               uses: codecov/codecov-action@v5
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   files: ./coverage/php-e2e/lcov.info
                   flags: e2e-php
                   slug: WordPress/secure-custom-fields
-                  name: e2e-php-merged
+                  name: e2e-php-shard${{ matrix.shard }}
                   disable_search: true
+
+            - name: Stop wp-env
+              if: always()
+              run: wp-env stop

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,6 +78,15 @@ jobs:
                   PHP_COVERAGE_ENABLED: true
               run: npm run test:e2e:coverage -- --shard=${{ matrix.shard }}/4
 
+            - name: Debug coverage directories
+              if: always()
+              run: |
+                  echo "Current directory: $(pwd)"
+                  echo "=== .nyc_output/ ==="
+                  ls -la .nyc_output/ 2>/dev/null || echo "Directory not found"
+                  echo "=== .php-coverage/ ==="
+                  ls -la .php-coverage/ 2>/dev/null || echo "Directory not found"
+
             - name: Upload E2E JS coverage artifact
               if: always()
               uses: actions/upload-artifact@v4
@@ -85,6 +94,7 @@ jobs:
                   name: e2e-js-coverage-node${{ matrix.node }}-wp${{ matrix.wp }}-shard${{ matrix.shard }}
                   path: .nyc_output/
                   if-no-files-found: ignore
+                  include-hidden-files: true
                   retention-days: 1
 
             - name: Upload E2E PHP coverage artifact
@@ -94,6 +104,7 @@ jobs:
                   name: e2e-php-coverage-node${{ matrix.node }}-wp${{ matrix.wp }}-shard${{ matrix.shard }}
                   path: .php-coverage/
                   if-no-files-found: ignore
+                  include-hidden-files: true
                   retention-days: 1
 
             - name: Stop wp-env

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,39 +78,96 @@ jobs:
                   PHP_COVERAGE_ENABLED: true
               run: npm run test:e2e:coverage -- --shard=${{ matrix.shard }}/4
 
-            - name: Generate LCOV report from Istanbul coverage
+            - name: Upload E2E JS coverage artifact
               if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: e2e-js-coverage-node${{ matrix.node }}-wp${{ matrix.wp }}-shard${{ matrix.shard }}
+                  path: .nyc_output/
+                  if-no-files-found: ignore
+                  retention-days: 1
+
+            - name: Upload E2E PHP coverage artifact
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: e2e-php-coverage-node${{ matrix.node }}-wp${{ matrix.wp }}-shard${{ matrix.shard }}
+                  path: .php-coverage/
+                  if-no-files-found: ignore
+                  retention-days: 1
+
+            - name: Stop wp-env
+              if: always()
+              run: wp-env stop
+
+    coverage:
+        name: Merge and Upload Coverage
+        runs-on: ubuntu-latest
+        needs: test
+        if: always()
+        permissions:
+            contents: read
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '22'
+                  cache: 'npm'
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Download all E2E JS coverage artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  pattern: e2e-js-coverage-*
+                  path: .nyc_output/
+                  merge-multiple: true
+
+            - name: Download all E2E PHP coverage artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  pattern: e2e-php-coverage-*
+                  path: .php-coverage/
+                  merge-multiple: true
+
+            - name: Merge E2E JS coverage and generate report
               run: |
-                  if [ -d ".nyc_output" ]; then
+                  if [ -d ".nyc_output" ] && [ "$(ls -A .nyc_output 2>/dev/null)" ]; then
+                    echo "Merging E2E JS coverage from $(ls .nyc_output | wc -l) files"
                     npm run test:e2e:coverage:report
                   else
-                    echo "No JS coverage data found for this shard, skipping report generation"
+                    echo "No E2E JS coverage data found"
                   fi
 
-            - name: Generate PHP coverage report
-              if: always()
-              run: npm run test:e2e:php-coverage:report
+            - name: Merge E2E PHP coverage and generate report
+              run: |
+                  if [ -d ".php-coverage" ] && [ "$(ls -A .php-coverage 2>/dev/null)" ]; then
+                    echo "Merging E2E PHP coverage from $(ls .php-coverage | wc -l) files"
+                    npm run test:e2e:php-coverage:report
+                  else
+                    echo "No E2E PHP coverage data found"
+                  fi
 
             - name: Upload E2E JS Coverage to Codecov
-              if: ${{ always() && hashFiles('./coverage/e2e/lcov.info') != '' }}
+              if: ${{ hashFiles('./coverage/e2e/lcov.info') != '' }}
               uses: codecov/codecov-action@v5
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   files: ./coverage/e2e/lcov.info
                   flags: e2e-js
                   slug: WordPress/secure-custom-fields
-                  name: e2e-js-node${{ matrix.node }}-wp${{ matrix.wp }}-shard${{ matrix.shard }}
+                  name: e2e-js-merged
 
             - name: Upload E2E PHP Coverage to Codecov
-              if: ${{ always() && hashFiles('./coverage/php-e2e/lcov.info') != '' }}
+              if: ${{ hashFiles('./coverage/php-e2e/lcov.info') != '' }}
               uses: codecov/codecov-action@v5
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   files: ./coverage/php-e2e/lcov.info
                   flags: e2e-php
                   slug: WordPress/secure-custom-fields
-                  name: e2e-php-node${{ matrix.node }}-wp${{ matrix.wp }}-shard${{ matrix.shard }}
-
-            - name: Stop wp-env
-              if: always()
-              run: wp-env stop
+                  name: e2e-php-merged

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,14 +80,19 @@ jobs:
 
             - name: Generate LCOV report from Istanbul coverage
               if: always()
-              run: npm run test:e2e:coverage:report
+              run: |
+                  if [ -d ".nyc_output" ]; then
+                    npm run test:e2e:coverage:report
+                  else
+                    echo "No JS coverage data found for this shard, skipping report generation"
+                  fi
 
             - name: Generate PHP coverage report
               if: always()
               run: npm run test:e2e:php-coverage:report
 
             - name: Upload E2E JS Coverage to Codecov
-              if: always()
+              if: ${{ always() && hashFiles('./coverage/e2e/lcov.info') != '' }}
               uses: codecov/codecov-action@v5
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
@@ -97,7 +102,7 @@ jobs:
                   name: e2e-js-node${{ matrix.node }}-wp${{ matrix.wp }}-shard${{ matrix.shard }}
 
             - name: Upload E2E PHP Coverage to Codecov
-              if: always()
+              if: ${{ always() && hashFiles('./coverage/php-e2e/lcov.info') != '' }}
               uses: codecov/codecov-action@v5
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}

--- a/scripts/merge-php-coverage.js
+++ b/scripts/merge-php-coverage.js
@@ -20,6 +20,7 @@ const path = require( 'path' );
 
 const COVERAGE_DIR = path.join( process.cwd(), '.php-coverage' );
 const OUTPUT_DIR = path.join( process.cwd(), 'coverage', 'php-e2e' );
+const SOURCE_DIR = path.join( process.cwd(), 'includes' );
 
 // Docker container path prefix to strip for relative paths.
 const CONTAINER_PLUGIN_PATH =
@@ -45,6 +46,166 @@ function parseArgs() {
 	} );
 
 	return args;
+}
+
+/**
+ * Recursively find all PHP files in a directory.
+ *
+ * @param {string} dir - Directory to scan.
+ * @param {Array}  files - Accumulator for found files.
+ * @return {Array} Array of absolute file paths.
+ */
+function findPhpFiles( dir, files = [] ) {
+	const entries = fs.readdirSync( dir, { withFileTypes: true } );
+
+	for ( const entry of entries ) {
+		const fullPath = path.join( dir, entry.name );
+
+		if ( entry.isDirectory() ) {
+			// Skip vendor, node_modules, tests directories.
+			if (
+				! [ 'vendor', 'node_modules', 'tests' ].includes( entry.name )
+			) {
+				findPhpFiles( fullPath, files );
+			}
+		} else if ( entry.isFile() && entry.name.endsWith( '.php' ) ) {
+			files.push( fullPath );
+		}
+	}
+
+	return files;
+}
+
+/**
+ * Parse a PHP file to find executable line numbers.
+ * Returns line numbers that contain executable code (not comments, not blank, not just braces).
+ *
+ * @param {string} filePath - Path to PHP file.
+ * @return {Array} Array of executable line numbers.
+ */
+function findExecutableLines( filePath ) {
+	const content = fs.readFileSync( filePath, 'utf8' );
+	const lines = content.split( '\n' );
+	const executableLines = [];
+
+	let inMultiLineComment = false;
+	let inHeredoc = false;
+	let heredocEnd = null;
+
+	for ( let i = 0; i < lines.length; i++ ) {
+		const lineNum = i + 1;
+		let line = lines[ i ].trim();
+
+		// Handle heredoc/nowdoc.
+		if ( inHeredoc ) {
+			if ( line === heredocEnd || line === heredocEnd + ';' ) {
+				inHeredoc = false;
+				heredocEnd = null;
+			}
+			continue;
+		}
+
+		// Check for heredoc/nowdoc start.
+		const heredocMatch = line.match( /<<<['"]?(\w+)['"]?$/ );
+		if ( heredocMatch ) {
+			inHeredoc = true;
+			heredocEnd = heredocMatch[ 1 ];
+			executableLines.push( lineNum );
+			continue;
+		}
+
+		// Handle multi-line comments.
+		if ( inMultiLineComment ) {
+			if ( line.includes( '*/' ) ) {
+				inMultiLineComment = false;
+				// Check if there's code after the comment end.
+				const afterComment = line.split( '*/' )[ 1 ].trim();
+				if ( afterComment && ! afterComment.startsWith( '//' ) ) {
+					executableLines.push( lineNum );
+				}
+			}
+			continue;
+		}
+
+		// Check for multi-line comment start.
+		if ( line.startsWith( '/*' ) || line.startsWith( '/**' ) ) {
+			if ( ! line.includes( '*/' ) ) {
+				inMultiLineComment = true;
+			}
+			continue;
+		}
+
+		// Skip empty lines.
+		if ( line === '' ) {
+			continue;
+		}
+
+		// Skip single-line comments.
+		if ( line.startsWith( '//' ) || line.startsWith( '#' ) ) {
+			continue;
+		}
+
+		// Skip PHP open/close tags alone.
+		if ( line === '<?php' || line === '?>' || line === '<?php' ) {
+			continue;
+		}
+
+		// Skip lines that are just braces or structural.
+		if ( /^[{})\]]+;?$/.test( line ) ) {
+			continue;
+		}
+
+		// Skip lines that are just class/function declarations without code.
+		// These are structural but we include them as they're part of the definition.
+		if (
+			/^(abstract\s+)?(class|interface|trait|enum)\s+\w+/.test( line ) ||
+			/^(public|private|protected|static|\s)*function\s+\w+/.test( line )
+		) {
+			executableLines.push( lineNum );
+			continue;
+		}
+
+		// Skip 'use' statements for traits (they're declarations).
+		if ( /^use\s+[\w\\]+\s*;/.test( line ) && ! line.includes( '(' ) ) {
+			continue;
+		}
+
+		// This line likely contains executable code.
+		executableLines.push( lineNum );
+	}
+
+	return executableLines;
+}
+
+/**
+ * Build baseline coverage from all PHP source files.
+ * Files not covered by PCOV will have all executable lines marked as uncovered.
+ *
+ * @return {Object} Baseline coverage data with all files and their executable lines.
+ */
+function buildBaselineCoverage() {
+	console.log( `Scanning PHP files in ${ SOURCE_DIR }...` );
+	const phpFiles = findPhpFiles( SOURCE_DIR );
+	console.log( `Found ${ phpFiles.length } PHP files.` );
+
+	const baseline = {};
+
+	for ( const file of phpFiles ) {
+		const executableLines = findExecutableLines( file );
+		if ( executableLines.length > 0 ) {
+			// Convert to container path format for consistency with PCOV output.
+			const relativePath = file.slice( process.cwd().length );
+			const containerPath = CONTAINER_PLUGIN_PATH + relativePath;
+
+			// Mark all executable lines as uncovered (-1 means executable but not hit).
+			baseline[ containerPath ] = {};
+			for ( const lineNum of executableLines ) {
+				baseline[ containerPath ][ lineNum ] = -1;
+			}
+		}
+	}
+
+	return baseline;
 }
 
 /**
@@ -314,17 +475,61 @@ function generateHtml( stats ) {
 function main() {
 	const args = parseArgs();
 
-	console.log( 'Merging PHP coverage files...' );
+	console.log( 'Building PHP coverage report...' );
 
-	const coverageFiles = readCoverageFiles();
+	// Step 1: Build baseline from all PHP source files.
+	const baseline = buildBaselineCoverage();
+	const baselineFileCount = Object.keys( baseline ).length;
 
-	if ( coverageFiles === null ) {
-		// No coverage files found, exit gracefully.
+	if ( baselineFileCount === 0 ) {
+		console.log( 'No PHP source files found in includes/.' );
 		return;
 	}
 
-	const merged = mergeCoverage( coverageFiles );
+	// Step 2: Read PCOV coverage files (if any).
+	const coverageFiles = readCoverageFiles();
+
+	// Step 3: Merge PCOV data on top of baseline.
+	// Start with baseline (all files, all lines marked as uncovered).
+	let merged = { ...baseline };
+
+	if ( coverageFiles !== null ) {
+		// Merge PCOV data - this will override baseline values with actual coverage.
+		const pcovMerged = mergeCoverage( coverageFiles );
+
+		// Merge PCOV data into baseline.
+		for ( const [ file, lines ] of Object.entries( pcovMerged ) ) {
+			if ( ! merged[ file ] ) {
+				// File from PCOV not in baseline (shouldn't happen, but handle it).
+				merged[ file ] = {};
+			}
+
+			for ( const [ lineNum, hitCount ] of Object.entries( lines ) ) {
+				// PCOV data takes precedence over baseline.
+				if ( hitCount > 0 ) {
+					merged[ file ][ lineNum ] = hitCount;
+				} else if (
+					! merged[ file ][ lineNum ] ||
+					merged[ file ][ lineNum ] < 0
+				) {
+					// Only set negative values if we don't have a positive hit.
+					merged[ file ][ lineNum ] = hitCount;
+				}
+			}
+		}
+
+		console.log(
+			`Merged PCOV data from ${ coverageFiles.length } coverage files.`
+		);
+	} else {
+		console.log( 'No PCOV coverage files found - using baseline only.' );
+	}
+
 	const stats = calculateStats( merged );
+	const pcovFileCount = coverageFiles ? coverageFiles.length : 0;
+
+	console.log( `\nBaseline: ${ baselineFileCount } PHP files scanned.` );
+	console.log( `PCOV: ${ pcovFileCount } coverage files merged.` );
 
 	console.log( `\nCoverage Summary:` );
 	console.log( `  Files: ${ stats.totalFiles }` );

--- a/scripts/merge-php-coverage.js
+++ b/scripts/merge-php-coverage.js
@@ -181,15 +181,23 @@ function generateLcov( mergedCoverage ) {
 		lcov += `SF:${ relativePath }\n`;
 
 		Object.entries( lines ).forEach( ( [ lineNum, hitCount ] ) => {
-			// Only include executable lines (hitCount >= 0 means it was tracked).
-			if ( hitCount >= 0 ) {
+			// PCOV returns: positive = executed count, -1 = executable but not executed.
+			if ( hitCount > 0 ) {
 				lcov += `DA:${ lineNum },${ hitCount }\n`;
+			} else if ( hitCount === -1 ) {
+				// Executable but not executed - report as uncovered (0 hits).
+				lcov += `DA:${ lineNum },0\n`;
+			}
+			// hitCount === 0 shouldn't occur with PCOV, but include it if it does.
+			else if ( hitCount === 0 ) {
+				lcov += `DA:${ lineNum },0\n`;
 			}
 		} );
 
 		const lineNumbers = Object.keys( lines );
+		// Count all executable lines (executed or not executed).
 		const linesFound = lineNumbers.filter(
-			( ln ) => lines[ ln ] >= 0
+			( ln ) => lines[ ln ] > 0 || lines[ ln ] === -1 || lines[ ln ] === 0
 		).length;
 		const linesHit = lineNumbers.filter( ( ln ) => lines[ ln ] > 0 ).length;
 

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -78,22 +78,10 @@ const test = wpTest.extend( {
 		await use( page );
 
 		// Collect JS coverage after test completes.
-		// eslint-disable-next-line no-console
-		console.log(
-			`[Coverage Debug] COVERAGE_ENABLED=${ process.env.COVERAGE_ENABLED }, test=${ testInfo.title }`
-		);
 		if ( process.env.COVERAGE_ENABLED ) {
 			const coverage = await page.evaluate( () => window.__coverage__ );
-			// eslint-disable-next-line no-console
-			console.log(
-				`[Coverage Debug] window.__coverage__ exists=${ !! coverage }, keys=${ coverage ? Object.keys( coverage ).length : 0 }`
-			);
 			if ( coverage ) {
 				await saveCoverage( coverage );
-				// eslint-disable-next-line no-console
-				console.log(
-					`[Coverage Debug] Saved coverage to ${ coverageDir }`
-				);
 			}
 		}
 	},

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -78,10 +78,22 @@ const test = wpTest.extend( {
 		await use( page );
 
 		// Collect JS coverage after test completes.
+		// eslint-disable-next-line no-console
+		console.log(
+			`[Coverage Debug] COVERAGE_ENABLED=${ process.env.COVERAGE_ENABLED }, test=${ testInfo.title }`
+		);
 		if ( process.env.COVERAGE_ENABLED ) {
 			const coverage = await page.evaluate( () => window.__coverage__ );
+			// eslint-disable-next-line no-console
+			console.log(
+				`[Coverage Debug] window.__coverage__ exists=${ !! coverage }, keys=${ coverage ? Object.keys( coverage ).length : 0 }`
+			);
 			if ( coverage ) {
 				await saveCoverage( coverage );
+				// eslint-disable-next-line no-console
+				console.log(
+					`[Coverage Debug] Saved coverage to ${ coverageDir }`
+				);
 			}
 		}
 	},

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -76,6 +76,28 @@ const test = wpTest.extend( {
 		}
 	},
 
+	// Extend requestUtils to add PHP coverage headers to REST API calls.
+	requestUtils: async ( { requestUtils }, use, testInfo ) => {
+		if ( process.env.PHP_COVERAGE_ENABLED ) {
+			const coverageId = generateCoverageId( testInfo );
+			const originalRest = requestUtils.rest.bind( requestUtils );
+
+			// Wrap the rest method to add coverage headers.
+			requestUtils.rest = async ( options ) => {
+				const headers = options.headers || {};
+				return originalRest( {
+					...options,
+					headers: {
+						...headers,
+						'X-PHP-Coverage': coverageId,
+					},
+				} );
+			};
+		}
+
+		await use( requestUtils );
+	},
+
 	// Override editor fixture to provide version-compatible methods.
 	// WP 6.3+ has "View" button and iframe canvas, WP 6.2 has "Preview" button and no iframe.
 	editor: async ( { editor, page, context }, use ) => {

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -38,7 +38,7 @@ async function saveCoverage( coverage ) {
 }
 
 /**
- * Generate a coverage ID for PHP coverage tracking.
+ * Generate a coverage ID for PHP coverage tracking from test info.
  * Format: testfile-testname-timestamp
  *
  * @param {import('@playwright/test').TestInfo} testInfo - Playwright test info.
@@ -46,10 +46,20 @@ async function saveCoverage( coverage ) {
  */
 function generateCoverageId( testInfo ) {
 	const testFile = path.basename( testInfo.file, '.spec.ts' );
-	const testName = testInfo.title
-		.replace( /[^a-zA-Z0-9]/g, '_' )
-		.slice( 0, 50 );
+	const testName = testInfo.title.replace( /[^a-zA-Z0-9]/g, '_' ).slice( 0, 50 );
 	return `${ testFile }-${ testName }-${ Date.now() }`;
+}
+
+/**
+ * Generate a coverage ID for PHP coverage tracking from worker info.
+ * Used for worker-scoped fixtures like requestUtils.
+ * Format: worker-workerIndex-timestamp
+ *
+ * @param {import('@playwright/test').WorkerInfo} workerInfo - Playwright worker info.
+ * @return {string} Coverage ID.
+ */
+function generateWorkerCoverageId( workerInfo ) {
+	return `worker-${ workerInfo.workerIndex }-${ Date.now() }`;
 }
 
 // Extend WordPress test with Istanbul coverage collection and WP version compatibility
@@ -77,9 +87,10 @@ const test = wpTest.extend( {
 	},
 
 	// Extend requestUtils to add PHP coverage headers to REST API calls.
-	requestUtils: async ( { requestUtils }, use, testInfo ) => {
+	// Note: requestUtils is worker-scoped, so we use workerInfo instead of testInfo.
+	requestUtils: async ( { requestUtils }, use, workerInfo ) => {
 		if ( process.env.PHP_COVERAGE_ENABLED ) {
-			const coverageId = generateCoverageId( testInfo );
+			const coverageId = generateWorkerCoverageId( workerInfo );
 			const originalRest = requestUtils.rest.bind( requestUtils );
 
 			// Wrap the rest method to add coverage headers.


### PR DESCRIPTION
## What
Follow-up to #343. Improves E2E test CI with sharding and accurate coverage reporting.

## Why
E2E tests were slow, and PHP coverage was incorrectly reporting ~99% due to PCOV only tracking files loaded during execution and not including those not loaded.

## How
- Adding test sharding to split the Playwright suite across 4 parallel runners.
- Fixing PHP coverage accuracy by scanning all PHP files in `includes/` to create a baseline with all executable lines marked as uncovered, then merging actual PCOV data on top. This corrects the e2e-php coverage from an incorrect ~99% introduced in #343 to a more realistic ~36%.
- Configuring Codecov with `disable_search: true` to prevent auto-discovery of raw coverage files, and adding `carryforward` flags to preserve coverage data across runs.

## Testing instructions
- E2E tests run in 4 parallel shards (faster than the previous single-runner approach)
- e2e PHP coverage is now 36%, not the unrealistic 99%
- The Codecov comment shows more hits but also many more misses, as we include the files not loaded in the baseline