### PR TITLE
Prepare 6.8.1 Release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Secure Custom Fields ===
 Contributors: wordpressdotorg
 Tags: fields, custom fields, meta, scf
-Requires at least: 6.0
-Tested up to: 6.9
+Requires at least: 6.2
+Tested up to: 6.9.1
 Requires PHP: 7.4
 Stable tag: 6.8.0
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -55,7 +55,7 @@ This plugin builds upon and is a fork of the previous work done by the contribut
 = 6.8.1 =
 *Release Date 11th March 2026*
 
-* Backports from 6.7.1*
+*Backports from 6.7.1*
 
 - Security - User field AJAX queries now enforce field-configured role restrictions and validate search permissions.
 - Security - Post Object, Relationship, and Page Link field AJAX queries now enforce field-configured restrictions for post status, post type, and taxonomy.

--- a/readme.txt
+++ b/readme.txt
@@ -52,6 +52,15 @@ This plugin builds upon and is a fork of the previous work done by the contribut
 
 == Changelog ==
 
+= 6.8.1 =
+*Release Date 11th March 2026*
+
+* Backports from 6.7.1*
+
+- Security - User field AJAX queries now enforce field-configured role restrictions and validate search permissions.
+- Security - Post Object, Relationship, and Page Link field AJAX queries now enforce field-configured restrictions for post status, post type, and taxonomy.
+- Site Health - Track blocks using auto inline editing.
+
 = 6.8.0 =
 *Release Date 30 Dec 2025*
 

--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -6,7 +6,7 @@
  * Plugin Name:       Secure Custom Fields
  * Plugin URI:        https://developer.wordpress.org/secure-custom-fields/
  * Description:       Secure Custom Fields (SCF) offers an intuitive way for developers to enhance WordPress content management by adding extra fields and options without coding requirements.
- * Version:           6.8.0
+ * Version:           6.8.1
  * Author:            WordPress.org
  * Author URI:        https://wordpress.org/
  * Text Domain:       secure-custom-fields
@@ -33,7 +33,7 @@ if ( ! class_exists( 'ACF' ) ) {
 		 *
 		 * @var string
 		 */
-		public $version = '6.8.0';
+		public $version = '6.8.1';
 
 		/**
 		 * The plugin settings array.


### PR DESCRIPTION
*Release Date 11th March 2026*

*Backports from 6.7.1*

- Security - User field AJAX queries now enforce field-configured role restrictions and validate search permissions.
- Security - Post Object, Relationship, and Page Link field AJAX queries now enforce field-configured restrictions for post status, post type, and taxonomy.
- Site Health - Track blocks using auto inline editing.

--- 

Supersedes #379.