### PR TITLE
Prepare 6.8.4 Release

### DIFF
--- a/bin/create-release-zip.sh
+++ b/bin/create-release-zip.sh
@@ -49,6 +49,7 @@ REQUIRED_DIRS=(
     "lang"
     "pro"
     "schemas"
+    "src"
 )
 
 for dir in "${REQUIRED_DIRS[@]}"; do
@@ -74,10 +75,20 @@ for item in "${DISALLOWED_ITEMS[@]}"; do
     fi
 done
 
-# Verify no untracked files exist in source directories
-if [[ -n $(git ls-files --others --exclude-standard includes/ pro/ | head -1) ]]; then
-    echo "Error: Untracked files found in includes/ or pro/ directories"
-    echo "Run 'git status' to see untracked files"
+# Verify no untracked files exist in release source directories
+SOURCE_DIRS=(
+    "includes"
+    "pro"
+    "src"
+    "schemas"
+    "assets"
+    "lang"
+)
+
+UNTRACKED_SOURCE_FILES=$(git ls-files --others --exclude-standard "${SOURCE_DIRS[@]}")
+if [[ -n "$UNTRACKED_SOURCE_FILES" ]]; then
+    echo "Error: Untracked files found in release source directories:"
+    printf '%s\n' "$UNTRACKED_SOURCE_FILES"
     exit 1
 fi
 

