### PR TITLE
CI: Collect e2e failure artifacts and generate merged HTML report

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,6 +73,22 @@ jobs:
                   PHP_COVERAGE_ENABLED: true
               run: npm run test:e2e:coverage -- --shard=${{ matrix.shard }}/4
 
+            - name: Archive debug artifacts (screenshots, traces)
+              uses: actions/upload-artifact@v4
+              if: ${{ !cancelled() }}
+              with:
+                  name: failures-artifacts--node${{ matrix.node }}-wp${{ matrix.wp }}-shard${{ matrix.shard }}
+                  path: artifacts/test-results
+                  if-no-files-found: ignore
+
+            - name: Archive blob reports (HTML)
+              uses: actions/upload-artifact@v4
+              if: ${{ !cancelled() }}
+              with:
+                  name: blob-reports--node${{ matrix.node }}-wp${{ matrix.wp }}-shard${{ matrix.shard }}
+                  path: blob-report
+                  if-no-files-found: ignore
+
             - name: Generate E2E JS coverage report
               if: always()
               run: |
@@ -112,3 +128,58 @@ jobs:
             - name: Stop wp-env
               if: always()
               run: npm run wp-env stop
+
+    merge-artifacts:
+        name: Merge Artifacts
+        if: ${{ !cancelled() }}
+        needs: [test]
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '22'
+                  cache: 'npm'
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Merge failures artifacts
+              uses: actions/upload-artifact/merge@v4
+              continue-on-error: true
+              with:
+                  name: failures-artifacts
+                  pattern: failures-artifacts--*
+                  delete-merged: true
+
+            - name: Merge blob reports
+              uses: actions/upload-artifact/merge@v4
+              continue-on-error: true
+              with:
+                  name: blob-reports-merged
+                  pattern: blob-reports--*
+                  delete-merged: true
+
+            - name: Download merged blob reports
+              uses: actions/download-artifact@v4
+              continue-on-error: true
+              with:
+                  name: blob-reports-merged
+                  path: all-blob-reports
+
+            - name: Merge blob reports into HTML report
+              run: npx playwright merge-reports --reporter html ./all-blob-reports
+              continue-on-error: true
+
+            - name: Upload merged HTML report
+              uses: actions/upload-artifact@v4
+              continue-on-error: true
+              with:
+                  name: html-report--attempt-${{ github.run_attempt }}
+                  path: playwright-report
+                  if-no-files-found: ignore

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,6 +24,9 @@ if ( ! process.env.WP_BASE_URL ) {
 const config = defineConfig( {
 	...baseConfig,
 	testDir: './tests/e2e',
+	reporter: process.env.CI
+		? [ [ 'github' ], [ 'blob' ] ]
+		: [ [ 'list' ] ],
 	use: {
 		...baseConfig.use,
 		baseURL: process.env.WP_BASE_URL,


### PR DESCRIPTION
Add screenshot/trace artifact uploads per shard and a merge-artifacts job that combines them into a single downloadable HTML report, following the same pattern used in Gutenberg's end2end workflow.

## AI Usage

Created with Claude Code (Opus 4.6) with the following prompt:

> I'd like to change the current GHA workflow to collect artifacts from e2e -- specifically screenshots if a test fails, and to include them in the test run summary, much like Gutenberg does.