### PR TITLE
CI: Pin GHA dependencies

### DIFF
--- a/.github/workflows/docs-manifest.yml
+++ b/.github/workflows/docs-manifest.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
       with:
         php-version: '8.4'
         tools: composer:v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,10 +42,10 @@ jobs:
             WP_ENV_CORE: ${{ matrix.wp == 'trunk' && 'WordPress/WordPress' || (matrix.wp != 'latest' && format('WordPress/WordPress#{0}', matrix.wp) || null) }}
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
               with:
                   node-version: ${{ matrix.node }}
                   cache: 'npm'
@@ -74,7 +74,7 @@ jobs:
               run: npm run test:e2e:coverage -- --shard=${{ matrix.shard }}/4
 
             - name: Archive debug artifacts (screenshots, traces)
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
               if: ${{ !cancelled() }}
               with:
                   name: failures-artifacts--node${{ matrix.node }}-wp${{ matrix.wp }}-shard${{ matrix.shard }}
@@ -82,7 +82,7 @@ jobs:
                   if-no-files-found: ignore
 
             - name: Archive blob reports (HTML)
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
               if: ${{ !cancelled() }}
               with:
                   name: blob-reports--node${{ matrix.node }}-wp${{ matrix.wp }}-shard${{ matrix.shard }}
@@ -105,7 +105,7 @@ jobs:
 
             - name: Upload E2E JS Coverage to Codecov
               if: always() && hashFiles('./coverage/e2e/lcov.info') != ''
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   files: ./coverage/e2e/lcov.info
@@ -116,7 +116,7 @@ jobs:
 
             - name: Upload E2E PHP Coverage to Codecov
               if: always() && hashFiles('./coverage/php-e2e/lcov.info') != ''
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   files: ./coverage/php-e2e/lcov.info
@@ -138,10 +138,10 @@ jobs:
             contents: read
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
               with:
                   node-version: '22'
                   cache: 'npm'
@@ -150,7 +150,7 @@ jobs:
               run: npm ci
 
             - name: Merge failures artifacts
-              uses: actions/upload-artifact/merge@v4
+              uses: actions/upload-artifact/merge@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
               continue-on-error: true
               with:
                   name: failures-artifacts
@@ -158,7 +158,7 @@ jobs:
                   delete-merged: true
 
             - name: Merge blob reports
-              uses: actions/upload-artifact/merge@v4
+              uses: actions/upload-artifact/merge@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
               continue-on-error: true
               with:
                   name: blob-reports-merged
@@ -166,7 +166,7 @@ jobs:
                   delete-merged: true
 
             - name: Download merged blob reports
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
               continue-on-error: true
               with:
                   name: blob-reports-merged
@@ -177,7 +177,7 @@ jobs:
               continue-on-error: true
 
             - name: Upload merged HTML report
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
               continue-on-error: true
               with:
                   name: html-report--attempt-${{ github.run_attempt }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0  # Required for phpcs-changed to compare with base branch
         
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
       with:
         php-version: '8.4'
         tools: composer:v2, cs2pr

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
         with:
           php-version: '8.4'
           coverage: none

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
@@ -50,7 +50,7 @@ jobs:
         run: mkdir -p coverage/phpunit && vendor/bin/phpunit --coverage-clover=coverage/phpunit/coverage.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: WordPress/secure-custom-fields

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,13 +36,13 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   show-progress: false
                   persist-credentials: false
 
             - name: Setup Node.js and install dependencies
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
               with:
                   node-version: ${{ matrix.node }}
                   cache: 'npm'
@@ -55,7 +55,7 @@ jobs:
 
             - name: Upload coverage to Codecov
               if: always()
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   files: ./coverage/unit/lcov.info

--- a/.github/workflows/verify-field-schema.yml
+++ b/.github/workflows/verify-field-schema.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
         with:
           php-version: '8.1'
 


### PR DESCRIPTION
Per GHA guidelines: https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

(Strictly speaking, it might not be necessary for actions provided by GH itself, i.e. anything with an `action/` prefix. For consistency's sake, and in line with Gutenberg's practice, I'm pinning all GHA dependencies. Dependabot should be able to update them regardless.)