### PR TITLE
Add @wordpress/env devDep and wp-env script

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,13 +62,10 @@ jobs:
                   COVERAGE_ENABLED: true
               run: npm run build
 
-            - name: Install wp-env
-              run: npm install -g @wordpress/env
-
             - name: Start wp-env and install PCOV
               env:
                   PHP_COVERAGE_ENABLED: true
-              run: wp-env start
+              run: npm run wp-env start
 
             - name: Install Playwright browsers
               run: npx playwright install --with-deps
@@ -116,4 +113,4 @@ jobs:
 
             - name: Stop wp-env
               if: always()
-              run: wp-env stop
+              run: npm run wp-env stop

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./schemas/json/wp-env.json",
+  "$schema": "https://schemas.wp.org/trunk/wp-env.json",
   "plugins": ["."],
   "lifecycleScripts": {
     "afterStart": "bash ./scripts/install-pcov.sh"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
 				"@testing-library/react": "^14.1.2",
 				"@wordpress/dependency-extraction-webpack-plugin": "^6.20.0",
 				"@wordpress/e2e-test-utils-playwright": "^1.20.0",
+				"@wordpress/env": "^10.39.0",
 				"@wordpress/icons": "^10.26.0",
 				"@wordpress/prettier-config": "^4.22.0",
 				"@wordpress/priority-queue": "^3.22.0",
@@ -96,7 +97,6 @@
 			"integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.3",
@@ -2119,7 +2119,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -2143,7 +2142,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2499,6 +2497,401 @@
 			"deprecated": "Use @eslint/object-schema instead",
 			"dev": true,
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/@inquirer/ansi": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+			"integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/checkbox": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+			"integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/figures": "^1.0.15",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/confirm": {
+			"version": "5.1.21",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+			"integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/core": {
+			"version": "10.3.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+			"integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/figures": "^1.0.15",
+				"@inquirer/type": "^3.0.10",
+				"cli-width": "^4.1.0",
+				"mute-stream": "^2.0.0",
+				"signal-exit": "^4.1.0",
+				"wrap-ansi": "^6.2.0",
+				"yoctocolors-cjs": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@inquirer/editor": {
+			"version": "4.2.23",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+			"integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/external-editor": "^1.0.3",
+				"@inquirer/type": "^3.0.10"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/expand": {
+			"version": "4.0.23",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+			"integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/external-editor": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+			"integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chardet": "^2.1.1",
+				"iconv-lite": "^0.7.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/@inquirer/figures": {
+			"version": "1.0.15",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+			"integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/input": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+			"integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/number": {
+			"version": "3.0.23",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+			"integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/password": {
+			"version": "4.0.23",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+			"integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/prompts": {
+			"version": "7.10.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+			"integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/checkbox": "^4.3.2",
+				"@inquirer/confirm": "^5.1.21",
+				"@inquirer/editor": "^4.2.23",
+				"@inquirer/expand": "^4.0.23",
+				"@inquirer/input": "^4.3.1",
+				"@inquirer/number": "^3.0.23",
+				"@inquirer/password": "^4.0.23",
+				"@inquirer/rawlist": "^4.1.11",
+				"@inquirer/search": "^3.2.2",
+				"@inquirer/select": "^4.4.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/rawlist": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+			"integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/search": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+			"integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/figures": "^1.0.15",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/select": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+			"integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/figures": "^1.0.15",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/type": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+			"integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
@@ -3040,6 +3433,23 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@kwsites/file-exists": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+			"integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1"
+			}
+		},
+		"node_modules/@kwsites/promise-deferred": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+			"integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@leichtgewicht/ip-codec": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -3095,13 +3505,583 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@octokit/app": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.1.0.tgz",
+			"integrity": "sha512-g3uEsGOQCBl1+W1rgfwoRFUIR6PtvB2T1E4RpygeUU5LrLvlOqcxrt5lfykIeRpUPpupreGJUYl70fqMDXdTpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-app": "^6.0.0",
+				"@octokit/auth-unauthenticated": "^5.0.0",
+				"@octokit/core": "^5.0.0",
+				"@octokit/oauth-app": "^6.0.0",
+				"@octokit/plugin-paginate-rest": "^9.0.0",
+				"@octokit/types": "^12.0.0",
+				"@octokit/webhooks": "^12.0.4"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-app": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.1.4.tgz",
+			"integrity": "sha512-QkXkSOHZK4dA5oUqY5Dk3S+5pN2s1igPjEASNQV8/vgJgW034fQWR16u7VsNOK/EljA00eyjYF5mWNxWKWhHRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-app": "^7.1.0",
+				"@octokit/auth-oauth-user": "^4.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/request-error": "^5.1.0",
+				"@octokit/types": "^13.1.0",
+				"deprecation": "^2.3.1",
+				"lru-cache": "npm:@wolfy1339/lru-cache@^11.0.2-patch.1",
+				"universal-github-app-jwt": "^1.1.2",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-app/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-app/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/auth-app/node_modules/lru-cache": {
+			"name": "@wolfy1339/lru-cache",
+			"version": "11.0.2-patch.1",
+			"resolved": "https://registry.npmjs.org/@wolfy1339/lru-cache/-/lru-cache-11.0.2-patch.1.tgz",
+			"integrity": "sha512-BgYZfL2ADCXKOw2wJtkM3slhHotawWkgIRRxq4wEybnZQPjvAp71SPX35xepMykTw8gXlzWcWPTY31hlbnRsDA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "18 >=18.20 || 20 || >=22"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-app": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-7.1.0.tgz",
+			"integrity": "sha512-w+SyJN/b0l/HEb4EOPRudo7uUOSW51jcK1jwLa+4r7PA8FPFpoxEnHBHMITqCsc/3Vo2qqFjgQfz/xUUvsSQnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-device": "^6.1.0",
+				"@octokit/auth-oauth-user": "^4.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/types": "^13.0.0",
+				"@types/btoa-lite": "^1.0.0",
+				"btoa-lite": "^1.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-device": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-6.1.0.tgz",
+			"integrity": "sha512-FNQ7cb8kASufd6Ej4gnJ3f1QB5vJitkoV1O0/g6e6lUsQ7+VsSNRHRmFScN2tV4IgKA12frrr/cegUs0t+0/Lw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/oauth-methods": "^4.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/types": "^13.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-user": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-4.1.0.tgz",
+			"integrity": "sha512-FrEp8mtFuS/BrJyjpur+4GARteUCrPeR/tZJzD8YourzoVhRics7u7we/aDcKv+yywRNwNi/P4fRi631rG/OyQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-device": "^6.1.0",
+				"@octokit/oauth-methods": "^4.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/types": "^13.0.0",
+				"btoa-lite": "^1.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/auth-token": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+			"integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-unauthenticated": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-5.0.1.tgz",
+			"integrity": "sha512-oxeWzmBFxWd+XolxKTc4zr+h3mt+yofn4r7OfoIkR/Cj/o70eEGmPsFbueyJE2iBAGpjgTnEOKM3pnuEGVmiqg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/types": "^12.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/core": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-token": "^4.0.0",
+				"@octokit/graphql": "^7.1.0",
+				"@octokit/request": "^8.4.1",
+				"@octokit/request-error": "^5.1.1",
+				"@octokit/types": "^13.0.0",
+				"before-after-hook": "^2.2.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/core/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/endpoint": {
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+			"integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^13.1.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/graphql": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+			"integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request": "^8.4.1",
+				"@octokit/types": "^13.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/graphql/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/oauth-app": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-6.1.0.tgz",
+			"integrity": "sha512-nIn/8eUJ/BKUVzxUXd5vpzl1rwaVxMyYbQkNZjHrF7Vk/yu98/YDF/N2KeWO7uZ0g3b5EyiFXFkZI8rJ+DH1/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-app": "^7.0.0",
+				"@octokit/auth-oauth-user": "^4.0.0",
+				"@octokit/auth-unauthenticated": "^5.0.0",
+				"@octokit/core": "^5.0.0",
+				"@octokit/oauth-authorization-url": "^6.0.2",
+				"@octokit/oauth-methods": "^4.0.0",
+				"@types/aws-lambda": "^8.10.83",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/oauth-authorization-url": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-6.0.2.tgz",
+			"integrity": "sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/oauth-methods": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-4.1.0.tgz",
+			"integrity": "sha512-4tuKnCRecJ6CG6gr0XcEXdZtkTDbfbnD5oaHBmLERTjTMZNi2CbfEHZxPU41xXLDG4DfKf+sonu00zvKI9NSbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/oauth-authorization-url": "^6.0.2",
+				"@octokit/request": "^8.3.1",
+				"@octokit/request-error": "^5.1.0",
+				"@octokit/types": "^13.0.0",
+				"btoa-lite": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/oauth-methods/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/oauth-methods/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/openapi-types": {
+			"version": "20.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+			"integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-paginate-graphql": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-4.0.1.tgz",
+			"integrity": "sha512-R8ZQNmrIKKpHWC6V2gum4x9LG2qF1RxRjo27gjQcG3j+vf2tLsEfE7I/wRWEPzYMaenr1M+qDAtNcwZve1ce1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=5"
+			}
+		},
+		"node_modules/@octokit/plugin-paginate-rest": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+			"integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^12.6.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "5"
+			}
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods": {
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+			"integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^12.6.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "5"
+			}
+		},
+		"node_modules/@octokit/plugin-retry": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.1.0.tgz",
+			"integrity": "sha512-WrO3bvq4E1Xh1r2mT9w6SDFg01gFmP81nIG77+p/MqW1JeXXgL++6umim3t6x0Zj5pZm3rXAN+0HEjmmdhIRig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/types": "^13.0.0",
+				"bottleneck": "^2.15.3"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "5"
+			}
+		},
+		"node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/plugin-throttling": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.2.0.tgz",
+			"integrity": "sha512-nOpWtLayKFpgqmgD0y3GqXafMFuKcA4tRPZIfu7BArd2lEZeb1988nhWhwx4aZWmjDmUfdgVf7W+Tt4AmvRmMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^12.2.0",
+				"bottleneck": "^2.15.3"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "^5.0.0"
+			}
+		},
+		"node_modules/@octokit/request": {
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+			"integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/endpoint": "^9.0.6",
+				"@octokit/request-error": "^5.1.1",
+				"@octokit/types": "^13.1.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/request-error": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+			"integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^13.1.0",
+				"deprecation": "^2.0.0",
+				"once": "^1.4.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/request-error/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/request/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/types": {
+			"version": "12.6.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+			"integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^20.0.0"
+			}
+		},
+		"node_modules/@octokit/webhooks": {
+			"version": "12.3.2",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.3.2.tgz",
+			"integrity": "sha512-exj1MzVXoP7xnAcAB3jZ97pTvVPkQF9y6GA/dvYC47HV7vLv+24XRS6b/v/XnyikpEuvMhugEXdGtAlU086WkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/webhooks-methods": "^4.1.0",
+				"@octokit/webhooks-types": "7.6.1",
+				"aggregate-error": "^3.1.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/webhooks-methods": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-4.1.0.tgz",
+			"integrity": "sha512-zoQyKw8h9STNPqtm28UGOYFE7O6D4Il8VJwhAtMHFt2C4L0VQT1qGKLeefUOqHNs1mNRYSadVv7x0z8U2yyeWQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/webhooks-types": {
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.6.1.tgz",
+			"integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@opentelemetry/api": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -3125,7 +4105,6 @@
 			"integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=14"
 			},
@@ -3139,7 +4118,6 @@
 			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
@@ -3622,7 +4600,6 @@
 			"integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "1.30.1",
 				"@opentelemetry/semantic-conventions": "1.28.0"
@@ -3650,7 +4627,6 @@
 			"integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "1.30.1",
 				"@opentelemetry/resources": "1.30.1",
@@ -3679,7 +4655,6 @@
 			"integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=14"
 			}
