### PR TITLE
Update AGENTS.md with corrections and missing info

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # AGENTS.md
 
+## Repository info
+
+-   Default branch: `trunk`
+-   PRs target `trunk` unless stated otherwise
+
 ## Dev environment tips
 
 ```bash
@@ -34,6 +39,10 @@ vendor/bin/phpunit <path_to_test_file.php>  # Specific file
 vendor/bin/phpunit <path_to_test_directory>/              # Directory
 composer test:phpstan     # Static analysis only
 
+# JavaScript unit tests
+npm run test:unit         # Jest unit tests
+npm run test:unit:watch   # Jest in watch mode
+
 # E2E (requires wp-env)
 npm run test:e2e
 npm run test:e2e:debug    # Debug mode
@@ -41,24 +50,26 @@ npm run test:e2e -- --headed                   # Run with browser visible
 npm run test:e2e -- <path_to_test_file.spec.js>  # Specific test file
 
 # Code Quality
-npx wp-scripts lint-js   # Check JavaScript linting
-npx wp-scripts format    # Fix JavaScript formatting
-composer lint:php        # Check PHP standards
-vendor/bin/phpcs         # Check PHP standards
-vendor/bin/phpcbf        # Fix PHP standards
+npx wp-scripts lint-js    # Check JavaScript linting
+npx wp-scripts format     # Fix JavaScript formatting
+composer lint:php         # Check PHP standards (phpcs)
+composer format:php       # Fix PHP standards (phpcbf)
 
 # Specific files
-vendor/bin/phpcbf <path_to_php_file.php>
+vendor/bin/phpcs <path_to_php_file.php>   # Check specific file
+vendor/bin/phpcbf <path_to_php_file.php>  # Fix specific file
 ```
 
 ## Code patterns
 
-- **Naming**: New functions use `scf_` prefix and hooks use `scf/hook_name`, existing use `acf_` and `acf/hook_name` (backward compat)  
+- **Naming**: New functions use `scf_` prefix and hooks use `scf/hook_name`, existing use `acf_` and `acf/hook_name` (backward compat)
 - **Internationalization**: Use `__()`, `_e()` with text domain `'secure-custom-fields'`
 - **Output escaping**: Always escape with `esc_html()`, `esc_attr()`, `esc_url()`
 - **Input sanitization**: Use `sanitize_text_field()`, `sanitize_file_name()`
 
 ## PR instructions
 
+-   Target branch: `trunk`
+-   Always use the pull request template at `.github/PULL_REQUEST_TEMPLATE.md` and fill out all sections
 -   Ensure build passes
 -   Fix all formatting/linting issues; these are enforced through CI in PRs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,9 +43,10 @@ composer test:phpstan     # Static analysis only
 npm run test:unit         # Jest unit tests
 npm run test:unit:watch   # Jest in watch mode
 
-# E2E (requires wp-env)
-npm run test:e2e
-npm run test:e2e:debug    # Debug mode
+# End-to-end tests (Playwright, requires wp-env)
+# IMPORTANT: NEVER run `npx playwright test` directly — always use these npm scripts:
+npm run test:e2e                               # All E2E tests
+npm run test:e2e:debug                         # Debug mode
 npm run test:e2e -- --headed                   # Run with browser visible
 npm run test:e2e -- <path_to_test_file.spec.js>  # Specific test file
 


### PR DESCRIPTION
Closes <!-- n/a -->

Reviewed the AGENTS.md file and found several issues and gaps:

- Added repository info section explicitly noting `trunk` as the default branch (AI agents often receive incorrect system prompt info saying `main`)
- Added JavaScript unit test commands (`npm run test:unit`, `test:unit:watch`) which were missing
- Replaced direct `vendor/bin/phpcs` / `vendor/bin/phpcbf` references with `composer lint:php` / `composer format:php` as the primary commands, keeping `vendor/bin/` only for targeting specific files
- Added `vendor/bin/phpcs` for checking specific files (only `phpcbf` was listed)
- Added PR instructions to always target `trunk` and use the PR template

## Use of AI Tools

This PR was authored with Claude Code after interactive review of the original file and changes were reviewed by Kraft before push.