### PR TITLE
Skip Command Palette e2e tests on older WP versions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,8 +35,6 @@ jobs:
                     # On trunk: full matrix with node 24 and minimum WP version
                     - event: 'pull_request'
                       node: '24'
-                    - event: 'pull_request'
-                      wp: '6.2'
 
         env:
             WP_ENV_CORE: ${{ matrix.wp == 'trunk' && 'WordPress/WordPress' || (matrix.wp != 'latest' && format('WordPress/WordPress#{0}', matrix.wp) || null) }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,6 +35,8 @@ jobs:
                     # On trunk: full matrix with node 24 and minimum WP version
                     - event: 'pull_request'
                       node: '24'
+                    - event: 'pull_request'
+                      wp: '6.2'
 
         env:
             WP_ENV_CORE: ${{ matrix.wp == 'trunk' && 'WordPress/WordPress' || (matrix.wp != 'latest' && format('WordPress/WordPress#{0}', matrix.wp) || null) }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
                 event: ['${{ github.event_name }}']
                 shard: [1, 2, 3, 4]
                 node: ['22', '24']
-                wp: ['6.2', '6.8', 'latest', 'trunk']
+                wp: ['6.2', '6.3', '6.8', 'latest', 'trunk']
                 exclude:
                     # On PRs: only test Node 22 + WP latest and trunk for fast feedback
                     # On trunk: full matrix with node 24 and minimum WP version

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
                 event: ['${{ github.event_name }}']
                 shard: [1, 2, 3, 4]
                 node: ['22', '24']
-                wp: ['6.2', '6.3', '6.4', '6.5', '6.6', '6.7', '6.8', 'latest', 'trunk']
+                wp: ['6.2', '6.3', '6.8', 'latest', 'trunk']
                 exclude:
                     # On PRs: only test Node 22 + WP latest and trunk for fast feedback
                     # On trunk: full matrix with node 24 and minimum WP version

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
                 event: ['${{ github.event_name }}']
                 shard: [1, 2, 3, 4]
                 node: ['22', '24']
-                wp: ['6.2', '6.3', '6.8', 'latest', 'trunk']
+                wp: ['6.2', '6.8', 'latest', 'trunk']
                 exclude:
                     # On PRs: only test Node 22 + WP latest and trunk for fast feedback
                     # On trunk: full matrix with node 24 and minimum WP version

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
                 event: ['${{ github.event_name }}']
                 shard: [1, 2, 3, 4]
                 node: ['22', '24']
-                wp: ['6.2', '6.3', '6.8', 'latest', 'trunk']
+                wp: ['6.2', '6.3', '6.4', '6.5', '6.6', '6.7', '6.8', 'latest', 'trunk']
                 exclude:
                     # On PRs: only test Node 22 + WP latest and trunk for fast feedback
                     # On trunk: full matrix with node 24 and minimum WP version

--- a/tests/e2e/command-palette.spec.ts
+++ b/tests/e2e/command-palette.spec.ts
@@ -12,6 +12,15 @@ test.describe( 'Command Palette', () => {
 		await requestUtils.deactivatePlugin( 'secure-custom-fields' );
 	} );
 
+	test.beforeEach( async ( { admin, page } ) => {
+		await admin.visitAdminPage( 'index.php' );
+
+		test.skip(
+			! ( await wpVersionAtLeast( page, 6, 3 ) ),
+			'Command Palette requires WordPress 6.3+'
+		);
+	} );
+
 	[ 'post-editor', 'wp-admin' ].forEach( ( context ) => {
 		test.describe( `opened in ${ context }`, () => {
 			test.beforeEach( async ( { admin, page } ) => {

--- a/tests/e2e/command-palette.spec.ts
+++ b/tests/e2e/command-palette.spec.ts
@@ -41,9 +41,10 @@ test.describe( 'Command Palette', () => {
 					// Open the command palette via keyboard shortcut.
 					await page.keyboard.press( 'ControlOrMeta+k' );
 
-					const input = page.getByRole( 'combobox', {
-						name: 'Search commands and settings',
+					const commandPalette = page.getByRole( 'dialog', {
+						name: 'Command palette',
 					} );
+					const input = commandPalette.getByRole( 'combobox' );
 					await expect( input ).toBeVisible();
 
 					// Search for a create command — these are always registered by SCF.
@@ -58,9 +59,10 @@ test.describe( 'Command Palette', () => {
 				} ) => {
 					await page.keyboard.press( 'ControlOrMeta+k' );
 
-					const input = page.getByRole( 'combobox', {
-						name: 'Search commands and settings',
+					const commandPalette = page.getByRole( 'dialog', {
+						name: 'Command palette',
 					} );
+					const input = commandPalette.getByRole( 'combobox' );
 
 					// Search for a view command that exists in both WP's auto-registered
 					// admin menu commands and SCF's view commands list.
@@ -79,9 +81,10 @@ test.describe( 'Command Palette', () => {
 				} ) => {
 					await page.keyboard.press( 'ControlOrMeta+k' );
 
-					const input = page.getByRole( 'combobox', {
-						name: 'Search commands and settings',
+					const commandPalette = page.getByRole( 'dialog', {
+						name: 'Command palette',
 					} );
+					const input = commandPalette.getByRole( 'combobox' );
 
 					await input.fill( 'Field Groups' );
 					await page
@@ -108,9 +111,10 @@ test.describe( 'Command Palette', () => {
 				} ) => {
 					await page.keyboard.press( 'ControlOrMeta+k' );
 
-					const input = page.getByRole( 'combobox', {
-						name: 'Search commands and settings',
+					const commandPalette = page.getByRole( 'dialog', {
+						name: 'Command palette',
 					} );
+					const input = commandPalette.getByRole( 'combobox' );
 					await expect( input ).toBeVisible();
 
 					// The "View All" command uses the post type's `all_items` label.
@@ -130,9 +134,10 @@ test.describe( 'Command Palette', () => {
 				} ) => {
 					await page.keyboard.press( 'ControlOrMeta+k' );
 
-					const input = page.getByRole( 'combobox', {
-						name: 'Search commands and settings',
+					const commandPalette = page.getByRole( 'dialog', {
+						name: 'Command palette',
 					} );
+					const input = commandPalette.getByRole( 'combobox' );
 					await expect( input ).toBeVisible();
 
 					await input.fill( 'Add New SCF E2E Test Type Item' );
@@ -150,9 +155,10 @@ test.describe( 'Command Palette', () => {
 				} ) => {
 					await page.keyboard.press( 'ControlOrMeta+k' );
 
-					const input = page.getByRole( 'combobox', {
-						name: 'Search commands and settings',
+					const commandPalette = page.getByRole( 'dialog', {
+						name: 'Command palette',
 					} );
+					const input = commandPalette.getByRole( 'combobox' );
 					await expect( input ).toBeVisible();
 
 					// The edit command label uses the post type's `name` label.


### PR DESCRIPTION
E2E tests are currently run against WP 6.2 upon commit to `trunk`. Command Palette tests are failing, as the Command Palette was only introduced in WP 6.3. We thus need to skip those tests on older WP versions.

Additionally, this PR makes the test more resilient against minor copy changes across versions that would previously cause tests to fail.

## Use of AI Tools

Claude Code was used to select the command palette input field in a label-agnostic way that would work across different WP versions.