@@ -4021,6 +4996,984 @@
 				"third-party-web": "latest"
 			}
 		},
+		"node_modules/@php-wasm/cli-util": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.2.tgz",
+			"integrity": "sha512-pUUbACHsrFc2QSNqKEhiFhwCD1dbroH8/14hQYW+lcgswG10sqMMgfmk7FBp61jTntXdweYhNFjcoIOMV3h0OA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/util": "3.1.2",
+				"fast-xml-parser": "^5.3.4",
+				"jsonc-parser": "3.3.1"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/cli-util/node_modules/jsonc-parser": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@php-wasm/fs-journal": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.1.2.tgz",
+			"integrity": "sha512-8e8lz/IG6EA8h2/lGSOijdhemaABTt45zohhMYYSjuCu5fV24p+6rGkK7I+dGqxaY4cO2IDjU4XE+HRnodW88g==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.2",
+				"@php-wasm/node": "3.1.2",
+				"@php-wasm/universal": "3.1.2",
+				"@php-wasm/util": "3.1.2",
+				"express": "4.22.0",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/fs-journal/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/@php-wasm/fs-journal/node_modules/express": {
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
+			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "~1.3.8",
+				"array-flatten": "1.1.1",
+				"body-parser": "~1.20.3",
+				"content-disposition": "~0.5.4",
+				"content-type": "~1.0.4",
+				"cookie": "~0.7.1",
+				"cookie-signature": "~1.0.6",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "~1.3.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.0",
+				"merge-descriptors": "1.0.3",
+				"methods": "~1.1.2",
+				"on-finished": "~2.4.1",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "~0.1.12",
+				"proxy-addr": "~2.0.7",
+				"qs": "~6.14.0",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.2.1",
+				"send": "~0.19.0",
+				"serve-static": "~1.16.2",
+				"setprototypeof": "1.2.0",
+				"statuses": "~2.0.1",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/@php-wasm/fs-journal/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/fs-journal/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@php-wasm/fs-journal/node_modules/qs": {
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@php-wasm/logger": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.2.tgz",
+			"integrity": "sha512-VD1SbuTL24LgbkPaQCijDzc9V7SSVU5hi+up4yNpHeL8pP8kabIYYSR7PgTfity1Awk6ctW5kUpOhSieD+1Btw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/node-polyfills": "3.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.2.tgz",
+			"integrity": "sha512-Y/I2nUjo1Aof4irF1cfAxX33Ra5xa2HQcy3HmIXXurqTBE7bZMu5TKvJW7t0cfBLohuaWY1bs8n4nLS1BetuTg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.2",
+				"@php-wasm/node-7-4": "3.1.2",
+				"@php-wasm/node-8-0": "3.1.2",
+				"@php-wasm/node-8-1": "3.1.2",
+				"@php-wasm/node-8-2": "3.1.2",
+				"@php-wasm/node-8-3": "3.1.2",
+				"@php-wasm/node-8-4": "3.1.2",
+				"@php-wasm/node-8-5": "3.1.2",
+				"@php-wasm/node-polyfills": "3.1.2",
+				"@php-wasm/universal": "3.1.2",
+				"@php-wasm/util": "3.1.2",
+				"@wp-playground/common": "3.1.2",
+				"express": "4.22.0",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-7-4": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.2.tgz",
+			"integrity": "sha512-n8QjH2/PiJV28Ad9a4jn/3Rq1cVU3bD+8+4aDOyEbhwxl9Qvb6NvSqMER/3KqasH5cvZiZLsMy92+q+CjcIQAA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.2",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-7-4/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-0": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.2.tgz",
+			"integrity": "sha512-sNSk858peKueucrNKAKbZ094XJOsP8AcK+XLM1KjS+VNoT5aVNC5xzZnQhArxCI6lZqkUhvmGqV1DNEdmX/ayA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.2",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-0/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-1": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.2.tgz",
+			"integrity": "sha512-HDfA0+uMhZEMFAeryN/kkCbcuW5Bv11liCuwxxwGdNj21NxRVFoDhYYm1FKyFPTbZWHemSJXkpZgyh4g2HfL5w==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.2",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-1/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-2": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.2.tgz",
+			"integrity": "sha512-+225WZUAf4foAr+DT9ahS7Rna3h7DslI9anrWShR7a8FxAaCUgi0dw4Rh2can2K0/Q+moC3l2OZC93NIhedsuw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.2",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-2/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-3": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.2.tgz",
+			"integrity": "sha512-fRncog0ai610bhzFmSYXq5N3vaVoZNAU0GxhzcKXGsPF4x5o07wViMClyqXpxcqn+KC4RhV4YK5hCGhGvzEvkA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.2",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-3/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-4": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.2.tgz",
+			"integrity": "sha512-3J5tnLJwmmZrX/bHiCA/nbBhMMC58kWhX8v62B2LB+Hx7zq2agSETaga1tk4RzbIrs85noq4tuPUng9yAsSkHw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.2",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-4/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-5": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.2.tgz",
+			"integrity": "sha512-JAalPcRB4VQd0Iz0BWcPp5DXNsNcw5Rq20XSz4YmlCDkGNJ46DsgGF1ZjptbacFYYGdJGm7mfMoiJuAhuVu1Cw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.2",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-5/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-polyfills": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.2.tgz",
+			"integrity": "sha512-fPKQVX8SEV5wWlAuO+wJeWTt4qf1eA5WVcoS3bS/dCHy437NzrnIZ/caJB8MHgjNRDh+d/QWHS3gDDs0NvYhjQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later"
+		},
+		"node_modules/@php-wasm/node/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node/node_modules/express": {
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
+			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "~1.3.8",
+				"array-flatten": "1.1.1",
+				"body-parser": "~1.20.3",
+				"content-disposition": "~0.5.4",
+				"content-type": "~1.0.4",
+				"cookie": "~0.7.1",
+				"cookie-signature": "~1.0.6",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "~1.3.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.0",
+				"merge-descriptors": "1.0.3",
+				"methods": "~1.1.2",
+				"on-finished": "~2.4.1",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "~0.1.12",
+				"proxy-addr": "~2.0.7",
+				"qs": "~6.14.0",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.2.1",
+				"send": "~0.19.0",
+				"serve-static": "~1.16.2",
+				"setprototypeof": "1.2.0",
+				"statuses": "~2.0.1",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/@php-wasm/node/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@php-wasm/node/node_modules/qs": {
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@php-wasm/progress": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.2.tgz",
+			"integrity": "sha512-IND/q2zpLufURpuiQ94w4/Thx6z2I1zkfvGZ7tbThz+kyMuTOrog2Q6f8vL7xL1UI1cGTWCRiUVxzj4EtMvJag==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.2",
+				"@php-wasm/node-polyfills": "3.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/scopes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.2.tgz",
+			"integrity": "sha512-M5BO27JMIS2FMifh2Eb2BjWrAmA0h26Q2Sf2gx5gOk64SleMaJNuYxpPC8WdqNru7IDmjZbRoK//OIPscaPhxA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/stream-compression": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.2.tgz",
+			"integrity": "sha512-nUM7DtBkPF1Y3v9FW1CMG7nJLIDnoH3MKfKON6R/knwDpAExQVOII3K8AZuiVyr4IAiFZwYza8H5bkM+UUmFBg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/node-polyfills": "3.1.2",
+				"@php-wasm/util": "3.1.2"
+			}
+		},
+		"node_modules/@php-wasm/universal": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.2.tgz",
+			"integrity": "sha512-rgKyeqBVHZ6bDOwoYg9lUtZxgh7aB+/ryGcL1QEYyr7260bFwVgf8MWNP+211fktLa1yvuvl4dyDepaQiV0sDA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.2",
+				"@php-wasm/node-polyfills": "3.1.2",
+				"@php-wasm/progress": "3.1.2",
+				"@php-wasm/stream-compression": "3.1.2",
+				"@php-wasm/util": "3.1.2",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/universal/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/util": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.2.tgz",
+			"integrity": "sha512-g22dH4zIQ26hQHRNBfp9csy3W8tDDdyB4G8Euvj6PNxEBsTnY/A6WG1/wLZ3PUED9ULsz/lKKFSiEZo8Hj8B8g==",
+			"dev": true,
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/web": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.1.2.tgz",
+			"integrity": "sha512-HV9RKqm3DfOuMlDlC+Q0nxLv8xCf6E5yhatrimJ8fXXLRUTaBzpDbsbwi2eq8qcb6A48Yj25wY8BSpqWSYJYVw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/fs-journal": "3.1.2",
+				"@php-wasm/logger": "3.1.2",
+				"@php-wasm/universal": "3.1.2",
+				"@php-wasm/util": "3.1.2",
+				"@php-wasm/web-7-4": "3.1.2",
+				"@php-wasm/web-8-0": "3.1.2",
+				"@php-wasm/web-8-1": "3.1.2",
+				"@php-wasm/web-8-2": "3.1.2",
+				"@php-wasm/web-8-3": "3.1.2",
+				"@php-wasm/web-8-4": "3.1.2",
+				"@php-wasm/web-8-5": "3.1.2",
+				"@php-wasm/web-service-worker": "3.1.2",
+				"@wp-playground/common": "3.1.2",
+				"express": "4.22.0",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/web-7-4": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-7-4/-/web-7-4-3.1.2.tgz",
+			"integrity": "sha512-3Vq1yt7fqEo40PXZFRobxNLTzrDGS8I0ciIQ5XED0/TJh6bnV39T3wmecq1dbDCw/wrCdDK3kdlBUnViUpSQ5g==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.2",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/web-7-4/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/web-8-0": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-0/-/web-8-0-3.1.2.tgz",
+			"integrity": "sha512-zKL10GRajDi59Q3wB7AyWNZZaEeikM7HRpHarBBs2UhmTVS93Tyhoj4WsaN5KC3MZlxIV2g6QgXhcJHEyuve+A==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.2",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/web-8-0/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/web-8-1": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-1/-/web-8-1-3.1.2.tgz",
+			"integrity": "sha512-zXsiao1+Op0Qkgc4zmrgEzkpON547pTuQdljNlqGKdRcA8l/xhTme7fhm5GsSP/UEQbP3n7PEOjKPAQi8S9wSA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.2",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/web-8-1/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/web-8-2": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-2/-/web-8-2-3.1.2.tgz",
+			"integrity": "sha512-tAgutFkzIwSir7HOnu4IRQLX3uTYArl3wqqlpK/GfIXwyCHSRaq1OTQfh4mq4U3ulCu97MwOHiJBqSDoE5qyrQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.2",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/web-8-2/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/web-8-3": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-3/-/web-8-3-3.1.2.tgz",
+			"integrity": "sha512-RZLz0XxwkdTy17ijpIPe2iZe1s5ZbEybVIw131jjgLm5bTSuTCwYod7LUNCdRy0QE651g8142Aw5W9iYFnLwfg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.2",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/web-8-3/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/web-8-4": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-4/-/web-8-4-3.1.2.tgz",
+			"integrity": "sha512-v4ujuPNwI1eWBkB9Nzj1+hUKVZaxr/ev7LFA0hi+wOMk4ZVW2hLx1AE7jE2v7L2zADW7JJ2tGP3gK37/TAmpug==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.2",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/web-8-4/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/web-8-5": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-5/-/web-8-5-3.1.2.tgz",
+			"integrity": "sha512-XSyTybscwd7CFhTjPMUq02s5WqJE1xwjfIMMut7sT3HzD0TM5wGpbQLS53Vj5XXWUtLgsG19hW/JyREHzR05eQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.2",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/web-8-5/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/web-service-worker": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.2.tgz",
+			"integrity": "sha512-rZOgdjOBed9EcQwsEVDBpdQVDY30eEAQ+bxEAMB1OrcpXzFPwMdfkVZvxo6fP7DA9qg9Qr/ethRve0O5dNJALA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/scopes": "3.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/web/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/@php-wasm/web/node_modules/express": {
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
+			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "~1.3.8",
+				"array-flatten": "1.1.1",
+				"body-parser": "~1.20.3",
+				"content-disposition": "~0.5.4",
+				"content-type": "~1.0.4",
+				"cookie": "~0.7.1",
+				"cookie-signature": "~1.0.6",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "~1.3.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.0",
+				"merge-descriptors": "1.0.3",
+				"methods": "~1.1.2",
+				"on-finished": "~2.4.1",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "~0.1.12",
+				"proxy-addr": "~2.0.7",
+				"qs": "~6.14.0",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.2.1",
+				"send": "~0.19.0",
+				"serve-static": "~1.16.2",
+				"setprototypeof": "1.2.0",
+				"statuses": "~2.0.1",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/@php-wasm/web/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/web/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@php-wasm/web/node_modules/qs": {
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@php-wasm/xdebug-bridge": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.2.tgz",
+			"integrity": "sha512-oArlnqIo9YFOro8rdaAPipSfuOht//47XxvpwQbjEvOsJ54WkyNKmxOD1QFqNjj4y9cc3yCaqeYb/xUcn0tp6Q==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.2",
+				"@php-wasm/node": "3.1.2",
+				"@php-wasm/universal": "3.1.2",
+				"@wp-playground/common": "3.1.2",
+				"express": "4.22.0",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"xml2js": "0.6.2",
+				"yargs": "17.7.2"
+			},
+			"bin": {
+				"xdebug-bridge": "xdebug-bridge.js"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/express": {
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
+			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "~1.3.8",
+				"array-flatten": "1.1.1",
+				"body-parser": "~1.20.3",
+				"content-disposition": "~0.5.4",
+				"content-type": "~1.0.4",
+				"cookie": "~0.7.1",
+				"cookie-signature": "~1.0.6",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "~1.3.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.0",
+				"merge-descriptors": "1.0.3",
+				"methods": "~1.1.2",
+				"on-finished": "~2.4.1",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "~0.1.12",
+				"proxy-addr": "~2.0.7",
+				"qs": "~6.14.0",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.2.1",
+				"send": "~0.19.0",
+				"serve-static": "~1.16.2",
+				"setprototypeof": "1.2.0",
+				"statuses": "~2.0.1",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/qs": {
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4282,6 +6235,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -4501,7 +6467,6 @@
 			"integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.21.3",
 				"@svgr/babel-preset": "8.1.0",
@@ -4602,6 +6567,19 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/@szmarczak/http-timer": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"defer-to-connect": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/@testing-library/dom": {
@@ -4749,6 +6727,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/aws-lambda": {
+			"version": "8.10.160",
+			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.160.tgz",
+			"integrity": "sha512-uoO4QVQNWFPJMh26pXtmtrRfGshPUSpMZGUyUQY20FhfHEElEBOPKgVmFs1z+kbpyBsRs2JnoOPT7++Z4GA9pA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4815,6 +6800,26 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/btoa-lite": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.2.tgz",
+			"integrity": "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/cacheable-request": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+			"integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/http-cache-semantics": "*",
+				"@types/keyv": "^3.1.4",
+				"@types/node": "*",
+				"@types/responselike": "^1.0.0"
+			}
+		},
 		"node_modules/@types/connect": {
 			"version": "3.4.38",
 			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -4842,7 +6847,6 @@
 			"integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
@@ -4915,6 +6919,13 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/http-cache-semantics": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/http-errors": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -4985,6 +6996,27 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/jsonwebtoken": {
+			"version": "9.0.10",
+			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+			"integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/keyv": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/mime": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -4996,6 +7028,13 @@
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
 			"integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5092,7 +7131,6 @@
 			"integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
@@ -5106,6 +7144,16 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
+			}
+		},
+		"node_modules/@types/responselike": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+			"integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/retry": {
@@ -5306,7 +7354,6 @@
 			"integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "6.21.0",
 				"@typescript-eslint/types": "6.21.0",
@@ -5747,7 +7794,6 @@
 			"integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.25.7",
@@ -6005,6 +8051,146 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/env": {
+			"version": "10.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.39.0.tgz",
+			"integrity": "sha512-Hgl2RQAAzXFMqkpegGWT1/KkX88OVikRroPidWkij1WtU8p+AZniTcncWmlWqbdLdfGbPqQS5ZkqDZCzrQjgnA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@inquirer/prompts": "^7.2.0",
+				"@wp-playground/cli": "^3.0.0",
+				"chalk": "^4.0.0",
+				"copy-dir": "^1.3.0",
+				"cross-spawn": "^7.0.6",
+				"docker-compose": "^0.24.3",
+				"extract-zip": "^1.6.7",
+				"got": "^11.8.5",
+				"js-yaml": "^3.13.1",
+				"ora": "^4.0.2",
+				"rimraf": "^5.0.10",
+				"simple-git": "^3.5.0",
+				"terminal-link": "^2.0.0",
+				"yargs": "^17.3.0"
+			},
+			"bin": {
+				"wp-env": "bin/wp-env"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/env/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@wordpress/env/node_modules/brace-expansion": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+			"integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@wordpress/env/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/@wordpress/env/node_modules/extract-zip": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+			"integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"concat-stream": "^1.6.2",
+				"debug": "^2.6.9",
+				"mkdirp": "^0.5.4",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"extract-zip": "cli.js"
+			}
+		},
+		"node_modules/@wordpress/env/node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@wordpress/env/node_modules/minimatch": {
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+			"integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^5.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@wordpress/env/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/env/node_modules/rimraf": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+			"integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^10.3.7"
+			},
+			"bin": {
+				"rimraf": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
@@ -6615,6 +8801,762 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wp-playground/blueprints": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.2.tgz",
+			"integrity": "sha512-46YYZ8FAq0G3aZ/b0d7/jTaBmjpktKz/aiYcZ6KBRQdBwpTg9ujennhlvciEHTwI6mJ4drRfBaEoAjYIIlwsWQ==",
+			"dev": true,
+			"dependencies": {
+				"@php-wasm/logger": "3.1.2",
+				"@php-wasm/node": "3.1.2",
+				"@php-wasm/node-polyfills": "3.1.2",
+				"@php-wasm/progress": "3.1.2",
+				"@php-wasm/scopes": "3.1.2",
+				"@php-wasm/stream-compression": "3.1.2",
+				"@php-wasm/universal": "3.1.2",
+				"@php-wasm/util": "3.1.2",
+				"@php-wasm/web-service-worker": "3.1.2",
+				"@wp-playground/common": "3.1.2",
+				"@wp-playground/storage": "3.1.2",
+				"@wp-playground/wordpress": "3.1.2",
+				"@zip.js/zip.js": "2.7.57",
+				"ajv": "8.12.0",
+				"async-lock": "1.4.1",
+				"clean-git-ref": "2.0.1",
+				"crc-32": "1.2.2",
+				"diff3": "0.0.4",
+				"express": "4.22.0",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ignore": "5.3.2",
+				"ini": "4.1.2",
+				"minimisted": "2.0.1",
+				"octokit": "3.1.2",
+				"pako": "1.0.10",
+				"pify": "2.3.0",
+				"readable-stream": "3.6.2",
+				"sha.js": "2.4.12",
+				"simple-get": "4.0.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/blueprints/node_modules/ajv": {
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@wp-playground/blueprints/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/@wp-playground/blueprints/node_modules/express": {
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
+			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "~1.3.8",
+				"array-flatten": "1.1.1",
+				"body-parser": "~1.20.3",
+				"content-disposition": "~0.5.4",
+				"content-type": "~1.0.4",
+				"cookie": "~0.7.1",
+				"cookie-signature": "~1.0.6",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "~1.3.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.0",
+				"merge-descriptors": "1.0.3",
+				"methods": "~1.1.2",
+				"on-finished": "~2.4.1",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "~0.1.12",
+				"proxy-addr": "~2.0.7",
+				"qs": "~6.14.0",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.2.1",
+				"send": "~0.19.0",
+				"serve-static": "~1.16.2",
+				"setprototypeof": "1.2.0",
+				"statuses": "~2.0.1",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/@wp-playground/blueprints/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@wp-playground/blueprints/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@wp-playground/blueprints/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@wp-playground/blueprints/node_modules/qs": {
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@wp-playground/cli": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.2.tgz",
+			"integrity": "sha512-mk9JDUvjwXII+yVZmjYSE1TWdSqdy8MeMm/7S0KpUTgHaVTwaeKH0ImWYDyAeC0H0HSXNbfuEnqe/Rls9cwKEQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/cli-util": "3.1.2",
+				"@php-wasm/logger": "3.1.2",
+				"@php-wasm/node": "3.1.2",
+				"@php-wasm/progress": "3.1.2",
+				"@php-wasm/universal": "3.1.2",
+				"@php-wasm/util": "3.1.2",
+				"@php-wasm/xdebug-bridge": "3.1.2",
+				"@wp-playground/blueprints": "3.1.2",
+				"@wp-playground/common": "3.1.2",
+				"@wp-playground/storage": "3.1.2",
+				"@wp-playground/tools": "3.1.2",
+				"@wp-playground/wordpress": "3.1.2",
+				"@zip.js/zip.js": "2.7.57",
+				"ajv": "8.12.0",
+				"async-lock": "1.4.1",
+				"clean-git-ref": "2.0.1",
+				"crc-32": "1.2.2",
+				"diff3": "0.0.4",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.3.4",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"fs-extra": "11.1.1",
+				"ignore": "5.3.2",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"minimisted": "2.0.1",
+				"octokit": "3.1.2",
+				"pako": "1.0.10",
+				"pify": "2.3.0",
+				"ps-man": "1.1.8",
+				"readable-stream": "3.6.2",
+				"sha.js": "2.4.12",
+				"simple-get": "4.0.1",
+				"tmp-promise": "3.0.3",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"xml2js": "0.6.2",
+				"yargs": "17.7.2"
+			},
+			"bin": {
+				"wp-playground-cli": "wp-playground.js"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/ajv": {
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/express": {
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
+			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "~1.3.8",
+				"array-flatten": "1.1.1",
+				"body-parser": "~1.20.3",
+				"content-disposition": "~0.5.4",
+				"content-type": "~1.0.4",
+				"cookie": "~0.7.1",
+				"cookie-signature": "~1.0.6",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "~1.3.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.0",
+				"merge-descriptors": "1.0.3",
+				"methods": "~1.1.2",
+				"on-finished": "~2.4.1",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "~0.1.12",
+				"proxy-addr": "~2.0.7",
+				"qs": "~6.14.0",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.2.1",
+				"send": "~0.19.0",
+				"serve-static": "~1.16.2",
+				"setprototypeof": "1.2.0",
+				"statuses": "~2.0.1",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@wp-playground/cli/node_modules/jsonc-parser": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@wp-playground/cli/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@wp-playground/cli/node_modules/qs": {
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@wp-playground/common": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.2.tgz",
+			"integrity": "sha512-HSCzwIe+5EVVsbbEtwdUh4O1805Co1GCOV6WQvshjJRtIzMTbRPtPeigkZVgDOMYvmDYrgBAEw5p9DqNK6mImA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.2",
+				"@php-wasm/util": "3.1.2",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/common/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@wp-playground/storage": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.2.tgz",
+			"integrity": "sha512-TKHtLhgRG73pXm9TRXXYpfZOEbU9/icXccnyy0y45DAPKsAbLQYaLei8JGWGZTONLJr+28t5ZBkmKOQxlQQfyg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/stream-compression": "3.1.2",
+				"@php-wasm/universal": "3.1.2",
+				"@php-wasm/util": "3.1.2",
+				"@php-wasm/web": "3.1.2",
+				"@zip.js/zip.js": "2.7.57",
+				"async-lock": "^1.4.1",
+				"clean-git-ref": "^2.0.1",
+				"crc-32": "^1.2.0",
+				"diff3": "0.0.3",
+				"express": "4.22.0",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ignore": "^5.1.4",
+				"ini": "4.1.2",
+				"minimisted": "^2.0.0",
+				"octokit": "3.1.2",
+				"pako": "^1.0.10",
+				"pify": "^4.0.1",
+				"readable-stream": "^3.4.0",
+				"sha.js": "^2.4.9",
+				"simple-get": "^4.0.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			}
+		},
+		"node_modules/@wp-playground/storage/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/@wp-playground/storage/node_modules/diff3": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@wp-playground/storage/node_modules/express": {
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
+			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "~1.3.8",
+				"array-flatten": "1.1.1",
+				"body-parser": "~1.20.3",
+				"content-disposition": "~0.5.4",
+				"content-type": "~1.0.4",
+				"cookie": "~0.7.1",
+				"cookie-signature": "~1.0.6",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "~1.3.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.0",
+				"merge-descriptors": "1.0.3",
+				"methods": "~1.1.2",
+				"on-finished": "~2.4.1",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "~0.1.12",
+				"proxy-addr": "~2.0.7",
+				"qs": "~6.14.0",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.2.1",
+				"send": "~0.19.0",
+				"serve-static": "~1.16.2",
+				"setprototypeof": "1.2.0",
+				"statuses": "~2.0.1",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/@wp-playground/storage/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@wp-playground/storage/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@wp-playground/storage/node_modules/pify": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@wp-playground/storage/node_modules/qs": {
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@wp-playground/tools": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.2.tgz",
+			"integrity": "sha512-Csg/aRY7ZLOHf0Rx71Ka37dTBaec2nknLP9wDQc1mLEAkd+GuXuJQfDz8JHmmbWuPm5K2MAaVJxuQeHk4jOrig==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wp-playground/blueprints": "3.1.2",
+				"@zip.js/zip.js": "2.7.57",
+				"ajv": "8.12.0",
+				"async-lock": "1.4.1",
+				"clean-git-ref": "2.0.1",
+				"crc-32": "1.2.2",
+				"diff3": "0.0.4",
+				"express": "4.22.0",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ignore": "5.3.2",
+				"ini": "4.1.2",
+				"minimisted": "2.0.1",
+				"octokit": "3.1.2",
+				"pako": "1.0.10",
+				"pify": "2.3.0",
+				"readable-stream": "3.6.2",
+				"sha.js": "2.4.12",
+				"simple-get": "4.0.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/ajv": {
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/express": {
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
+			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "~1.3.8",
+				"array-flatten": "1.1.1",
+				"body-parser": "~1.20.3",
+				"content-disposition": "~0.5.4",
+				"content-type": "~1.0.4",
+				"cookie": "~0.7.1",
+				"cookie-signature": "~1.0.6",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "~1.3.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.0",
+				"merge-descriptors": "1.0.3",
+				"methods": "~1.1.2",
+				"on-finished": "~2.4.1",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "~0.1.12",
+				"proxy-addr": "~2.0.7",
+				"qs": "~6.14.0",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.2.1",
+				"send": "~0.19.0",
+				"serve-static": "~1.16.2",
+				"setprototypeof": "1.2.0",
+				"statuses": "~2.0.1",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@wp-playground/tools/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@wp-playground/tools/node_modules/qs": {
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@wp-playground/wordpress": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.2.tgz",
+			"integrity": "sha512-8R1gNGrJ2pEliMl67EF8E3aB1ZL+0oZ6FA4ZREjIhaOrqm8ZmBcXnqmrX27cvGM7aJ3FGrQurdq4jIdDd9rp0w==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.2",
+				"@php-wasm/node": "3.1.2",
+				"@php-wasm/universal": "3.1.2",
+				"@php-wasm/util": "3.1.2",
+				"@wp-playground/common": "3.1.2",
+				"express": "4.22.0",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/wordpress/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/@wp-playground/wordpress/node_modules/express": {
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
+			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "~1.3.8",
+				"array-flatten": "1.1.1",
+				"body-parser": "~1.20.3",
+				"content-disposition": "~0.5.4",
+				"content-type": "~1.0.4",
+				"cookie": "~0.7.1",
+				"cookie-signature": "~1.0.6",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "~1.3.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.0",
+				"merge-descriptors": "1.0.3",
+				"methods": "~1.1.2",
+				"on-finished": "~2.4.1",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "~0.1.12",
+				"proxy-addr": "~2.0.7",
+				"qs": "~6.14.0",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.2.1",
+				"send": "~0.19.0",
+				"serve-static": "~1.16.2",
+				"setprototypeof": "1.2.0",
+				"statuses": "~2.0.1",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/@wp-playground/wordpress/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@wp-playground/wordpress/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@wp-playground/wordpress/node_modules/qs": {
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@xtuc/ieee754": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -6628,6 +9570,18 @@
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true,
 			"license": "Apache-2.0"
+		},
+		"node_modules/@zip.js/zip.js": {
+			"version": "2.7.57",
+			"resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.57.tgz",
+			"integrity": "sha512-BtonQ1/jDnGiMed6OkV6rZYW78gLmLswkHOzyMrMb+CAR7CZO8phOHO6c2qw6qb1g1betN7kwEHhhZk30dv+NA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"bun": ">=0.7.0",
+				"deno": ">=1.0.0",
+				"node": ">=16.5.0"
+			}
 		},
 		"node_modules/abab": {
 			"version": "2.0.6",
@@ -6667,7 +9621,6 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -6775,7 +9728,6 @@
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -7251,6 +10203,13 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/async-lock": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+			"integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -7702,6 +10661,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/before-after-hook": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+			"integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
 		"node_modules/big.js": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -7798,6 +10764,13 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/bottleneck": {
+			"version": "2.19.5",
+			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+			"integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/brace-expansion": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -7841,7 +10814,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.9",
 				"caniuse-lite": "^1.0.30001746",
@@ -7865,6 +10837,13 @@
 			"dependencies": {
 				"node-int64": "^0.4.0"
 			}
+		},
+		"node_modules/btoa-lite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/buffer": {
 			"version": "5.7.1",
@@ -7900,6 +10879,13 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
@@ -7944,6 +10930,51 @@
 				"hookified": "^1.12.1",
 				"keyv": "^5.5.3",
 				"qified": "^0.5.0"
+			}
+		},
+		"node_modules/cacheable-lookup": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.6.0"
+			}
+		},
+		"node_modules/cacheable-request": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+			"integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clone-response": "^1.0.2",
+				"get-stream": "^5.1.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^4.0.0",
+				"lowercase-keys": "^2.0.0",
+				"normalize-url": "^6.0.1",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cacheable-request/node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/cacheable/node_modules/keyv": {
@@ -8207,6 +11238,13 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/chardet": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+			"integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/charenc": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
@@ -8333,6 +11371,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/clean-git-ref": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
 		"node_modules/clean-stack": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -8341,6 +11386,42 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/cli-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"restore-cursor": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cli-spinners": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+			"integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-width": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+			"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/cliui": {