--- a/bin/prepare-release.php
+++ b/bin/prepare-release.php
@@ -49,6 +49,7 @@ class Release_Preparation {
 		$this->build_assets();
 		$this->run_tests();
 		$this->generate_docs();
+		$this->check_generated_schemas();
 		$this->update_translations();
 		$this->commit_changes();
 
@@ -177,7 +178,18 @@ class Release_Preparation {
 	}
 
 	/**
-	 * Commit any changes from build/tests/docs
+	 * Check generated schemas
+	 */
+	private function check_generated_schemas() {
+		echo "Checking generated schemas...\n";
+		passthru( 'php bin/generate-field-schema.php --check', $return );
+		if ( 0 !== $return ) {
+			exit( $return );
+		}
+	}
+
+	/**
+	 * Commit any changes from build/tests/docs/translations
 	 */
 	private function commit_changes() {
 		exec( 'git status --porcelain', $output );

--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,10 @@
 			"SCF\\AI\\": "src/AI/",
 			"SCF\\Blocks\\": "includes/Blocks/",
 			"SCF\\CLI\\": "src/CLI/",
-			"SCF\\Site_Health\\": "src/Site_Health/",
 			"SCF\\Fields\\FlexibleContent\\": "includes/fields/FlexibleContent/",
 			"SCF\\Forms\\": "includes/forms/",
-			"SCF\\Meta\\": "includes/Meta/"
+			"SCF\\Meta\\": "includes/Meta/",
+			"SCF\\Site_Health\\": "src/Site_Health/"
 		}
 	},
 	"config": {

--- a/docs/code-reference/META.md
+++ b/docs/code-reference/META.md
@@ -379,6 +379,7 @@ This file tracks code elements that need documentation.
 
 - `acf/blocks/default_block_version`
 - `acf/blocks/default_block_version`
+- `acf/blocks/default_expanded_editor_button_text`
 - `acf/blocks/fields_needing_wide_popover`
 - `acf/blocks/fields_to_open_in_expanded_editor`
 - `acf/blocks/no_fields_assigned_message`
@@ -389,6 +390,8 @@ This file tracks code elements that need documentation.
 - `acf/blocks/template_not_found_message`
 - `acf/blocks/top_toolbar_fields`
 - `acf/blocks/top_toolbar_fields`
+- `acf/blocks/top_toolbar_fields`
+- `acf/blocks/wrap_frontend_innerblocks`
 - `acf/blocks/wrap_frontend_innerblocks`
 - `acf/pre_save_block`
 - `acf/register_block_type_args`

--- a/docs/code-reference/acf-field-functions-file.md
+++ b/docs/code-reference/acf-field-functions-file.md
@@ -391,4 +391,12 @@ Allows parent fields to modify themselves and also return sub fields.
 * @param   array $field The field array.
 * @return array
 
+## `acf_get_field_json_schema()`
+
+Retrieves the JSON schema for a field.
+
+* @since 6.8.0
+* @param string $field_type The field to get the JSON schema for.
+* @return array
+
 ---

--- a/docs/code-reference/api/api-helpers-file.md
+++ b/docs/code-reference/api/api-helpers-file.md
@@ -53,6 +53,13 @@ Alias of acf()->get_setting()
 * @param string $value An optional default value for the setting if it doesn't exist.
 * @return n/a
 
+## `acf_is_pro()`
+
+Returns whether the current plugin load is running with PRO features enabled.
+
+* @since ACF 6.8
+* @return bool
+
 ## `acf_get_internal_post_types()`
 
 Return an array of ACF's internal post type names

--- a/docs/code-reference/blocks-file.md
+++ b/docs/code-reference/blocks-file.md
@@ -140,6 +140,29 @@ Returns the rendered block HTML.
 * @param boolean  $is_ajax_render Whether or not this is an ACF AJAX render.
 * @return string   The block HTML.
 
+## `acf_rendered_block_v3()`
+
+Returns the rendered block HTML for v3 blocks.
+
+* @date    21/1/26
+* @since ACF 6.8
+* @param   array    $attributes The block attributes.
+* @param string   $content    The block content.
+* @param boolean  $is_preview Whether or not the block is being rendered for editing preview.
+* @param integer  $post_id    The current post being edited or viewed.
+* @param WP_Block $wp_block   The block instance (since WP 5.5).
+* @param array    $context    The block context array.
+* @return string   The block HTML.
+
+## `acf_replace_inner_blocks_in_block_content()`
+
+Replaces InnerBlocks strings in a block with the inner block content.
+
+* @since ACF 6.8
+* @param string $content The block content.
+* @param string $html    The block html.
+* @return string
+
 ## `acf_render_block()`
 
 Renders the block HTML.

--- a/docs/contributing/releases.md
+++ b/docs/contributing/releases.md
@@ -44,7 +44,7 @@ composer prepare-release
 This will run an interactive script that will:
 
 - Build the assets required for the release
-- Generate documentation and update translations
+- Generate documentation, verify generated schemas, and update translations
 - Commit these changes to the current branch
 - Prompt the user for the new version number and update it accordingly in `secure-custom-fields.php`
 - Offer the user to update the stable tag in `readme.txt`
@@ -60,7 +60,7 @@ From the `release/x.y.z` branch, run:
 ./bin/create-release-zip.sh
 ```
 
-This script runs a few checks to verify that all required files and directories are present, and that there are no untracked files. It then installs production dependencies and creates and verifies `release/secure-custom-fields.zip`.
+This script runs a few checks to verify that all required files and directories are present, and that there are no untracked files in release source directories. It then installs production dependencies and creates and verifies `release/secure-custom-fields.zip`.
 
 ## Deploy to WordPress.org
 

--- a/readme.txt
+++ b/readme.txt
@@ -52,6 +52,47 @@ This plugin builds upon and is a fork of the previous work done by the contribut
 
 == Changelog ==
 
+= 6.8.4 =
+*Release Date 30th April 2026*
+
+*Features*
+
+- Backports 6.8.0 and 6.8.0.1 feature work into SCF.
+- AI integration: SCF now integrates with the WordPress Abilities API, allowing external consumers, including AI tools, to manage field groups, post types, and taxonomies when explicitly enabled via the `enable_acf_ai` feature flag.
+- Structured data: SCF can now generate JSON-LD structured data fields when explicitly enabled via the `enable_schema` feature flag.
+- WP-CLI: Added `wp scf json` and backward-compatible `wp acf json` commands for importing, exporting, syncing, and checking the status of SCF JSON files.
+- Post types: SCF custom post types now support the WordPress 6.9+ Notes editor feature via a new Notes checkbox in the Supports settings.
+- JSON Schemas: Added v1 schemas for supported field types and updated field group, post type, and taxonomy schemas.
+
+*Enhancements*
+
+- Blocks V3: The Open in Expanded Editor button text can now be customized via a new `acf.expandedEditorButtonText` block.json property.
+- Blocks V3: Added an `acf/blocks/default_expanded_editor_button_text` PHP filter to customize the default Open in Expanded Editor button text.
+- Blocks V3: The edit and Open in Expanded Editor buttons can now be hidden via a new `acf.expandedEditorButtons` block.json property.
+- Blocks V3: Added a `blocks/expanded_editor_overlay_class` JavaScript filter for customizing the Expanded Editor modal overlay class.
+- Blocks V3: The block form HTML is now preloaded alongside the preview, eliminating an extra AJAX call on mount.
+- Blocks V3: Expanded Editor buttons are now hidden for V3 blocks that have no fields assigned.
+- SCF inline script tags now use `wp_print_inline_script_tag()` for Content Security Policy (CSP) compliance and nonce support.
+
+*Fixes*
+
+- V3 blocks with WYSIWYG fields no longer enqueue TinyMCE editor assets on the frontend.
+- V3 blocks with identical attributes and different InnerBlocks content no longer return cached output from the first block on the frontend.
+- Flexible Content fields now properly clean up nested postmeta when a parent layout containing nested Flexible Content fields is deleted.
+- The Expanded Editor Done button now stays disabled until the AJAX save completes, preventing data loss.
+- Pressing Escape while the Expanded Editor is saving will no longer close the modal, preventing data loss.
+- InnerBlocks content containing backslashes or dollar signs now renders correctly.
+- Auto Inline Editing now only applies to SCF Blocks V3, resolving incorrect hover/focus borders appearing on V2 blocks.
+- Auto Inline Editing blocks now receive block context variables in render templates.
+- Auto Inline Editing now works with blocks using `renderCallback`.
+- Validation errors in the V3 Expanded Editor no longer cause a dead-end state.
+- Icon Picker selections in Repeater fields no longer disappear.
+- Range field number input now syncs to the slider and correctly updates V3 block previews.
+- Message field Name and Instructions settings are no longer shown in the field group editor.
+- Image field no longer crashes in WordPress 7.0 release candidates.
+- V3 blocks registered via PHP now correctly show the Open in Expanded Editor button.
+- Flexible Content disabled layouts now work correctly in Blocks V3.
+
 = 6.8.3 =
 *Release Date 22th April 2026*
 

--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -6,7 +6,7 @@
  * Plugin Name:       Secure Custom Fields
  * Plugin URI:        https://developer.wordpress.org/secure-custom-fields/
  * Description:       Secure Custom Fields (SCF) offers an intuitive way for developers to enhance WordPress content management by adding extra fields and options without coding requirements.
- * Version:           6.8.3
+ * Version:           6.8.4
  * Author:            WordPress.org
  * Author URI:        https://wordpress.org/
  * Text Domain:       secure-custom-fields
@@ -33,7 +33,7 @@ if ( ! class_exists( 'ACF' ) ) {
 		 *
 		 * @var string
 		 */
-		public $version = '6.8.3';
+		public $version = '6.8.4';
 
 		/**
 		 * The plugin settings array.


### PR DESCRIPTION
*Release Date 30th April 2026*

*Features*

- Backports 6.8.0 and 6.8.0.1 feature work into SCF.
- AI integration: SCF now integrates with the WordPress Abilities API, allowing external consumers, including AI tools, to manage field groups, post types, and taxonomies when explicitly enabled via the  feature flag.
- Structured data: SCF can now generate JSON-LD structured data fields when explicitly enabled via the  feature flag.
- WP-CLI: Added  and backward-compatible  commands for importing, exporting, syncing, and checking the status of SCF JSON files.
- Post types: SCF custom post types now support the WordPress 6.9+ Notes editor feature via a new Notes checkbox in the Supports settings.
- JSON Schemas: Added v1 schemas for supported field types and updated field group, post type, and taxonomy schemas.

*Enhancements*

- Blocks V3: The Open in Expanded Editor button text can now be customized via a new  block.json property.
- Blocks V3: Added an  PHP filter to customize the default Open in Expanded Editor button text.
- Blocks V3: The edit and Open in Expanded Editor buttons can now be hidden via a new  block.json property.
- Blocks V3: Added a  JavaScript filter for customizing the Expanded Editor modal overlay class.
- Blocks V3: The block form HTML is now preloaded alongside the preview, eliminating an extra AJAX call on mount.
- Blocks V3: Expanded Editor buttons are now hidden for V3 blocks that have no fields assigned.
- SCF inline script tags now use  for Content Security Policy (CSP) compliance and nonce support.

*Fixes*

- V3 blocks with WYSIWYG fields no longer enqueue TinyMCE editor assets on the frontend.
- V3 blocks with identical attributes and different InnerBlocks content no longer return cached output from the first block on the frontend.
- Flexible Content fields now properly clean up nested postmeta when a parent layout containing nested Flexible Content fields is deleted.
- The Expanded Editor Done button now stays disabled until the AJAX save completes, preventing data loss.
- Pressing Escape while the Expanded Editor is saving will no longer close the modal, preventing data loss.
- InnerBlocks content containing backslashes or dollar signs now renders correctly.
- Auto Inline Editing now only applies to SCF Blocks V3, resolving incorrect hover/focus borders appearing on V2 blocks.
- Auto Inline Editing blocks now receive block context variables in render templates.
- Auto Inline Editing now works with blocks using .
- Validation errors in the V3 Expanded Editor no longer cause a dead-end state.
- Icon Picker selections in Repeater fields no longer disappear.
- Range field number input now syncs to the slider and correctly updates V3 block previews.
- Message field Name and Instructions settings are no longer shown in the field group editor.
- Image field no longer crashes in WordPress 7.0 release candidates.
- V3 blocks registered via PHP now correctly show the Open in Expanded Editor button.
- Flexible Content disabled layouts now work correctly in Blocks V3.