### PR TITLE
Security: contain schema $ref paths, pin props-bot-action

### DIFF
--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Gather a list of contributors
-        uses: WordPress/props-bot-action@trunk
+        uses: WordPress/props-bot-action@635b2c5330167e194cd7b2c8a909991592a5022d # trunk
         with:
           format: 'svn'
 

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Gather a list of contributors
-        uses: WordPress/props-bot-action@635b2c5330167e194cd7b2c8a909991592a5022d # trunk
+        uses: WordPress/props-bot-action@635b2c5330167e194cd7b2c8a909991592a5022d # pinned 2026-04-24, no releases upstream
         with:
           format: 'svn'
 

--- a/includes/class-scf-schema-builder.php
+++ b/includes/class-scf-schema-builder.php
@@ -82,6 +82,7 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 			$root_schema = $root_schema ?? $schema;
 			$definitions = $root_schema['definitions'] ?? array();
 			$base_path   = $base_path ?? acf_get_path( 'schemas/' );
+			$base_path   = rtrim( $base_path, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR;
 
 			if ( isset( $schema['$ref'] ) ) {
 				$ref      = $schema['$ref'];

--- a/includes/class-scf-schema-builder.php
+++ b/includes/class-scf-schema-builder.php
@@ -66,15 +66,24 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 		 * - Internal refs: #/definitions/foo (resolved from root_schema)
 		 * - Relative file refs: file.schema.json#/definitions/foo (loaded from base_path)
 		 *
+		 * Cycle detection uses two guards:
+		 * - $visited tracks external-file ref strings on the current resolution chain
+		 *   so cycles (A -> B -> A) abort cleanly without exhausting the stack.
+		 * - $depth is a belt-and-suspenders upper bound, only incremented when
+		 *   recursing into a resolved external-file $ref (not on plain structural
+		 *   descent into properties, items, etc.), so deeply nested schemas don't
+		 *   trip the cycle guard prematurely.
+		 *
 		 * @since 6.8.0
 		 *
 		 * @param array       $schema      The schema to resolve.
 		 * @param array|null  $root_schema The root schema containing definitions. If null, uses $schema.
 		 * @param string|null $base_path   Base path for loading external schema files. Defaults to schemas/.
-		 * @param int         $depth       Internal recursion depth counter.
+		 * @param int         $depth       Internal external-ref recursion depth counter.
+		 * @param array       $visited     External-file ref strings seen on the current resolution chain.
 		 * @return array The resolved schema.
 		 */
-		public function resolve_refs( array $schema, ?array $root_schema = null, ?string $base_path = null, int $depth = 0 ): array {
+		public function resolve_refs( array $schema, ?array $root_schema = null, ?string $base_path = null, int $depth = 0, array $visited = array() ): array {
 			if ( $depth >= self::MAX_REF_DEPTH ) {
 				return $schema;
 			}
@@ -85,8 +94,9 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 			$base_path   = rtrim( $base_path, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR;
 
 			if ( isset( $schema['$ref'] ) ) {
-				$ref      = $schema['$ref'];
-				$resolved = null;
+				$ref           = $schema['$ref'];
+				$resolved      = null;
+				$ref_signature = null;
 
 				// Internal ref: #/definitions/path/to/def
 				if ( preg_match( '~^#/definitions/(.+)$~', $ref, $matches ) ) {
@@ -107,6 +117,14 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 						&& 0 === strpos( $real_file, rtrim( $real_base, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR );
 
 					if ( $within_base && is_file( $real_file ) ) {
+						// Signature uses the resolved real file path so equivalent refs collapse to the same key.
+						$ref_signature = $real_file . '#/definitions/' . $def_path;
+
+						// Abort unresolved if this external ref is already on the current resolution chain.
+						if ( in_array( $ref_signature, $visited, true ) ) {
+							return $schema;
+						}
+
 						$external_content = file_get_contents( $real_file );
 						$external_schema  = json_decode( $external_content, true );
 
@@ -121,13 +139,23 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 
 				if ( is_array( $resolved ) ) {
 					unset( $schema['$ref'] );
-					return array_merge( $this->resolve_refs( $resolved, $root_schema, $base_path, $depth + 1 ), $schema );
+
+					// Only bump depth and extend visited on external-file refs — internal refs
+					// resolve against already-loaded definitions and don't open new files.
+					if ( null !== $ref_signature ) {
+						$next_visited   = $visited;
+						$next_visited[] = $ref_signature;
+						return array_merge( $this->resolve_refs( $resolved, $root_schema, $base_path, $depth + 1, $next_visited ), $schema );
+					}
+
+					return array_merge( $this->resolve_refs( $resolved, $root_schema, $base_path, $depth, $visited ), $schema );
 				}
 			}
 
 			foreach ( $schema as $key => $value ) {
 				if ( is_array( $value ) ) {
-					$schema[ $key ] = $this->resolve_refs( $value, $root_schema, $base_path, $depth + 1 );
+					// Structural descent: don't bump $depth, just thread the visited set through.
+					$schema[ $key ] = $this->resolve_refs( $value, $root_schema, $base_path, $depth, $visited );
 				}
 			}
 

--- a/includes/class-scf-schema-builder.php
+++ b/includes/class-scf-schema-builder.php
@@ -93,7 +93,7 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 					foreach ( explode( '/', $matches[1] ) as $part ) {
 						$resolved = $resolved[ $part ] ?? null;
 					}
-				} elseif ( preg_match( '~^([^#]+)#/definitions/(.+)$~', $ref, $matches ) ) {
+				} elseif ( preg_match( '~^([^#]+)#/definitions/(.+)$~', $ref, $matches ) && false === strpos( $matches[1], "\0" ) ) {
 					// Relative file ref: file.schema.json#/definitions/path/to/def.
 					// Contain the resolved path to $base_path to block traversal via ../ or absolute paths.
 					$candidate = $base_path . $matches[1];

--- a/includes/class-scf-schema-builder.php
+++ b/includes/class-scf-schema-builder.php
@@ -52,6 +52,11 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 		private ?array $base_schema = null;
 
 		/**
+		 * Max recursion depth for $ref resolution. Guards against circular refs.
+		 */
+		private const MAX_REF_DEPTH = 32;
+
+		/**
 		 * Recursively resolves $ref references in a JSON schema.
 		 *
 		 * WordPress internal validation doesn't understand JSON Schema $ref,
@@ -66,9 +71,14 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 		 * @param array       $schema      The schema to resolve.
 		 * @param array|null  $root_schema The root schema containing definitions. If null, uses $schema.
 		 * @param string|null $base_path   Base path for loading external schema files. Defaults to schemas/.
+		 * @param int         $depth       Internal recursion depth counter.
 		 * @return array The resolved schema.
 		 */
-		public function resolve_refs( array $schema, ?array $root_schema = null, ?string $base_path = null ): array {
+		public function resolve_refs( array $schema, ?array $root_schema = null, ?string $base_path = null, int $depth = 0 ): array {
+			if ( $depth >= self::MAX_REF_DEPTH ) {
+				return $schema;
+			}
+
 			$root_schema = $root_schema ?? $schema;
 			$definitions = $root_schema['definitions'] ?? array();
 			$base_path   = $base_path ?? acf_get_path( 'schemas/' );
@@ -84,12 +94,19 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 						$resolved = $resolved[ $part ] ?? null;
 					}
 				} elseif ( preg_match( '~^([^#]+)#/definitions/(.+)$~', $ref, $matches ) ) {
-					// Relative file ref: file.schema.json#/definitions/path/to/def
-					$file_path = $base_path . $matches[1];
+					// Relative file ref: file.schema.json#/definitions/path/to/def.
+					// Contain the resolved path to $base_path to block traversal via ../ or absolute paths.
+					$candidate = $base_path . $matches[1];
+					$real_base = realpath( $base_path );
+					$real_file = realpath( $candidate );
 					$def_path  = $matches[2];
 
-					if ( file_exists( $file_path ) ) {
-						$external_content = file_get_contents( $file_path );
+					$within_base = false !== $real_base
+						&& false !== $real_file
+						&& 0 === strpos( $real_file, rtrim( $real_base, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR );
+
+					if ( $within_base && is_file( $real_file ) ) {
+						$external_content = file_get_contents( $real_file );
 						$external_schema  = json_decode( $external_content, true );
 
 						if ( is_array( $external_schema ) ) {
@@ -103,13 +120,13 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 
 				if ( is_array( $resolved ) ) {
 					unset( $schema['$ref'] );
-					return array_merge( $this->resolve_refs( $resolved, $root_schema, $base_path ), $schema );
+					return array_merge( $this->resolve_refs( $resolved, $root_schema, $base_path, $depth + 1 ), $schema );
 				}
 			}
 
 			foreach ( $schema as $key => $value ) {
 				if ( is_array( $value ) ) {
-					$schema[ $key ] = $this->resolve_refs( $value, $root_schema, $base_path );
+					$schema[ $key ] = $this->resolve_refs( $value, $root_schema, $base_path, $depth + 1 );
 				}
 			}
 

--- a/tests/php/includes/SCFSchemaBuilderTest.php
+++ b/tests/php/includes/SCFSchemaBuilderTest.php
@@ -22,11 +22,80 @@ class SCFSchemaBuilderTest extends BaseTestCase {
 	private $builder;
 
 	/**
+	 * Temporary directory used by containment tests.
+	 *
+	 * Populated in tests that need a scratch $base_path and cleaned in tearDown().
+	 *
+	 * @var string|null
+	 */
+	private $temp_dir = null;
+
+	/**
 	 * Set up the test.
 	 */
 	public function setUp(): void {
 		parent::setUp();
 		$this->builder = acf_get_instance( 'SCF_Schema_Builder' );
+	}
+
+	/**
+	 * Clean up any temp directories/symlinks created by a test.
+	 */
+	public function tearDown(): void {
+		if ( null !== $this->temp_dir && is_dir( $this->temp_dir ) ) {
+			$this->remove_tree( $this->temp_dir );
+			$this->temp_dir = null;
+		}
+		parent::tearDown();
+	}
+
+	/**
+	 * Recursively remove a directory, including symlinks.
+	 *
+	 * @param string $dir Directory to remove.
+	 */
+	private function remove_tree( string $dir ): void {
+		if ( is_link( $dir ) ) {
+			unlink( $dir );
+			return;
+		}
+		if ( ! is_dir( $dir ) ) {
+			if ( file_exists( $dir ) ) {
+				unlink( $dir );
+			}
+			return;
+		}
+		$entries = scandir( $dir );
+		if ( false === $entries ) {
+			return;
+		}
+		foreach ( $entries as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$path = $dir . DIRECTORY_SEPARATOR . $entry;
+			if ( is_link( $path ) ) {
+				unlink( $path );
+			} elseif ( is_dir( $path ) ) {
+				$this->remove_tree( $path );
+			} else {
+				unlink( $path );
+			}
+		}
+		rmdir( $dir );
+	}
+
+	/**
+	 * Create a unique temp directory under the system tmp and remember it.
+	 *
+	 * @return string Absolute path to the created temp dir.
+	 */
+	private function make_temp_dir(): string {
+		$base = rtrim( sys_get_temp_dir(), DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR
+			. 'scf-schema-builder-test-' . uniqid( '', true );
+		mkdir( $base, 0700, true );
+		$this->temp_dir = $base;
+		return $base;
 	}
 
 	/**
@@ -318,5 +387,189 @@ class SCFSchemaBuilderTest extends BaseTestCase {
 		// Should resolve the active definition.
 		$this->assertEquals( 'boolean', $result['type'] );
 		$this->assertArrayNotHasKey( '$ref', $result );
+	}
+
+	/**
+	 * Parent-traversal refs like "../evil.schema.json#/..." must be rejected.
+	 *
+	 * Containment is enforced by realpath() prefix check; the ref must stay
+	 * unresolved and no fatal error should be raised.
+	 */
+	public function test_resolve_refs_rejects_parent_traversal() {
+		$base_path = $this->make_temp_dir() . DIRECTORY_SEPARATOR . 'schemas' . DIRECTORY_SEPARATOR;
+		mkdir( $base_path, 0700, true );
+
+		// Place a real file outside $base_path that the traversal would reach, to prove
+		// the rejection comes from containment and not from the file being missing.
+		$outside_path = dirname( rtrim( $base_path, DIRECTORY_SEPARATOR ) ) . DIRECTORY_SEPARATOR . 'evil.schema.json';
+		file_put_contents(
+			$outside_path,
+			wp_json_encode(
+				array(
+					'definitions' => array(
+						'x' => array( 'type' => 'string' ),
+					),
+				)
+			)
+		);
+
+		$schema = array(
+			'$ref' => '../evil.schema.json#/definitions/x',
+		);
+
+		$result = $this->builder->resolve_refs( $schema, $schema, $base_path );
+
+		// Ref must come back unchanged (unresolved).
+		$this->assertSame( $schema, $result );
+	}
+
+	/**
+	 * Absolute-path refs like "/etc/passwd#/..." must be rejected.
+	 *
+	 * Concatenating $base_path with an absolute ref produces a non-existent
+	 * nested path, and even if it did exist realpath() would fall outside
+	 * $base_path and be rejected.
+	 */
+	public function test_resolve_refs_rejects_absolute_path() {
+		$base_path = $this->make_temp_dir() . DIRECTORY_SEPARATOR . 'schemas' . DIRECTORY_SEPARATOR;
+		mkdir( $base_path, 0700, true );
+
+		$schema = array(
+			'$ref' => '/etc/passwd#/definitions/x',
+		);
+
+		$result = $this->builder->resolve_refs( $schema, $schema, $base_path );
+
+		$this->assertSame( $schema, $result );
+	}
+
+	/**
+	 * Symlinks that resolve outside $base_path must be rejected.
+	 *
+	 * The real path containment check should reject a ref whose target, after
+	 * realpath(), lives outside the configured base directory even though the
+	 * lexical path (base + filename) looked safe.
+	 */
+	public function test_resolve_refs_rejects_symlink_escape() {
+		if ( DIRECTORY_SEPARATOR === '\\' ) {
+			$this->markTestSkipped( 'Symlink semantics differ on Windows.' );
+		}
+
+		$root      = $this->make_temp_dir();
+		$base_path = $root . DIRECTORY_SEPARATOR . 'schemas' . DIRECTORY_SEPARATOR;
+		mkdir( $base_path, 0700, true );
+
+		// Valid in-base schema to prove the builder works in this temp layout.
+		file_put_contents(
+			$base_path . 'inner.schema.json',
+			wp_json_encode(
+				array(
+					'definitions' => array(
+						'x' => array( 'type' => 'string' ),
+					),
+				)
+			)
+		);
+
+		// Real schema file OUTSIDE $base_path (sibling to schemas/ under $root).
+		$outside_file = $root . DIRECTORY_SEPARATOR . 'outside.schema.json';
+		file_put_contents(
+			$outside_file,
+			wp_json_encode(
+				array(
+					'definitions' => array(
+						'x' => array( 'type' => 'string' ),
+					),
+				)
+			)
+		);
+
+		// Symlink inside $base_path pointing at the outside real file.
+		$link = $base_path . 'escape.schema.json';
+		if ( ! symlink( $outside_file, $link ) ) {
+			$this->markTestSkipped( 'Unable to create symlink in this environment.' );
+		}
+
+		$schema = array(
+			'$ref' => 'escape.schema.json#/definitions/x',
+		);
+
+		$result = $this->builder->resolve_refs( $schema, $schema, $base_path );
+
+		// Symlink resolution escapes $base_path -> containment check must reject.
+		$this->assertSame( $schema, $result );
+	}
+
+	/**
+	 * A cycle between two external-file refs must halt via the visited-set guard.
+	 *
+	 * The two files reference each other; resolve_refs() must return in bounded
+	 * time and leave the cycle entry unresolved, without tripping the
+	 * MAX_REF_DEPTH structural cap or exhausting the PHP call stack.
+	 */
+	public function test_resolve_refs_halts_on_circular_ref() {
+		$base_path = $this->make_temp_dir() . DIRECTORY_SEPARATOR . 'schemas' . DIRECTORY_SEPARATOR;
+		mkdir( $base_path, 0700, true );
+
+		file_put_contents(
+			$base_path . 'a.schema.json',
+			wp_json_encode(
+				array(
+					'definitions' => array(
+						'x' => array( '$ref' => 'b.schema.json#/definitions/y' ),
+					),
+				)
+			)
+		);
+		file_put_contents(
+			$base_path . 'b.schema.json',
+			wp_json_encode(
+				array(
+					'definitions' => array(
+						'y' => array( '$ref' => 'a.schema.json#/definitions/x' ),
+					),
+				)
+			)
+		);
+
+		$schema = array(
+			'$ref' => 'a.schema.json#/definitions/x',
+		);
+
+		$start   = microtime( true );
+		$result  = $this->builder->resolve_refs( $schema, $schema, $base_path );
+		$elapsed = microtime( true ) - $start;
+
+		// Bounded time sanity fence — cycle must be cut short, not wait for depth cap.
+		$this->assertLessThan( 1.0, $elapsed, 'Cycle should halt quickly via visited-set guard.' );
+
+		// The returned schema must still carry an unresolved $ref somewhere on the
+		// chain (either the top-level entry or one of its descendants kept intact
+		// when the cycle was detected).
+		$this->assertTrue(
+			$this->contains_ref( $result ),
+			'Circular ref chain should leave a $ref in place rather than fully inlining.'
+		);
+	}
+
+	/**
+	 * Recursively check whether a schema array contains any $ref key.
+	 *
+	 * @param mixed $node Schema node to inspect.
+	 * @return bool True when a $ref key is present anywhere in the structure.
+	 */
+	private function contains_ref( $node ): bool {
+		if ( ! is_array( $node ) ) {
+			return false;
+		}
+		if ( isset( $node['$ref'] ) ) {
+			return true;
+		}
+		foreach ( $node as $value ) {
+			if ( $this->contains_ref( $value ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/tests/php/includes/SCFSchemaBuilderTest.php
+++ b/tests/php/includes/SCFSchemaBuilderTest.php
@@ -2,6 +2,14 @@
 /**
  * Tests for SCF_Schema_Builder class.
  *
+ * Fixture setup for containment/cycle tests needs direct filesystem calls
+ * (symlink, temp-dir cycles) that WP_Filesystem cannot express.
+ *
+ * phpcs:disable WordPress.WP.AlternativeFunctions.unlink_unlink
+ * phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+ * phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+ * phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+ *
  * @package wordpress/secure-custom-fields
  */
 


### PR DESCRIPTION
Harden `SCF_Schema_Builder::resolve_refs()` against external-file `$ref` traversal and pin the `WordPress/props-bot-action` GitHub Action to a full commit SHA.

## Changes

- **`includes/class-scf-schema-builder.php`** — `resolve_refs()` hardened:
  - `realpath`-based containment check rejects refs resolved outside the base `schemas/` directory (traversal via `../`, absolute paths, symlink escapes).
  - Null-byte filter on ref paths prevents PHP 8+ `realpath()` `ValueError` fatals.
  - `$base_path` is normalized to always end in `DIRECTORY_SEPARATOR` once at the top, so callers passing `"/x/schemas"` and `"/x/schemas/"` behave identically.
  - Cycle detection via a visited-set of `realpath`-based ref signatures, threaded through the recursion — collapses path aliases (symlinks, `./` prefixes) and halts mutual `$ref` cycles in bounded time.
  - `MAX_REF_DEPTH = 32` retained as a belt-and-suspenders cap on external-file ref chains. `$depth` now increments only on the external-file ref branch, not on plain structural descent.
  - Public signature adds `array $visited = array()` as an optional last parameter — backward-compatible with all existing callers.

- **`tests/php/includes/SCFSchemaBuilderTest.php`** — four new PHPUnit tests:
  - `test_resolve_refs_rejects_parent_traversal` — `../evil.schema.json#/definitions/x` rejected.
  - `test_resolve_refs_rejects_absolute_path` — `/etc/passwd#/definitions/x` rejected.
  - `test_resolve_refs_rejects_symlink_escape` — symlink inside `schemas/` pointing outside is rejected; skips on Windows and environments without `symlink()`.
  - `test_resolve_refs_halts_on_circular_ref` — two mutually referencing schemas halt in `< 1.0s` via the visited-set guard, not via the depth cap.

- **`.github/workflows/props-bot.yml`** — pin `WordPress/props-bot-action@<sha>` rationale comment changed from `# trunk` to `# pinned 2026-04-24, no releases upstream` to match the repo's `# vX.Y.Z` convention (dated substitute since `props-bot-action` has no tagged releases). SHA unchanged.

## Verification

- PHPUnit: 17 / 17 pass, 270 assertions, 0 failures.
- phpcs: 0 errors on changed files. Test-helper warnings (`mkdir`/`unlink`/`file_put_contents`/`rmdir` vs. `WP_Filesystem`) are unavoidable for symlink/cycle fixtures.

## Use of AI Tools

Initial implementation and review produced via Claude Code (Opus 4.7) in an orchestrator team-review flow: implementer agents applied each hardening item, a separate code-reviewer agent verified the diff against the reviewer's criteria and approved all items. A detailed per-item review will be posted as a comment on this PR.