@@ -8356,6 +11437,16 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/clone": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8"
 			}
 		},
 		"node_modules/clone-deep": {
@@ -8386,6 +11477,19 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/clone-response": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/clsx": {
@@ -8553,6 +11657,62 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/concat-stream": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"dev": true,
+			"engines": [
+				"node >= 0.8"
+			],
+			"license": "MIT",
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
+			}
+		},
+		"node_modules/concat-stream/node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/concat-stream/node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/concat-stream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/concat-stream/node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
 		"node_modules/configstore": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
@@ -8638,6 +11798,13 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
 			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/copy-dir": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
+			"integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -8803,6 +11970,19 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/crc-32": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"crc32": "bin/crc32.njs"
+			},
+			"engines": {
+				"node": ">=0.8"
 			}
 		},
 		"node_modules/create-jest": {
@@ -9941,6 +13121,35 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/decompress-response/node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/dedent": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
@@ -10045,6 +13254,29 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/defaults": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+			"integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clone": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/defer-to-connect": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/define-data-property": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -10126,6 +13358,13 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/deprecation": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/destroy": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -10186,8 +13425,7 @@
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1507524.tgz",
 			"integrity": "sha512-OjaNE7qpk6GRTXtqQjAE5bGx6+c4F1zZH0YXtpZQLM92HNXx4zMAaqlKhP4T52DosG6hDW8gPMNhGOF8xbwk/w==",
 			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/diff-sequences": {
 			"version": "29.6.3",
@@ -10198,6 +13436,13 @@
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
+		},
+		"node_modules/diff3": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.4.tgz",
+			"integrity": "sha512-f1rQ7jXDn/3i37hdwRk9ohqcvLRH3+gEIgmA6qEM280WUOh7cOr3GXV8Jm5sPwUs46Nzl48SE8YNLGJoaLuodg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -10223,6 +13468,19 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/docker-compose": {
+			"version": "0.24.8",
+			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+			"integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"yaml": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
 			}
 		},
 		"node_modules/doctrine": {
@@ -10395,6 +13653,16 @@
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"node_modules/ee-first": {
 			"version": "1.1.1",
@@ -10826,7 +14094,6 @@
 			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -10883,7 +14150,6 @@
 			"integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -11972,6 +15238,25 @@
 			],
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.3.7",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.7.tgz",
+			"integrity": "sha512-JzVLro9NQv92pOM/jTCR6mHlJh2FGwtomH8ZQjhFj/R29P2Fnj38OgPJVtcvYw6SuKClhgYuwUZf5b3rd8u2mA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"strnum": "^2.1.2"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
 		"node_modules/fastest-levenshtein": {
 			"version": "1.0.16",
 			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -12406,6 +15691,45 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/fs-ext-extra-prebuilt": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/fs-ext-extra-prebuilt/-/fs-ext-extra-prebuilt-2.2.7.tgz",
+			"integrity": "sha512-Q7rayYRBDIvDF01HWOwSSjoaP+05N1g+o3BXL1Zf8Frw2JkjSmi4EtvCBITuW30l6hB2m2TW1pehdh8wyU/+gw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"nan": "^2.24.0"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+			"integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/fs-extra/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
 		"node_modules/fs-monkey": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
@@ -12820,6 +16144,32 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/got": {
+			"version": "11.8.6",
+			"resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+			"integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/is": "^4.0.0",
+				"@szmarczak/http-timer": "^4.0.5",
+				"@types/cacheable-request": "^6.0.1",
+				"@types/responselike": "^1.0.0",
+				"cacheable-lookup": "^5.0.3",
+				"cacheable-request": "^7.0.2",
+				"decompress-response": "^6.0.0",
+				"http2-wrapper": "^1.0.0-beta.5.2",
+				"lowercase-keys": "^2.0.0",
+				"p-cancelable": "^2.0.0",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/got?sponsor=1"
+			}
+		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -13162,6 +16512,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/http-cache-semantics": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
 		"node_modules/http-deceiver": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -13256,6 +16613,33 @@
 				"@types/express": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/http2-wrapper": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"quick-lru": "^5.1.1",
+				"resolve-alpn": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
+			}
+		},
+		"node_modules/http2-wrapper/node_modules/quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/https-proxy-agent": {
@@ -13905,6 +17289,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-interactive": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/is-map": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -14388,7 +17782,6 @@
 			"integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jest/core": "^29.7.0",
 				"@jest/types": "^29.6.3",
@@ -15194,6 +18587,65 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/jsonfile": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonfile/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/jsonwebtoken": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+			"integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jws": "^4.0.1",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			}
+		},
+		"node_modules/jsonwebtoken/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/jsx-ast-utils": {
 			"version": "3.3.5",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -15208,6 +18660,29 @@
 			},
 			"engines": {
 				"node": ">=4.0"
+			}
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/keyv": {
@@ -15454,8 +18929,7 @@
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1508733.tgz",
 			"integrity": "sha512-QJ1R5gtck6nDcdM+nlsaJXcelPEI7ZxSMw1ujHpO1c4+9l+Nue5qlebi9xO1Z2MGr92bFOQTW7/rrheh5hHxDg==",
 			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
 			"version": "8.18.3",
