### PR TITLE
Fix block editor rendering: query decoding and StrictMode

### DIFF
--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -914,7 +914,7 @@ function acf_enqueue_block_assets() {
 		array(
 			'blockTypes' => array_values( $block_types ),
 			'postType'   => get_post_type(),
-			'StrictMode' => true,
+			'StrictMode' => version_compare( $GLOBALS['wp_version'], '6.9', '>=' ),
 		)
 	);
 

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -899,6 +899,10 @@ function acf_enqueue_block_assets() {
 		)
 	);
 
+	// React StrictMode is only active in the block editor on WP 6.9+.
+	global $wp_version;
+	$is_wp_69_plus = version_compare( $wp_version, '6.9', '>=' );
+
 	// Get block types.
 	$block_types = array_map(
 		function ( $block ) {
@@ -914,7 +918,9 @@ function acf_enqueue_block_assets() {
 		array(
 			'blockTypes' => array_values( $block_types ),
 			'postType'   => get_post_type(),
-			'StrictMode' => version_compare( $GLOBALS['wp_version'], '6.9', '>=' ),
+			// Key is intentionally PascalCase to match `acf.get('StrictMode')` in the
+			// compiled `acf-pro-blocks.js`. Do not normalize to camelCase.
+			'StrictMode' => $is_wp_69_plus,
 		)
 	);
 
@@ -987,7 +993,37 @@ function acf_enqueue_block_type_assets( $block_type ) {
 }
 
 /**
+ * Decodes the block `query` ajax arg, which may arrive as either an array
+ * or a JSON-encoded string depending on how the block editor JS serializes
+ * the request. Falls back to an empty array when decoding fails or yields
+ * a non-array value.
+ *
+ * @since SCF 6.5.4
+ *
+ * @param mixed $query The raw query arg.
+ * @return array
+ */
+function acf_decode_block_query_arg( $query ) {
+	if ( is_array( $query ) ) {
+		return $query;
+	}
+
+	if ( ! is_string( $query ) ) {
+		return array();
+	}
+
+	$decoded = json_decode( wp_unslash( $query ), true );
+
+	return is_array( $decoded ) ? $decoded : array();
+}
+
+/**
  * Handles the ajax request for block data.
+ *
+ * The `query` arg may arrive as a JSON-encoded string instead of an array
+ * (the block editor JS may serialize it that way). It is normalized via
+ * `acf_decode_block_query_arg()` to avoid a fatal TypeError on PHP 8.4
+ * when accessing offsets on a string.
  *
  * @since   ACF 5.7.13
  *
@@ -1032,15 +1068,11 @@ function acf_ajax_fetch_block() {
 	$raw_context = $args['context'];
 	$post_id     = $args['post_id'];
 
-	// Decode query if sent as a JSON string instead of an array.
-	// The block editor JS may serialize the query parameter as JSON,
-	// which causes a fatal TypeError on PHP 8.4 when accessing offsets.
-	if ( is_string( $query ) ) {
-		$query = json_decode( wp_unslash( $query ), true );
-		if ( ! is_array( $query ) ) {
-			$query = array();
-		}
-	}
+	// `$query` flows through `acf_sanitize_request_args()` (so a JSON string
+	// is `wp_kses`-filtered before we see it). Safe today because callers only
+	// boolean-test keys like `preview`/`form`/`validate`; revisit if a string
+	// value ever gets read out of `$query`.
+	$query = acf_decode_block_query_arg( $query );
 
 	// Bail early if no block.
 	if ( ! $block ) {

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -1028,6 +1028,9 @@ function acf_ajax_fetch_block() {
 
 	$block       = $args['block'];
 	$query       = $args['query'];
+	$client_id   = $args['clientId'];
+	$raw_context = $args['context'];
+	$post_id     = $args['post_id'];
 
 	// Decode query if sent as a JSON string instead of an array.
 	// The block editor JS may serialize the query parameter as JSON,
@@ -1038,10 +1041,6 @@ function acf_ajax_fetch_block() {
 			$query = array();
 		}
 	}
-
-	$client_id   = $args['clientId'];
-	$raw_context = $args['context'];
-	$post_id     = $args['post_id'];
 
 	// Bail early if no block.
 	if ( ! $block ) {

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -914,6 +914,7 @@ function acf_enqueue_block_assets() {
 		array(
 			'blockTypes' => array_values( $block_types ),
 			'postType'   => get_post_type(),
+			'StrictMode' => true,
 		)
 	);
 
@@ -1027,6 +1028,17 @@ function acf_ajax_fetch_block() {
 
 	$block       = $args['block'];
 	$query       = $args['query'];
+
+	// Decode query if sent as a JSON string instead of an array.
+	// The block editor JS may serialize the query parameter as JSON,
+	// which causes a fatal TypeError on PHP 8.4 when accessing offsets.
+	if ( is_string( $query ) ) {
+		$query = json_decode( wp_unslash( $query ), true );
+		if ( ! is_array( $query ) ) {
+			$query = array();
+		}
+	}
+
 	$client_id   = $args['clientId'];
 	$raw_context = $args['context'];
 	$post_id     = $args['post_id'];

--- a/tests/php/includes/test-blocks-query-decoding.php
+++ b/tests/php/includes/test-blocks-query-decoding.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for block query parameter decoding in acf_ajax_fetch_block().
+ * Tests for acf_decode_block_query_arg().
  *
  * @package wordpress/secure-custom-fields
  */
@@ -10,102 +10,126 @@ use WorDBless\BaseTestCase;
 /**
  * Class Test_Blocks_Query_Decoding
  *
- * Tests that the query parameter is correctly decoded from a JSON string
- * to an array in acf_ajax_fetch_block(), preventing fatal TypeError
- * on PHP 8.4 when accessing offsets on a string.
+ * Verifies acf_decode_block_query_arg() — the helper used by
+ * acf_ajax_fetch_block() to normalize the `query` ajax arg, which
+ * may arrive as either an array or a JSON-encoded string. Without
+ * this normalization PHP 8.4 raises a fatal TypeError when offsets
+ * are accessed on a string.
  *
  * @group blocks
  */
 class Test_Blocks_Query_Decoding extends BaseTestCase {
 
 	/**
-	 * Test that a JSON-encoded query string is decoded to an array.
+	 * A JSON object string is decoded to an array.
 	 */
-	public function test_json_string_query_is_decoded_to_array() {
-		$query = wp_slash( '{"post_type":"post","posts_per_page":3}' );
+	public function test_json_object_string_is_decoded_to_array() {
+		$result = acf_decode_block_query_arg( '{"post_type":"post","posts_per_page":3}' );
 
-		// Simulate the decoding logic from acf_ajax_fetch_block().
-		if ( is_string( $query ) ) {
-			$query = json_decode( wp_unslash( $query ), true );
-			if ( ! is_array( $query ) ) {
-				$query = array();
-			}
-		}
-
-		$this->assertIsArray( $query );
-		$this->assertSame( 'post', $query['post_type'] );
-		$this->assertSame( 3, $query['posts_per_page'] );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'post', $result['post_type'] );
+		$this->assertSame( 3, $result['posts_per_page'] );
 	}
 
 	/**
-	 * Test that an invalid JSON string falls back to an empty array.
+	 * A slashed JSON string (as it would arrive in $_REQUEST) is decoded.
 	 */
-	public function test_invalid_json_string_falls_back_to_empty_array() {
-		$query = 'not valid json {{{';
+	public function test_slashed_json_string_is_decoded() {
+		$result = acf_decode_block_query_arg( wp_slash( '{"preview":true,"form":false}' ) );
 
-		if ( is_string( $query ) ) {
-			$query = json_decode( wp_unslash( $query ), true );
-			if ( ! is_array( $query ) ) {
-				$query = array();
-			}
-		}
-
-		$this->assertIsArray( $query );
-		$this->assertEmpty( $query );
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['preview'] );
+		$this->assertFalse( $result['form'] );
 	}
 
 	/**
-	 * Test that an array query is left unchanged.
+	 * A nested JSON object matching real query keys decodes correctly.
 	 */
-	public function test_array_query_is_unchanged() {
+	public function test_nested_json_object_decodes() {
+		$json   = '{"preview":true,"form":true,"validate":false,"meta":{"foo":"bar"}}';
+		$result = acf_decode_block_query_arg( $json );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['preview'] );
+		$this->assertSame( 'bar', $result['meta']['foo'] );
+	}
+
+	/**
+	 * An array is returned unchanged.
+	 */
+	public function test_array_is_returned_unchanged() {
 		$query = array(
 			'post_type'      => 'page',
 			'posts_per_page' => 5,
 		);
 
-		if ( is_string( $query ) ) {
-			$query = json_decode( wp_unslash( $query ), true );
-			if ( ! is_array( $query ) ) {
-				$query = array();
-			}
-		}
+		$result = acf_decode_block_query_arg( $query );
 
-		$this->assertIsArray( $query );
-		$this->assertSame( 'page', $query['post_type'] );
-		$this->assertSame( 5, $query['posts_per_page'] );
+		$this->assertSame( $query, $result );
 	}
 
 	/**
-	 * Test that a JSON string encoding a non-array value falls back to empty array.
+	 * Invalid JSON falls back to an empty array.
 	 */
-	public function test_json_non_array_value_falls_back_to_empty_array() {
-		$query = '"just a string"';
-
-		if ( is_string( $query ) ) {
-			$query = json_decode( wp_unslash( $query ), true );
-			if ( ! is_array( $query ) ) {
-				$query = array();
-			}
-		}
-
-		$this->assertIsArray( $query );
-		$this->assertEmpty( $query );
+	public function test_invalid_json_falls_back_to_empty_array() {
+		$this->assertSame( array(), acf_decode_block_query_arg( 'not valid json {{{' ) );
 	}
 
 	/**
-	 * Test that an empty string falls back to an empty array.
+	 * An empty string falls back to an empty array.
 	 */
 	public function test_empty_string_falls_back_to_empty_array() {
-		$query = '';
+		$this->assertSame( array(), acf_decode_block_query_arg( '' ) );
+	}
 
-		if ( is_string( $query ) ) {
-			$query = json_decode( wp_unslash( $query ), true );
-			if ( ! is_array( $query ) ) {
-				$query = array();
-			}
-		}
+	/**
+	 * A JSON string encoding a scalar (not an array/object) falls back to an empty array.
+	 *
+	 * @dataProvider provide_json_scalars
+	 *
+	 * @param string $json A JSON-encoded scalar.
+	 */
+	public function test_json_scalar_falls_back_to_empty_array( $json ) {
+		$this->assertSame( array(), acf_decode_block_query_arg( $json ) );
+	}
 
-		$this->assertIsArray( $query );
-		$this->assertEmpty( $query );
+	/**
+	 * Data provider for JSON scalars.
+	 *
+	 * @return array
+	 */
+	public function provide_json_scalars() {
+		return array(
+			'string' => array( '"just a string"' ),
+			'true'   => array( 'true' ),
+			'false'  => array( 'false' ),
+			'null'   => array( 'null' ),
+			'number' => array( '42' ),
+		);
+	}
+
+	/**
+	 * Non-string, non-array values fall back to an empty array.
+	 *
+	 * @dataProvider provide_non_string_non_array
+	 *
+	 * @param mixed $value Input value.
+	 */
+	public function test_non_string_non_array_falls_back_to_empty_array( $value ) {
+		$this->assertSame( array(), acf_decode_block_query_arg( $value ) );
+	}
+
+	/**
+	 * Data provider for non-string, non-array inputs.
+	 *
+	 * @return array
+	 */
+	public function provide_non_string_non_array() {
+		return array(
+			'null'    => array( null ),
+			'integer' => array( 42 ),
+			'bool'    => array( true ),
+			'object'  => array( new stdClass() ),
+		);
 	}
 }

--- a/tests/php/includes/test-blocks-query-decoding.php
+++ b/tests/php/includes/test-blocks-query-decoding.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Tests for block query parameter decoding in acf_ajax_fetch_block().
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Class Test_Blocks_Query_Decoding
+ *
+ * Tests that the query parameter is correctly decoded from a JSON string
+ * to an array in acf_ajax_fetch_block(), preventing fatal TypeError
+ * on PHP 8.4 when accessing offsets on a string.
+ *
+ * @group blocks
+ */
+class Test_Blocks_Query_Decoding extends BaseTestCase {
+
+	/**
+	 * Test that a JSON-encoded query string is decoded to an array.
+	 */
+	public function test_json_string_query_is_decoded_to_array() {
+		$query = wp_slash( '{"post_type":"post","posts_per_page":3}' );
+
+		// Simulate the decoding logic from acf_ajax_fetch_block().
+		if ( is_string( $query ) ) {
+			$query = json_decode( wp_unslash( $query ), true );
+			if ( ! is_array( $query ) ) {
+				$query = array();
+			}
+		}
+
+		$this->assertIsArray( $query );
+		$this->assertSame( 'post', $query['post_type'] );
+		$this->assertSame( 3, $query['posts_per_page'] );
+	}
+
+	/**
+	 * Test that an invalid JSON string falls back to an empty array.
+	 */
+	public function test_invalid_json_string_falls_back_to_empty_array() {
+		$query = 'not valid json {{{';
+
+		if ( is_string( $query ) ) {
+			$query = json_decode( wp_unslash( $query ), true );
+			if ( ! is_array( $query ) ) {
+				$query = array();
+			}
+		}
+
+		$this->assertIsArray( $query );
+		$this->assertEmpty( $query );
+	}
+
+	/**
+	 * Test that an array query is left unchanged.
+	 */
+	public function test_array_query_is_unchanged() {
+		$query = array(
+			'post_type'      => 'page',
+			'posts_per_page' => 5,
+		);
+
+		if ( is_string( $query ) ) {
+			$query = json_decode( wp_unslash( $query ), true );
+			if ( ! is_array( $query ) ) {
+				$query = array();
+			}
+		}
+
+		$this->assertIsArray( $query );
+		$this->assertSame( 'page', $query['post_type'] );
+		$this->assertSame( 5, $query['posts_per_page'] );
+	}
+
+	/**
+	 * Test that a JSON string encoding a non-array value falls back to empty array.
+	 */
+	public function test_json_non_array_value_falls_back_to_empty_array() {
+		$query = '"just a string"';
+
+		if ( is_string( $query ) ) {
+			$query = json_decode( wp_unslash( $query ), true );
+			if ( ! is_array( $query ) ) {
+				$query = array();
+			}
+		}
+
+		$this->assertIsArray( $query );
+		$this->assertEmpty( $query );
+	}
+
+	/**
+	 * Test that an empty string falls back to an empty array.
+	 */
+	public function test_empty_string_falls_back_to_empty_array() {
+		$query = '';
+
+		if ( is_string( $query ) ) {
+			$query = json_decode( wp_unslash( $query ), true );
+			if ( ! is_array( $query ) ) {
+				$query = array();
+			}
+		}
+
+		$this->assertIsArray( $query );
+		$this->assertEmpty( $query );
+	}
+}


### PR DESCRIPTION
## Summary

Two fixes for ACF block rendering in the Gutenberg editor:

### 1. Decode `$query` when sent as JSON string (`acf_ajax_fetch_block`)

The block editor JS may serialize the `query` parameter as a JSON string, but `acf_ajax_fetch_block()` assumes it is already a PHP array. On **PHP 8.4** this causes a fatal TypeError at line 1099:

```
Cannot access offset of type string on string
```

The `$block` and `$context` parameters are already decoded with `json_decode()` (lines 1040-1046), but `$query` is not. This adds the same treatment.

### 2. Enable `StrictMode` flag in localized block editor data (gated on WP 6.9+)

The block editor JS already has code to handle React 18 StrictMode (mount → unmount → remount), gated behind `acf.get('StrictMode')`:

```js
// acf-pro-blocks.js — V.setState()
(this.subscribed || acf.get('StrictMode')) && super.setState(e);
```

But the flag is **never set** — `acf.get('StrictMode')` always returns `null`. Without it, when React StrictMode remounts a block component, `this.subscribed` is `false` (set during unmount) and `super.setState()` is skipped. The block form HTML is fetched successfully but never rendered — the block shows an infinite spinner.

This adds `'StrictMode' => version_compare( $GLOBALS['wp_version'], '6.9', '>=' )` to the localized data so the flag is only active where React StrictMode is actually used.

### PHPUnit tests

Added tests covering the query decoding logic: valid JSON string, invalid JSON fallback, array passthrough, non-array JSON values, and empty strings.

## Steps to reproduce

1. Use WordPress 6.9+ (React 18 StrictMode in the block editor)
2. Register any ACF block with `acf_block_version: 2` and `mode: edit`
3. Insert the block in the editor
4. Block shows infinite spinner (fix 2), or on PHP 8.4 a 500 error (fix 1)

## Test plan

- [ ] Insert an ACF block in the editor on PHP 8.4 — should render form without errors
- [ ] Insert an ACF block in the editor on WordPress 6.9+ — should render form without infinite spinner
- [ ] Verify block preview mode works correctly
- [ ] Verify block frontend rendering is unaffected

> **Note:** This replaces #391 which was closed when the fork was accidentally deleted. All review feedback from that PR has been incorporated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)