### PR TITLE
E2E Tests: Fix post types setup plugin

### DIFF
--- a/tests/e2e/plugins/scf-test-setup-post-types.php
+++ b/tests/e2e/plugins/scf-test-setup-post-types.php
@@ -6,15 +6,6 @@
  * Author: SCF Testing
  *
  * @package wordpress/secure-custom-fields
- *
- * IMPORTANT NOTE:
- * This plugin uses a hacky approach to create a test post type that SCF will recognize as its own, don't replicate in production code:
- *
- * - We use SCF's internal APIs (acf_get_internal_post_type_instance) that aren't meant for public use
- *    and could change between versions without notice.
- *
- * - We're directly creating database entries that SCF normally manages through its UI,
- *    bypassing the normal workflow and validation that the UI might provide.
  */
 
 // Exit if accessed directly
@@ -61,79 +52,38 @@ function scf_test_register_post_types() {
 }
 
 /**
- * Create an SCF post type entry in the database
+ * Register a local SCF post type (no database entry needed).
  *
- * This function creates a post of type 'acf-post-type' in the database, which is how SCF
- * stores its post type definitions. When the REST API endpoint calls
- * acf_get_internal_post_type_posts('acf-post-type'), it will return our custom post type,
- * causing it to be categorized as an SCF post type.
- *
- * NOTE: This is a hacky approach that uses SCF's internal APIs and should not be used
- * in production. Ideally, SCF would provide a public API for registering post types
- * programmatically.
+ * Uses the acf/include_post_types hook, which fires before SCF's
+ * register_post_types(), so the post type is available on the very
+ * first request after plugin activation — no second page-load required.
  */
-function scf_test_create_scf_post_type_entry() {
-	// Check if we've already created this post type to avoid duplicates
-	if ( get_option( 'scf_test_post_type_created' ) ) {
-		return;
-	}
-
-	// Make sure SCF is fully loaded
-	if ( ! function_exists( 'acf_get_internal_post_type_instance' ) ) {
-		return;
-	}
-
-	// Get the internal post type instance for managing acf-post-type entries
-	$instance = acf_get_internal_post_type_instance( 'acf-post-type' );
-	if ( ! $instance ) {
-		return;
-	}
-
-	// Define our post type configuration (similar to what you'd fill in the UI)
-	// This structure mirrors what SCF creates when you use the UI to create a post type
-	$post_type_config = array(
-		'key'                => 'scf_e2e_test_post_type',
-		'title'              => 'SCF E2E Test Type',
-		'post_type'          => 'scf-e2e-test-type',
-		'description'        => 'Test post type for SCF E2E testing',
-		'active'             => 1,
-		'public'             => 1,
-		'show_in_rest'       => 1,
-		'publicly_queryable' => 1,
-		'show_ui'            => 1,
-		'show_in_menu'       => 1,
-		'has_archive'        => 1,
-		'supports'           => array( 'title', 'editor' ),
-		'labels'             => array(
-			'name'          => 'SCF E2E Test Type',
-			'singular_name' => 'SCF E2E Test Item',
+function scf_test_add_local_scf_post_type() {
+	acf_add_local_internal_post_type(
+		array(
+			'key'                => 'scf_e2e_test_post_type',
+			'title'              => 'SCF E2E Test Type',
+			'post_type'          => 'scf-e2e-test-type',
+			'description'        => 'Test post type for SCF E2E testing',
+			'active'             => true,
+			'public'             => true,
+			'show_in_rest'       => true,
+			'publicly_queryable' => true,
+			'show_ui'            => true,
+			'show_in_menu'       => true,
+			'has_archive'        => true,
+			'supports'           => array( 'title', 'editor' ),
+			'labels'             => array(
+				'name'          => 'SCF E2E Test Types',
+				'singular_name' => 'SCF E2E Test Item',
+				'add_new_item'  => 'Add New SCF E2E Test Item',
+				'all_items'     => 'All SCF E2E Test Types',
+			),
 		),
+		'acf-post-type'
 	);
-
-	// Create the post type entry in the database using SCF's internal API
-	$result = $instance->update_post( $post_type_config );
-
-	if ( is_array( $result ) && isset( $result['ID'] ) ) {
-		// Store the post ID so we can delete it later
-		update_option( 'scf_test_post_type_created', $result['ID'] );
-	}
-}
-
-/**
- * Clean up on plugin deactivation
- */
-function scf_test_cleanup() {
-	// Get the stored post ID and delete the post
-	$post_id = get_option( 'scf_test_post_type_created' );
-	if ( $post_id ) {
-		wp_delete_post( $post_id, true );
-	}
-
-	// Clean up the option
-	delete_option( 'scf_test_post_type_created' );
 }
 
 // Register hooks
 add_action( 'init', 'scf_test_register_post_types', 20 );
-add_action( 'acf/init', 'scf_test_create_scf_post_type_entry', 15 );
-register_deactivation_hook( __FILE__, 'scf_test_cleanup' );
+add_action( 'acf/include_post_types', 'scf_test_add_local_scf_post_type' );


### PR DESCRIPTION
While working on https://github.com/WordPress/secure-custom-fields/pull/397, I needed to change the `add_new` label on the custom post type (CPT) used for tests. However, this change didn't seem to take effect on the frontend.

This was due to the way the test CPT was registered: It was persisted to the DB, with another DB option set as a flag so the test wouldn't attempt to recreate the CPT and instead use the persisted one. As a result, any changes made programmatically to the CPT didn't take effect.

This PR changes the test setup so the CPT is created on the fly by the plugin (and not persisted to the DB). 

## Use of AI Tools

Claude Code was used to investigate the issue, and to write the fix.
(This is only fair: The issue was originally also produced by Claude Code.)