@@ -15624,6 +19098,48 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -15635,6 +19151,13 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -15711,6 +19234,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/lowercase-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/lru-cache": {
@@ -16176,6 +19709,16 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -16275,6 +19818,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/minimisted": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.2.5"
+			}
+		},
 		"node_modules/minipass": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -16316,6 +19869,19 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/mkdirp": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.2.6"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			}
+		},
 		"node_modules/module-details-from-path": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -16353,6 +19919,23 @@
 			"bin": {
 				"multicast-dns": "cli.js"
 			}
+		},
+		"node_modules/mute-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+			"integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/nan": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
+			"integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
@@ -16512,6 +20095,19 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/normalize-url": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/npm-bundled": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
@@ -16535,7 +20131,6 @@
 			"integrity": "sha512-cuXAJJB1Rdqz0UO6w524matlBqDBjcNt7Ru+RDIu4y6RI1gVqiWBnylrK8sPRk81gGBA0X8hJbDXolVOoTc+sA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.6",
 				"ajv-errors": "^1.0.1",
@@ -16972,6 +20567,28 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/octokit": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/octokit/-/octokit-3.1.2.tgz",
+			"integrity": "sha512-MG5qmrTL5y8KYwFgE1A4JWmgfQBaIETE/lOlfwNYx1QOtCQHGVxkRJmdUJltFc1HVn73d61TlMhMyNTOtMl+ng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/app": "^14.0.2",
+				"@octokit/core": "^5.0.0",
+				"@octokit/oauth-app": "^6.0.0",
+				"@octokit/plugin-paginate-graphql": "^4.0.0",
+				"@octokit/plugin-paginate-rest": "^9.0.0",
+				"@octokit/plugin-rest-endpoint-methods": "^10.0.0",
+				"@octokit/plugin-retry": "^6.0.0",
+				"@octokit/plugin-throttling": "^8.0.0",
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/types": "^12.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
 		"node_modules/on-finished": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -17067,6 +20684,141 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/ora": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
