### PR TITLE
Map ACF dependency slug to SCF

### DIFF
--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -840,6 +840,24 @@ if ( ! class_exists( 'ACF' ) ) {
 	acf();
 } // class_exists check
 
+if ( ! function_exists( 'scf_map_plugin_dependency_slug' ) ) {
+	/**
+	 * Maps ACF dependency slugs so SCF satisfies plugins requiring ACF.
+	 *
+	 * @param string $slug Plugin dependency slug.
+	 * @return string
+	 */
+	function scf_map_plugin_dependency_slug( $slug ) {
+		if ( 'advanced-custom-fields' === $slug ) {
+			return 'secure-custom-fields';
+		}
+
+		return $slug;
+	}
+
+	add_filter( 'wp_plugin_dependencies_slug', 'scf_map_plugin_dependency_slug' );
+}
+
 if ( ! function_exists( 'scf_deactivate_other_instances' ) ) {
 	/**
 	 * Checks if another version of ACF/ACF PRO is active and deactivates it.

--- a/tests/php/test-secure-custom-fields.php
+++ b/tests/php/test-secure-custom-fields.php
@@ -34,4 +34,23 @@ class Test_Secure_Custom_Fields extends BaseTestCase {
 		$acf = acf();
 		$this->assertNotEmpty( $acf->version, 'ACF version should be defined' );
 	}
+
+	/**
+	 * Plugins that require "advanced-custom-fields" should be satisfied by SCF.
+	 */
+	public function test_map_plugin_dependency_slug() {
+		$this->assertSame(
+			'secure-custom-fields',
+			scf_map_plugin_dependency_slug( 'advanced-custom-fields' )
+		);
+
+		$this->assertSame(
+			'some-other-plugin',
+			scf_map_plugin_dependency_slug( 'some-other-plugin' )
+		);
+
+		$this->assertNotFalse(
+			has_filter( 'wp_plugin_dependencies_slug', 'scf_map_plugin_dependency_slug' )
+		);
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Secure Custom Fields (SCF)! Please have a look at the Contributing Guidelines:
https://github.com/WordPress/secure-custom-fields/blob/trunk/docs/contributing/index.md -->

Add scf_map_plugin_dependency_slug() to map the 'advanced-custom-fields' dependency slug to 'secure-custom-fields', allowing plugins that check for ACF to recognize SCF. The function is hooked to 'wp_plugin_dependencies_slug' and wrapped in a function_exists guard.


## Use of AI Tools

Used Copilot to draft a quick implementation of a core filter so I didn't have to pull up my own prior examples or sort out where in the codebase to land it. 🙃
