### PR TITLE
Ignore .claude local agent directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,8 +65,7 @@ assets/build/**/*.php
 /.php-coverage/
 
 # Claude settings
-**/.claude/settings.local.json
-**/.claude/worktrees/
+**/.claude/
 
 # Serena MCP
 /.serena/


### PR DESCRIPTION
Adds `.claude` to `.gitignore` so per-developer Claude Code agent state (skills, settings, cache, transcripts) stays out of the repo.

Closes <!-- #ISSUE-NUMBER -->

## Use of AI Tools

Commit authored by me; the PR description was drafted with Claude Code.