+			"integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^3.0.0",
+				"cli-cursor": "^3.1.0",
+				"cli-spinners": "^2.2.0",
+				"is-interactive": "^1.0.0",
+				"log-symbols": "^3.0.0",
+				"mute-stream": "0.0.8",
+				"strip-ansi": "^6.0.0",
+				"wcwidth": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/chalk": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+			"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ora/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/ora/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ora/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/ora/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/ora/node_modules/log-symbols": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+			"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^2.4.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ora/node_modules/log-symbols/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/ora/node_modules/log-symbols/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/ora/node_modules/log-symbols/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/ora/node_modules/mute-stream": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -17093,6 +20845,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/p-cancelable": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/p-limit": {
@@ -17264,6 +21026,20 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0"
+		},
+		"node_modules/pako": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+			"dev": true,
+			"license": "(MIT AND Zlib)"
 		},
 		"node_modules/param-case": {
 			"version": "3.0.4",
@@ -17521,6 +21297,16 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/pirates": {
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -17641,6 +21427,7 @@
 			"integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"playwright-core": "1.56.0"
 			},
@@ -17660,6 +21447,7 @@
 			"integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"playwright-core": "cli.js"
 			},
@@ -17678,6 +21466,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
@@ -17728,7 +21517,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -18475,7 +22263,6 @@
 			"integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -18689,6 +22476,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/ps-man": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/ps-man/-/ps-man-1.1.8.tgz",
