### PR TITLE
Changed name of auto post-type config export

### DIFF
--- a/includes/admin/post-types/admin-field-groups.php
+++ b/includes/admin/post-types/admin-field-groups.php
@@ -93,7 +93,7 @@ if ( ! class_exists( 'ACF_Admin_Field_Groups' ) ) :
 			);
 
 			if ( acf_get_local_json_files( $this->post_type ) ) {
-				$columns['acf-json'] = __( 'Local JSON', 'secure-custom-fields' );
+				$columns['scf-json'] = __( 'Local JSON', 'secure-custom-fields' );
 			}
 
 			return $columns;
@@ -139,7 +139,7 @@ if ( ! class_exists( 'ACF_Admin_Field_Groups' ) ) :
 					break;
 
 					// Local JSON.
-				case 'acf-json':
+				case 'scf-json':
 					$this->render_admin_table_column_local_status( $post );
 					break;
 			}

--- a/includes/admin/post-types/admin-post-types.php
+++ b/includes/admin/post-types/admin-post-types.php
@@ -114,7 +114,7 @@ if ( ! class_exists( 'ACF_Admin_Post_Types' ) ) :
 			);
 
 			if ( acf_get_local_json_files( $this->post_type ) ) {
-				$columns['acf-json'] = __( 'Local JSON', 'secure-custom-fields' );
+				$columns['scf-json'] = __( 'Local JSON', 'secure-custom-fields' );
 			}
 
 			return $columns;
@@ -160,7 +160,7 @@ if ( ! class_exists( 'ACF_Admin_Post_Types' ) ) :
 					break;
 
 					// Local JSON.
-				case 'acf-json':
+				case 'scf-json':
 					$this->render_admin_table_column_local_status( $post );
 					break;
 			}

--- a/includes/admin/post-types/admin-taxonomies.php
+++ b/includes/admin/post-types/admin-taxonomies.php
@@ -114,7 +114,7 @@ if ( ! class_exists( 'ACF_Admin_Taxonomies' ) ) :
 			);
 
 			if ( acf_get_local_json_files( $this->post_type ) ) {
-				$columns['acf-json'] = __( 'Local JSON', 'secure-custom-fields' );
+				$columns['scf-json'] = __( 'Local JSON', 'secure-custom-fields' );
 			}
 
 			return $columns;
@@ -160,7 +160,7 @@ if ( ! class_exists( 'ACF_Admin_Taxonomies' ) ) :
 					break;
 
 					// Local JSON.
-				case 'acf-json':
+				case 'scf-json':
 					$this->render_admin_table_column_local_status( $post );
 					break;
 			}

--- a/includes/admin/post-types/class-acf-admin-ui-options-pages.php
+++ b/includes/admin/post-types/class-acf-admin-ui-options-pages.php
@@ -123,7 +123,7 @@ if ( ! class_exists( 'ACF_Admin_UI_Options_Pages' ) ) :
 			);
 
 			if ( acf_get_local_json_files( $this->post_type ) ) {
-				$columns['acf-json'] = __( 'Local JSON', 'secure-custom-fields' );
+				$columns['scf-json'] = __( 'Local JSON', 'secure-custom-fields' );
 			}
 
 			return $columns;
@@ -157,7 +157,7 @@ if ( ! class_exists( 'ACF_Admin_UI_Options_Pages' ) ) :
 					break;
 
 					// Local JSON.
-				case 'acf-json':
+				case 'scf-json':
 					$this->render_admin_table_column_local_status( $post );
 					break;
 			}

--- a/includes/local-json.php
+++ b/includes/local-json.php
@@ -27,8 +27,8 @@ if ( ! class_exists( 'ACF_Local_JSON' ) ) :
 		public function __construct() {
 
 			// Update settings.
-			acf_update_setting( 'save_json', get_stylesheet_directory() . '/acf-json' );
-			acf_append_setting( 'load_json', get_stylesheet_directory() . '/acf-json' );
+			acf_update_setting( 'save_json', get_stylesheet_directory() . '/scf-json' );
+			acf_append_setting( 'load_json', get_stylesheet_directory() . '/scf-json' );
 
 			// Add listeners.
 			add_action( 'acf/update_field_group', array( $this, 'update_field_group' ) );


### PR DESCRIPTION
Changed the theme directory prefix for post type auto json export. So user simply needs to create a directory called `scf-json` in the theme and on save of scf group it is auto exported as a .json file into the codebase for env sync. 

Steps:
- Create a directory called scf-json in your theme
- Create a new SCF Group add a field and save.
- scf-json should now have an exported .json file of your scf-json