### PR TITLE
E2E Tests: Fix post types setup plugin

### DIFF
--- a/tests/e2e/plugins/scf-test-setup-post-types.php
+++ b/tests/e2e/plugins/scf-test-setup-post-types.php
@@ -8,13 +8,9 @@
  * @package wordpress/secure-custom-fields
  *
  * IMPORTANT NOTE:
- * This plugin uses a hacky approach to create a test post type that SCF will recognize as its own, don't replicate in production code:
- *
- * - We use SCF's internal APIs (acf_get_internal_post_type_instance) that aren't meant for public use
- *    and could change between versions without notice.
- *
- * - We're directly creating database entries that SCF normally manages through its UI,
- *    bypassing the normal workflow and validation that the UI might provide.
+ * This plugin uses SCF's internal API (acf_update_internal_post_type) to create a test post type
+ * that SCF will recognize as its own. This API isn't meant for public use and could change
+ * between versions without notice.
  */
 
 // Exit if accessed directly
@@ -67,10 +63,6 @@ function scf_test_register_post_types() {
  * stores its post type definitions. When the REST API endpoint calls
  * acf_get_internal_post_type_posts('acf-post-type'), it will return our custom post type,
  * causing it to be categorized as an SCF post type.
- *
- * NOTE: This is a hacky approach that uses SCF's internal APIs and should not be used
- * in production. Ideally, SCF would provide a public API for registering post types
- * programmatically.
  */
 function scf_test_create_scf_post_type_entry() {
 	// Check if we've already created this post type to avoid duplicates
@@ -79,13 +71,7 @@ function scf_test_create_scf_post_type_entry() {
 	}
 
 	// Make sure SCF is fully loaded
-	if ( ! function_exists( 'acf_get_internal_post_type_instance' ) ) {
-		return;
-	}
-
-	// Get the internal post type instance for managing acf-post-type entries
-	$instance = acf_get_internal_post_type_instance( 'acf-post-type' );
-	if ( ! $instance ) {
+	if ( ! function_exists( 'acf_update_internal_post_type' ) ) {
 		return;
 	}
 
@@ -111,7 +97,7 @@ function scf_test_create_scf_post_type_entry() {
 	);
 
 	// Create the post type entry in the database using SCF's internal API
-	$result = $instance->update_post( $post_type_config );
+	$result = acf_update_internal_post_type( $post_type_config, 'acf-post-type' );
 
 	if ( is_array( $result ) && isset( $result['ID'] ) ) {
 		// Store the post ID so we can delete it later

--- a/tests/e2e/plugins/scf-test-setup-post-types.php
+++ b/tests/e2e/plugins/scf-test-setup-post-types.php
@@ -6,11 +6,6 @@
  * Author: SCF Testing
  *
  * @package wordpress/secure-custom-fields
- *
- * IMPORTANT NOTE:
- * This plugin uses SCF's internal API (acf_update_internal_post_type) to create a test post type
- * that SCF will recognize as its own. This API isn't meant for public use and could change
- * between versions without notice.
  */
 
 // Exit if accessed directly

--- a/tests/e2e/plugins/scf-test-setup-post-types.php
+++ b/tests/e2e/plugins/scf-test-setup-post-types.php
@@ -61,9 +61,10 @@ function scf_test_register_post_types() {
  * causing it to be categorized as an SCF post type.
  */
 function scf_test_create_scf_post_type_entry() {
-	// Check if we've already created this post type to avoid duplicates
+	// If the post type already exists (e.g. from a previous test run), delete it.
+	// This ensures that any changes to this file will be reflected it the tests.
 	if ( acf_get_internal_post_type( 'scf_e2e_test_post_type', 'acf-post-type' ) ) {
-		return;
+		acf_delete_internal_post_type( 'scf_e2e_test_post_type', 'acf-post-type' );
 	}
 
 	// Define our post type configuration (similar to what you'd fill in the UI)

--- a/tests/e2e/plugins/scf-test-setup-post-types.php
+++ b/tests/e2e/plugins/scf-test-setup-post-types.php
@@ -4,6 +4,7 @@
  * Description: Creates SCF post types for E2E testing
  * Version: 1.0.0
  * Author: SCF Testing
+ * Requires Plugins: secure-custom-fields
  *
  * @package wordpress/secure-custom-fields
  */
@@ -60,11 +61,6 @@ function scf_test_register_post_types() {
  * causing it to be categorized as an SCF post type.
  */
 function scf_test_create_scf_post_type_entry() {
-	// Make sure SCF is fully loaded
-	if ( ! function_exists( 'acf_update_internal_post_type' ) ) {
-		return;
-	}
-
 	// Check if we've already created this post type to avoid duplicates
 	if ( acf_get_internal_post_type( 'scf_e2e_test_post_type', 'acf-post-type' ) ) {
 		return;
@@ -99,9 +95,7 @@ function scf_test_create_scf_post_type_entry() {
  * Clean up on plugin deactivation
  */
 function scf_test_cleanup() {
-	if ( function_exists( 'acf_delete_internal_post_type' ) ) {
-		acf_delete_internal_post_type( 'scf_e2e_test_post_type', 'acf-post-type' );
-	}
+	acf_delete_internal_post_type( 'scf_e2e_test_post_type', 'acf-post-type' );
 }
 
 // Register hooks

--- a/tests/e2e/plugins/scf-test-setup-post-types.php
+++ b/tests/e2e/plugins/scf-test-setup-post-types.php
@@ -65,13 +65,13 @@ function scf_test_register_post_types() {
  * causing it to be categorized as an SCF post type.
  */
 function scf_test_create_scf_post_type_entry() {
-	// Check if we've already created this post type to avoid duplicates
-	if ( get_option( 'scf_test_post_type_created' ) ) {
+	// Make sure SCF is fully loaded
+	if ( ! function_exists( 'acf_update_internal_post_type' ) ) {
 		return;
 	}
 
-	// Make sure SCF is fully loaded
-	if ( ! function_exists( 'acf_update_internal_post_type' ) ) {
+	// Check if we've already created this post type to avoid duplicates
+	if ( acf_get_internal_post_type( 'scf_e2e_test_post_type', 'acf-post-type' ) ) {
 		return;
 	}
 
@@ -97,26 +97,16 @@ function scf_test_create_scf_post_type_entry() {
 	);
 
 	// Create the post type entry in the database using SCF's internal API
-	$result = acf_update_internal_post_type( $post_type_config, 'acf-post-type' );
-
-	if ( is_array( $result ) && isset( $result['ID'] ) ) {
-		// Store the post ID so we can delete it later
-		update_option( 'scf_test_post_type_created', $result['ID'] );
-	}
+	acf_update_internal_post_type( $post_type_config, 'acf-post-type' );
 }
 
 /**
  * Clean up on plugin deactivation
  */
 function scf_test_cleanup() {
-	// Get the stored post ID and delete the post
-	$post_id = get_option( 'scf_test_post_type_created' );
-	if ( $post_id ) {
-		wp_delete_post( $post_id, true );
+	if ( function_exists( 'acf_delete_internal_post_type' ) ) {
+		acf_delete_internal_post_type( 'scf_e2e_test_post_type', 'acf-post-type' );
 	}
-
-	// Clean up the option
-	delete_option( 'scf_test_post_type_created' );
 }
 
 // Register hooks

--- a/tests/e2e/plugins/scf-test-setup-post-types.php
+++ b/tests/e2e/plugins/scf-test-setup-post-types.php
@@ -54,17 +54,12 @@ function scf_test_register_post_types() {
 
 /**
  * Create an SCF post type entry in the database
- *
- * This function creates a post of type 'acf-post-type' in the database, which is how SCF
- * stores its post type definitions. When the REST API endpoint calls
- * acf_get_internal_post_type_posts('acf-post-type'), it will return our custom post type,
- * causing it to be categorized as an SCF post type.
  */
 function scf_test_create_scf_post_type_entry() {
 	// If the post type already exists (e.g. from a previous test run), delete it.
 	// This ensures that any changes to this file will be reflected it the tests.
-	if ( acf_get_internal_post_type( 'scf_e2e_test_post_type', 'acf-post-type' ) ) {
-		acf_delete_internal_post_type( 'scf_e2e_test_post_type', 'acf-post-type' );
+	if ( acf_get_post_type( 'scf_e2e_test_post_type' ) ) {
+		acf_delete_post_type( 'scf_e2e_test_post_type' );
 	}
 
 	// Define our post type configuration (similar to what you'd fill in the UI)
@@ -88,15 +83,15 @@ function scf_test_create_scf_post_type_entry() {
 		),
 	);
 
-	// Create the post type entry in the database using SCF's internal API
-	acf_update_internal_post_type( $post_type_config, 'acf-post-type' );
+	// Create the post type entry in the database using SCF's API
+	acf_update_post_type( $post_type_config );
 }
 
 /**
  * Clean up on plugin deactivation
  */
 function scf_test_cleanup() {
-	acf_delete_internal_post_type( 'scf_e2e_test_post_type', 'acf-post-type' );
+	acf_delete_post_type( 'scf_e2e_test_post_type' );
 }
 
 // Register hooks


### PR DESCRIPTION
_Alternative to https://github.com/WordPress/secure-custom-fields/pull/401._

Previously, the "SCF E2E Test Type" post type registered by the "SCF Test Setup Post Types" plugin was persisted to the database and never deleted. This meant that after an initial test run, any changes made to that plugin didn't propagate to the UI, which was confusing for developers.

To fix this issue, this PR deletes any existing "SCF E2E Test Type" post type before attempting to register it (and upon plugin deactivation). The now-obsolete `scf_test_post_type_created` option that was used to determine if the post type had been created is removed. Finally, more semantic functions are used for post type creation and deletion.

Discovered while working on https://github.com/WordPress/secure-custom-fields/pull/397, where I needed to change the `add_new` label on the custom post type (CPT) used for tests.

## Use of AI Tools

Claude Code was used to investigate the issue, and to write most of the fix.
(This is only fair: The issue was originally also produced by Claude Code.)