+			"integrity": "sha512-ZKDPZwHLYVWIk/Q75N7jCFbuQyokSg2+3WBlt8l35S/uBvxoc+LiRUbb3RUt83pwW82dzwiCpoQIHd9PAxUzHg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/psl": {
 			"version": "1.15.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -18897,7 +22691,6 @@
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -18911,7 +22704,6 @@
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -18933,7 +22725,6 @@
 			"integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -19287,6 +23078,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/resolve-alpn": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/resolve-bin": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/resolve-bin/-/resolve-bin-0.4.3.tgz",
@@ -19342,6 +23140,33 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/responselike": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lowercase-keys": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/restore-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/retry": {
@@ -19672,7 +23497,6 @@
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -19987,6 +23811,27 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/sha.js": {
+			"version": "2.4.12",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+			"integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+			"dev": true,
+			"license": "(MIT AND BSD-3-Clause)",
+			"dependencies": {
+				"inherits": "^2.0.4",
+				"safe-buffer": "^5.2.1",
+				"to-buffer": "^1.2.0"
+			},
+			"bin": {
+				"sha.js": "bin.js"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/shallow-clone": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
@@ -20151,6 +23996,69 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
+		"node_modules/simple-git": {
+			"version": "3.32.2",
+			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.32.2.tgz",
+			"integrity": "sha512-n/jhNmvYh8dwyfR6idSfpXrFazuyd57jwNMzgjGnKZV/1lTh0HKvPq20v4AQ62rP+l19bWjjXPTCdGHMt0AdrQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@kwsites/file-exists": "^1.1.1",
+				"@kwsites/promise-deferred": "^1.1.1",
+				"debug": "^4.4.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/steveukx/git-js?sponsor=1"
+			}
 		},
 		"node_modules/sirv": {
 			"version": "2.0.4",
@@ -20935,6 +24843,19 @@
 				"node": ">=0.8.0"
 			}
 		},
