### PR TITLE
Prepare 6.8.3 Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,9 +66,11 @@ assets/build/**/*.php
 
 # Claude settings
 **/.claude/settings.local.json
+**/.claude/worktrees/
 
 # Serena MCP
 /.serena/
 
 # Release folder
 release/
+

--- a/docs/code-reference/META.md
+++ b/docs/code-reference/META.md
@@ -306,6 +306,7 @@ This file tracks code elements that need documentation.
 - `acf/acf_get_posts/args`
 - `acf/acf_get_posts/results`
 - `acf/connect_attachment_to_post`
+- `acf/current_user_can_edit_in_context`
 - `acf/current_user_can_edit_post`
 - `acf/filesize`
 - `acf/get_image_sizes`

--- a/docs/code-reference/api/api-helpers-file.md
+++ b/docs/code-reference/api/api-helpers-file.md
@@ -696,6 +696,16 @@ Wrapper function for current_user_can( 'edit_post', $post_id ).
 * @param integer $post_id The post ID to check.
 * @return boolean
 
+## `acf_current_user_can_edit_in_context()`
+
+Checks if the current user can edit a given ACF context.
+
+* Handles post, user, term, comment, woo_order, block, and option contexts returned by acf_decode_post_id().
+* @since 6.7.2
+* @param array  $post_id_info      The result of acf_decode_post_id(), containing 'type' and 'id'.
+* @param string $options_page_slug Optional. The options page menu slug, used to look up the page's capability.
+* @return boolean
+
 ## `acf_get_filesize()`
 
 acf_get_filesize

--- a/docs/code-reference/rest-api/class-acf-rest-types-endpoint-file.md
+++ b/docs/code-reference/rest-api/class-acf-rest-types-endpoint-file.md
@@ -67,6 +67,14 @@ Get SCF fields for a post type.
 * @param array $post_type_object The post type object.
 * @return array Array of field data.
 
+### `get_scf_post_id`
+
+Get the SCF internal post ID for a post type.
+
+* @since SCF 6.8.3
+* @param array $post_type_object The post type object.
+* @return int|null The post ID if managed by SCF, null otherwise.
+
 ### `get_field_schema`
 
 Get the schema for the SCF fields.

--- a/readme.txt
+++ b/readme.txt
@@ -52,6 +52,19 @@ This plugin builds upon and is a fork of the previous work done by the contribut
 
 == Changelog ==
 
+= 6.8.3 =
+*Release Date 22th April 2026*
+
+*Fixes*
+
+- Fix command palette type error on wp-admin.
+- Plugins requiring ACF are also validated for SCF.
+- REST API calls now honor the user's `unfiltered_html` capability.
+- Block Preview rendering now verifies the user can edit the target post.
+- Paginated Repeater fields now verify the user can edit the target post.
+- Flexible Content layout title AJAX requests now validate a security nonce.
+- Clone field AJAX endpoints now enforce SCF admin permissions on field group listings.
+
 = 6.8.2 =
 *Release Date 24th March 2026*
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: fields, custom fields, meta, scf
 Requires at least: 6.2
 Tested up to: 6.9.1
 Requires PHP: 7.4
-Stable tag: 6.8.2
+Stable tag: 6.8.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -6,7 +6,7 @@
  * Plugin Name:       Secure Custom Fields
  * Plugin URI:        https://developer.wordpress.org/secure-custom-fields/
  * Description:       Secure Custom Fields (SCF) offers an intuitive way for developers to enhance WordPress content management by adding extra fields and options without coding requirements.
- * Version:           6.8.2
+ * Version:           6.8.3
  * Author:            WordPress.org
  * Author URI:        https://wordpress.org/
  * Text Domain:       secure-custom-fields
@@ -33,7 +33,7 @@ if ( ! class_exists( 'ACF' ) ) {
 		 *
 		 * @var string
 		 */
-		public $version = '6.8.2';
+		public $version = '6.8.3';
 
 		/**
 		 * The plugin settings array.


### PR DESCRIPTION
*Release Date 22th April 2026*

*Fixes*

- Fix command palette type error on wp-admin.
- Plugins requiring ACF are also validated for SCF.
- REST API calls now honor the user's  capability.
- Block Preview rendering now verifies the user can edit the target post.
- Paginated Repeater fields now verify the user can edit the target post.
- Flexible Content layout title AJAX requests now validate a security nonce.
- Clone field AJAX endpoints now enforce SCF admin permissions on field group listings.