### PR TITLE
Exclude bin/ directory from code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -39,7 +39,7 @@ ignore:
     - '*.min.css'
     - '*.min.js'
     - '.wp-env'
-    - 'bin/' # CLI/infrastructure scripts - integration code with external APIs
+    - 'bin' # CLI/infrastructure scripts - integration code with external APIs
     - 'build'
     - 'dist'
     - 'docs'

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -39,6 +39,7 @@ ignore:
     - '*.min.css'
     - '*.min.js'
     - '.wp-env'
+    - 'bin/' # CLI/infrastructure scripts - integration code with external APIs
     - 'build'
     - 'dist'
     - 'docs'


### PR DESCRIPTION
## Summary

- Excludes the `bin/` directory from Codecov coverage calculations

The `bin/` directory contains CLI and infrastructure scripts that make HTTP requests to external APIs (GitHub REST/GraphQL). These are integration scripts that are inherently difficult to unit test without extensive HTTP mocking.

See #354 as an example - the `codecov/patch` check passes (confirming the testable parsing logic has coverage), but `codecov/project` fails because the CLI orchestration code in `bin/` isn't covered.

## Test plan

- [ ] Verify Codecov no longer counts `bin/` files toward project coverage