+		"node_modules/strnum": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+			"integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/stubborn-fs": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.5.tgz",
@@ -20981,7 +24902,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@csstools/css-parser-algorithms": "^3.0.5",
 				"@csstools/css-tokenizer": "^3.0.4",
@@ -21317,7 +25237,6 @@
 			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -21599,6 +25518,37 @@
 				}
 			}
 		},
+		"node_modules/terminal-link": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+			"integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-escapes": "^4.2.1",
+				"supports-hyperlinks": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/terminal-link/node_modules/supports-hyperlinks": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+			"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/terser": {
 			"version": "5.44.0",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.44.0.tgz",
@@ -21845,7 +25795,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -21870,12 +25819,47 @@
 				"tldts-core": "^7.0.17"
 			}
 		},
+		"node_modules/tmp": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/tmp-promise": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+			"integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tmp": "^0.2.0"
+			}
+		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
 			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
 			"dev": true,
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/to-buffer": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+			"integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"isarray": "^2.0.5",
+				"safe-buffer": "^5.2.1",
+				"typed-array-buffer": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -22090,7 +26074,6 @@
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -22194,6 +26177,13 @@
 			"version": "2.12.0",
 			"resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
 			"integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -22309,6 +26299,24 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/universal-github-app-jwt": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.2.0.tgz",
