### PR TITLE
CI: Include WP trunk in e2e test runs on PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,14 +31,12 @@ jobs:
                 node: ['22', '24']
                 wp: ['6.2', 'latest', 'trunk']
                 exclude:
-                    # On PRs: only test Node 22 + WP latest for fast feedback
-                    # On trunk: full matrix with minimum and latest WP versions
+                    # On PRs: only test Node 22 + WP latest and trunk for fast feedback
+                    # On trunk: full matrix with node 24 and minimum WP version
                     - event: 'pull_request'
                       node: '24'
                     - event: 'pull_request'
                       wp: '6.2'
-                    - event: 'pull_request'
-                      wp: 'trunk'
 
         env:
             WP_ENV_CORE: ${{ matrix.wp == 'trunk' && 'WordPress/WordPress' || (matrix.wp != 'latest' && format('WordPress/WordPress#{0}', matrix.wp) || null) }}


### PR DESCRIPTION
I've noticed that e2e tests are failing when run against WP `trunk`. (See e.g. [here](https://github.com/WordPress/secure-custom-fields/actions/runs/22869787034/job/66346197434) and [here](https://github.com/WordPress/secure-custom-fields/actions/runs/22869787034/job/66346197424).)

This is somewhat unsurprising, since we're currently near the release of WP 7.0, so WP `trunk` has evolved considerably since the latest stable release (6.9.x).

It'd be good to preemptively catch problems, so I'm adding back WP `trunk` to the test matrix for PRs (rather than only on merge, i.e. after the fact).

If we find that e2e tests take to long, we might want to audit them (and e.g. tweak test fixtures and setup, and/or use `test.step` to cover multiple scenarios in one test).