+			"integrity": "sha512-dncpMpnsKBk0eetwfN8D8OUHGfiDhhJ+mtsbMl+7PfW7mYjiH8LIcqRmYMtzYLgSh47HjfdBtrBwIQ/gizKR3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/jsonwebtoken": "^9.0.0",
+				"jsonwebtoken": "^9.0.2"
+			}
+		},
+		"node_modules/universal-user-agent": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/universalify": {
 			"version": "0.2.0",
@@ -22576,6 +26584,13 @@
 				"makeerror": "1.0.12"
 			}
 		},
+		"node_modules/wasm-feature-detect": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+			"integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
 		"node_modules/watchpack": {
 			"version": "2.4.4",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -22598,6 +26613,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"minimalistic-assert": "^1.0.0"
+			}
+		},
+		"node_modules/wcwidth": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"defaults": "^1.0.3"
 			}
 		},
 		"node_modules/web-vitals": {
@@ -22630,7 +26655,6 @@
 			"integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -22739,7 +26763,6 @@
 			"integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.0",
 				"@webpack-cli/configtest": "^2.1.1",
@@ -22820,7 +26843,6 @@
 			"integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/bonjour": "^3.5.9",
 				"@types/connect-history-api-fallback": "^1.3.5",
@@ -23323,6 +27345,30 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/xml2js": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
 		"node_modules/xmlchars": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -23356,6 +27402,22 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/yaml": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
 		},
 		"node_modules/yargs": {
 			"version": "17.7.2",
@@ -23405,6 +27467,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yoctocolors-cjs": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+			"integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"test:e2e:all-coverage": "rm -rf .nyc_output .php-coverage && COVERAGE_ENABLED=true PHP_COVERAGE_ENABLED=true wp-scripts test-playwright",
 		"test:unit": "wp-scripts test-unit-js",
 		"test:unit:watch": "wp-scripts test-unit-js --watch",
-		"watch": "webpack --watch"
+		"watch": "webpack --watch",
+		"wp-env": "wp-env"
 	},
 	"dependencies": {
 		"@wordpress/icons": "^10.26.0",
@@ -30,6 +31,7 @@
 		"@testing-library/react": "^14.1.2",
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.20.0",
 		"@wordpress/e2e-test-utils-playwright": "^1.20.0",
+		"@wordpress/env": "^10.39.0",
 		"@wordpress/icons": "^10.26.0",
 		"@wordpress/prettier-config": "^4.22.0",
 		"@wordpress/priority-queue": "^3.22.0",


### PR DESCRIPTION
To fix e2e tests in CI, and to make instructions from `AGENTS.md` work out of the box.

Previously, `@wordpress/env` was installed globally (`npm i -g`) by the e2e CI workflow. With the [recent update to `@wordpress/env`](https://github.com/WordPress/gutenberg/pull/75341) (which included a major change to the `.wp-env.json` format), this has started failing.

To fix this, we can simply add `@wordpress/env` as a `devDependency` to `package.json` and have it installed locally. This allows us to control the version of the package that's used.

As an additional benefit, this makes local setup consistent with CI, and more reproducible. Previously, Claude Code was struggling to get the environment to start, as the commands in `AGENTS.md` required running `npm run wp-env start`, which wouldn't work: https://github.com/WordPress/secure-custom-fields/blob/b25cb5858a3d3ee2676e0815b431c2b92b059dc0/AGENTS.md

Eventually, we can consider upgrading to `@wordpress/env` v11.x and its new format, but that's for another PR.