### PR TITLE
Prepare 6.8.6 Release

### DIFF
--- a/docs/code-reference/META.md
+++ b/docs/code-reference/META.md
@@ -561,6 +561,7 @@ This file tracks code elements that need documentation.
 
 ### Hooks
 
+- `acf/form/allowed_field_keys`
 - `acf/pre_save_post`
 - `acf/pre_submit_form`
 - `acf/submit_form`

--- a/docs/features/field/oembed/index.md
+++ b/docs/features/field/oembed/index.md
@@ -15,3 +15,7 @@ The oEmbed field allows embedding external content from various providers like Y
 - Width - Maximum width of embedded content
 - Height - Maximum height of embedded content
 - Preview Size - Display size in admin
+
+## Availability
+
+The live URL preview and search (which resolves a pasted URL into embed HTML on the fly) is reserved for authenticated users with the standard WordPress content-authoring capability (`edit_posts`) — typically Authors, Editors, and Administrators. Anonymous and front-end visitors do not see the live preview populate when typing a URL into an oEmbed input. Already-stored oEmbed values continue to render normally for all viewers regardless of login state.

--- a/includes/fields/class-acf-field-oembed.php
+++ b/includes/fields/class-acf-field-oembed.php
@@ -49,6 +49,7 @@ if ( ! class_exists( 'acf_field_oembed' ) ) :
 
 			// extra
 			add_action( 'wp_ajax_acf/fields/oembed/search', array( $this, 'ajax_query' ) );
+			add_action( 'wp_ajax_nopriv_acf/fields/oembed/search', array( $this, 'ajax_query' ) );
 		}
 
 
@@ -123,6 +124,13 @@ if ( ! class_exists( 'acf_field_oembed' ) ) :
 			);
 
 			if ( ! acf_verify_ajax( $args['nonce'], $args['field_key'], true ) || ! current_user_can( 'edit_posts' ) ) {
+				if ( ! is_user_logged_in() ) {
+					_doing_it_wrong(
+						__METHOD__,
+						esc_html__( 'The oEmbed AJAX search endpoint now requires an authenticated user with the edit_posts capability. Unauthenticated access via wp_ajax_nopriv_acf/fields/oembed/search is deprecated and will be removed in a future release.', 'secure-custom-fields' ),
+						'6.8.5'
+					);
+				}
 				wp_send_json_error();
 			}
 

--- a/includes/fields/class-acf-field-oembed.php
+++ b/includes/fields/class-acf-field-oembed.php
@@ -49,7 +49,6 @@ if ( ! class_exists( 'acf_field_oembed' ) ) :
 
 			// extra
 			add_action( 'wp_ajax_acf/fields/oembed/search', array( $this, 'ajax_query' ) );
-			add_action( 'wp_ajax_nopriv_acf/fields/oembed/search', array( $this, 'ajax_query' ) );
 		}
 
 
@@ -123,8 +122,8 @@ if ( ! class_exists( 'acf_field_oembed' ) ) :
 				)
 			);
 
-			if ( ! acf_verify_ajax( $args['nonce'], $args['field_key'], true ) ) {
-				die();
+			if ( ! acf_verify_ajax( $args['nonce'], $args['field_key'], true ) || ! current_user_can( 'edit_posts' ) ) {
+				wp_send_json_error();
 			}
 
 			wp_send_json( $this->get_ajax_query( $_POST ) );

--- a/includes/forms/form-front.php
+++ b/includes/forms/form-front.php
@@ -265,14 +265,21 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 			}
 
 			// phpcs:disable WordPress.Security.NonceVerification.Missing -- Verified in check_submit_form().
-			// save post_title
+			// Always extract the special _post_title / _post_content fields from $_POST['acf'] so they
+			// cannot leak into acf_update_values() downstream, but only apply them to the post when the
+			// form was rendered with the corresponding option enabled (mirrors render_form()).
 			if ( isset( $_POST['acf']['_post_title'] ) ) {
-				$save['post_title'] = acf_extract_var( $_POST['acf'], '_post_title' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by WP when saved.
+				$post_title = acf_extract_var( $_POST['acf'], '_post_title' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by WP when saved.
+				if ( ! empty( $form['post_title'] ) ) {
+					$save['post_title'] = $post_title;
+				}
 			}
 
-			// save post_content
 			if ( isset( $_POST['acf']['_post_content'] ) ) {
-				$save['post_content'] = acf_extract_var( $_POST['acf'], '_post_content' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by WP when saved.
+				$post_content = acf_extract_var( $_POST['acf'], '_post_content' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by WP when saved.
+				if ( ! empty( $form['post_content'] ) ) {
+					$save['post_content'] = $post_content;
+				}
 			}
 			// phpcs:enable WordPress.Security.NonceVerification.Missing
 
@@ -389,6 +396,15 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 			// allow for custom save
 			$post_id = apply_filters( 'acf/pre_save_post', $post_id, $form );
 
+			// Restrict $_POST['acf'] to the field keys the form actually exposed, so the
+			// save path cannot accept values for fields the form did not render.
+			// phpcs:disable WordPress.Security.NonceVerification.Missing -- Verified in check_submit_form().
+			if ( isset( $_POST['acf'] ) && is_array( $_POST['acf'] ) ) {
+				$allowed_keys = $this->get_allowed_field_keys( $form );
+				$_POST['acf'] = array_intersect_key( $_POST['acf'], array_flip( $allowed_keys ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Sanitized downstream; save pipeline expects slashed input.
+			}
+			// phpcs:enable WordPress.Security.NonceVerification.Missing
+
 			// save
 			acf_save_post( $post_id );
 
@@ -416,21 +432,156 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 
 
 		/**
-		 * description
+		 * Returns the fields a given form configuration will expose, mirroring the
+		 * selection logic used by render_form().
 		 *
-		 * @type    function
-		 * @date    7/09/2016
-		 * @since   ACF 5.4.0
+		 * Used by render_form() to discover what to render, and by submit_form() to
+		 * derive the set of $_POST['acf'] keys the save path will accept.
 		 *
-		 * @param   $post_id (int)
-		 * @return  $post_id (int)
+		 * @since SCF 6.8.5
+		 *
+		 * @param array $args The validated form configuration.
+		 * @return array
+		 */
+		protected function get_form_fields( array $args ): array {
+			$fields       = array();
+			$field_groups = array();
+			$post_id      = $args['post_id'] ?? 0;
+
+			// Prevent ACF from loading values for "new_post".
+			if ( $post_id === 'new_post' ) {
+				$post_id = false;
+			}
+
+			// Register local default fields so the special _post_title / _post_content / _validate_email
+			// keys are resolvable via acf_get_field().
+			foreach ( $this->get_default_fields() as $field ) {
+				acf_add_local_field( $field );
+			}
+
+			// Append post_title field.
+			if ( ! empty( $args['post_title'] ) ) {
+				$fields[] = acf_get_field( '_post_title' );
+			}
+
+			// Append post_content field.
+			if ( ! empty( $args['post_content'] ) ) {
+				$fields[] = acf_get_field( '_post_content' );
+			}
+
+			// Load specific fields.
+			if ( ! empty( $args['fields'] ) ) {
+
+				// Lookup fields using $strict = false for better compatibility with field names.
+				foreach ( $args['fields'] as $selector ) {
+					$fields[] = acf_maybe_get_field( $selector, $post_id, false );
+				}
+
+				// Load specific field groups.
+			} elseif ( ! empty( $args['field_groups'] ) ) {
+				foreach ( $args['field_groups'] as $selector ) {
+					$field_groups[] = acf_get_field_group( $selector );
+				}
+
+				// Load fields for the given "new_post" args.
+			} elseif ( ( $args['post_id'] ?? 0 ) === 'new_post' ) {
+				$field_groups = acf_get_field_groups( $args['new_post'] ?? array() );
+
+				// Load fields for the given "post_id" arg.
+			} elseif ( ! empty( $args['post_id'] ) ) {
+				$field_groups = acf_get_field_groups(
+					array(
+						'post_id' => $args['post_id'],
+					)
+				);
+			}
+
+			// Load fields from the found field groups.
+			if ( $field_groups ) {
+				foreach ( $field_groups as $field_group ) {
+					$_fields = acf_get_fields( $field_group );
+					if ( $_fields ) {
+						foreach ( $_fields as $_field ) {
+							$fields[] = $_field;
+						}
+					}
+				}
+			}
+
+			// Add honeypot field.
+			if ( ! empty( $args['honeypot'] ) ) {
+				$fields[] = acf_get_field( '_validate_email' );
+			}
+
+			return array_filter( $fields );
+		}
+
+		/**
+		 * Returns the top-level $_POST['acf'] keys a given form configuration will accept on save.
+		 *
+		 * Derived from the same field discovery render_form() uses, so the set of save-acceptable
+		 * keys matches the set of keys the form actually rendered. For seamless clone fields whose
+		 * subfield input names nest under the parent clone's key (e.g. acf[clone_key][subkey]),
+		 * the parent's top-level key is what gets returned.
+		 *
+		 * @since SCF 6.8.5
+		 *
+		 * @param array $form The validated form configuration.
+		 * @return array
+		 */
+		public function get_allowed_field_keys( array $form ): array {
+			$keys = array();
+
+			foreach ( $this->get_form_fields( $form ) as $field ) {
+				$prefix = $field['prefix'] ?? 'acf';
+
+				if ( $prefix === 'acf' ) {
+					if ( ! empty( $field['key'] ) ) {
+						$keys[] = $field['key'];
+					}
+				} elseif ( preg_match( '/^acf\[([^]]+)]$/', $prefix, $matches ) ) {
+					$keys[] = $matches[1];
+				}
+			}
+
+			$keys = array_values( array_unique( array_filter( $keys ) ) );
+
+			/**
+			 * Filters the list of $_POST['acf'] keys a front-end form submission is allowed to save.
+			 *
+			 * Use this to permit additional field keys when a developer dynamically injects fields
+			 * into a form via JavaScript that aren't part of the form's declared field configuration.
+			 *
+			 * @since SCF 6.8.5
+			 *
+			 * @param array $keys The allowed top-level $_POST['acf'] keys.
+			 * @param array $form The validated form configuration.
+			 */
+			$keys = apply_filters( 'acf/form/allowed_field_keys', $keys, $form );
+
+			// Re-normalize after the filter so a misbehaving callback can't break array_flip()
+			// downstream in submit_form() with non-scalar or empty values.
+			$keys = array_filter( (array) $keys, 'is_scalar' );
+			return array_values( array_unique( array_filter( array_map( 'strval', $keys ) ) ) );
+		}
+
+		/**
+		 * Renders a front-end ACF form.
+		 *
+		 * Accepts either an array of form configuration (validated via validate_form()) or the
+		 * string id of a form previously registered with acf_register_form(). Outputs the form
+		 * HTML directly.
+		 *
+		 * @since ACF 5.4.0
+		 *
+		 * @param array|string $args Form configuration array, or the id of a registered form.
+		 * @return false|void False if a registered form id was passed and no matching form exists;
+		 *                    otherwise outputs the form and returns no value.
 		 */
 		function render_form( $args = array() ) {
 
 			// Vars.
 			$is_registered = false;
-			$field_groups  = array();
-			$fields        = array();
 
 			// Allow form settings to be directly provided.
 			if ( is_array( $args ) ) {
@@ -456,68 +607,22 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 			// Set uploader type.
 			acf_update_setting( 'uploader', $args['uploader'] );
 
-			// Register local fields.
-			foreach ( $this->get_default_fields() as $k => $field ) {
-				acf_add_local_field( $field );
-			}
+			// Discover the fields this form will expose.
+			$fields = $this->get_form_fields( $args );
 
-			// Append post_title field.
-			if ( $args['post_title'] ) {
-				$_post_title          = acf_get_field( '_post_title' );
-				$_post_title['value'] = $post_id ? get_post_field( 'post_title', $post_id ) : '';
-				$fields[]             = $_post_title;
-			}
-
-			// Append post_content field.
-			if ( $args['post_content'] ) {
-				$_post_content          = acf_get_field( '_post_content' );
-				$_post_content['value'] = $post_id ? get_post_field( 'post_content', $post_id ) : '';
-				$fields[]               = $_post_content;
-			}
-
-			// Load specific fields.
-			if ( $args['fields'] ) {
-
-				// Lookup fields using $strict = false for better compatibility with field names.
-				foreach ( $args['fields'] as $selector ) {
-					$fields[] = acf_maybe_get_field( $selector, $post_id, false );
+			// Load values for the special _post_title / _post_content fields so they
+			// render pre-populated with the current post's data.
+			foreach ( $fields as &$field ) {
+				if ( ! isset( $field['key'] ) ) {
+					continue;
 				}
-
-				// Load specific field groups.
-			} elseif ( $args['field_groups'] ) {
-				foreach ( $args['field_groups'] as $selector ) {
-					$field_groups[] = acf_get_field_group( $selector );
-				}
-
-				// Load fields for the given "new_post" args.
-			} elseif ( $args['post_id'] == 'new_post' ) {
-				$field_groups = acf_get_field_groups( $args['new_post'] );
-
-				// Load fields for the given "post_id" arg.
-			} else {
-				$field_groups = acf_get_field_groups(
-					array(
-						'post_id' => $args['post_id'],
-					)
-				);
-			}
-
-			// load fields from the found field groups.
-			if ( $field_groups ) {
-				foreach ( $field_groups as $field_group ) {
-					$_fields = acf_get_fields( $field_group );
-					if ( $_fields ) {
-						foreach ( $_fields as $_field ) {
-							$fields[] = $_field;
-						}
-					}
+				if ( $field['key'] === '_post_title' ) {
+					$field['value'] = $post_id ? get_post_field( 'post_title', $post_id ) : '';
+				} elseif ( $field['key'] === '_post_content' ) {
+					$field['value'] = $post_id ? get_post_field( 'post_content', $post_id ) : '';
 				}
 			}
-
-			// Add honeypot field.
-			if ( $args['honeypot'] ) {
-				$fields[] = acf_get_field( '_validate_email' );
-			}
+			unset( $field );
 
 			// Display updated_message
 			if ( ! empty( $_GET['updated'] ) && $args['updated_message'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Used as a flag; data not used.

--- a/includes/forms/form-front.php
+++ b/includes/forms/form-front.php
@@ -578,7 +578,7 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 		 * @return false|void False if a registered form id was passed and no matching form exists;
 		 *                    otherwise outputs the form and returns no value.
 		 */
-		function render_form( $args = array() ) {
+		public function render_form( $args = array() ) {
 
 			// Vars.
 			$is_registered = false;

--- a/includes/forms/form-front.php
+++ b/includes/forms/form-front.php
@@ -446,7 +446,7 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 		protected function get_form_fields( array $args ): array {
 			$fields       = array();
 			$field_groups = array();
-			$post_id      = $args['post_id'] ?? 0;
+			$post_id      = $args['post_id'];
 
 			// Prevent ACF from loading values for "new_post".
 			if ( 'new_post' === $post_id ) {
@@ -460,17 +460,17 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 			}
 
 			// Append post_title field.
-			if ( ! empty( $args['post_title'] ) ) {
+			if ( $args['post_title'] ) {
 				$fields[] = acf_get_field( '_post_title' );
 			}
 
 			// Append post_content field.
-			if ( ! empty( $args['post_content'] ) ) {
+			if ( $args['post_content'] ) {
 				$fields[] = acf_get_field( '_post_content' );
 			}
 
 			// Load specific fields.
-			if ( ! empty( $args['fields'] ) ) {
+			if ( $args['fields'] ) {
 
 				// Lookup fields using $strict = false for better compatibility with field names.
 				foreach ( $args['fields'] as $selector ) {
@@ -478,17 +478,17 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 				}
 
 				// Load specific field groups.
-			} elseif ( ! empty( $args['field_groups'] ) ) {
+			} elseif ( $args['field_groups'] ) {
 				foreach ( $args['field_groups'] as $selector ) {
 					$field_groups[] = acf_get_field_group( $selector );
 				}
 
 				// Load fields for the given "new_post" args.
-			} elseif ( 'new_post' === ( $args['post_id'] ?? 0 ) ) {
-				$field_groups = acf_get_field_groups( $args['new_post'] ?? array() );
+			} elseif ( 'new_post' === $args['post_id'] ) {
+				$field_groups = acf_get_field_groups( $args['new_post'] );
 
 				// Load fields for the given "post_id" arg.
-			} elseif ( ! empty( $args['post_id'] ) ) {
+			} else {
 				$field_groups = acf_get_field_groups(
 					array(
 						'post_id' => $args['post_id'],
@@ -509,7 +509,7 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 			}
 
 			// Add honeypot field.
-			if ( ! empty( $args['honeypot'] ) ) {
+			if ( $args['honeypot'] ) {
 				$fields[] = acf_get_field( '_validate_email' );
 			}
 

--- a/includes/forms/form-front.php
+++ b/includes/forms/form-front.php
@@ -269,14 +269,14 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 			// cannot leak into acf_update_values() downstream, but only apply them to the post when the
 			// form was rendered with the corresponding option enabled (mirrors render_form()).
 			if ( isset( $_POST['acf']['_post_title'] ) ) {
-				$post_title = acf_extract_var( $_POST['acf'], '_post_title' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by WP when saved.
+				$post_title = acf_extract_var( $_POST['acf'], '_post_title' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Sanitized by WP when saved; wp_insert_post / wp_update_post expect slashed input.
 				if ( ! empty( $form['post_title'] ) ) {
 					$save['post_title'] = $post_title;
 				}
 			}
 
 			if ( isset( $_POST['acf']['_post_content'] ) ) {
-				$post_content = acf_extract_var( $_POST['acf'], '_post_content' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by WP when saved.
+				$post_content = acf_extract_var( $_POST['acf'], '_post_content' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Sanitized by WP when saved; wp_insert_post / wp_update_post expect slashed input.
 				if ( ! empty( $form['post_content'] ) ) {
 					$save['post_content'] = $post_content;
 				}
@@ -449,7 +449,7 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 			$post_id      = $args['post_id'] ?? 0;
 
 			// Prevent ACF from loading values for "new_post".
-			if ( $post_id === 'new_post' ) {
+			if ( 'new_post' === $post_id ) {
 				$post_id = false;
 			}
 
@@ -484,7 +484,7 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 				}
 
 				// Load fields for the given "new_post" args.
-			} elseif ( ( $args['post_id'] ?? 0 ) === 'new_post' ) {
+			} elseif ( 'new_post' === ( $args['post_id'] ?? 0 ) ) {
 				$field_groups = acf_get_field_groups( $args['new_post'] ?? array() );
 
 				// Load fields for the given "post_id" arg.
@@ -535,7 +535,7 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 			foreach ( $this->get_form_fields( $form ) as $field ) {
 				$prefix = $field['prefix'] ?? 'acf';
 
-				if ( $prefix === 'acf' ) {
+				if ( 'acf' === $prefix ) {
 					if ( ! empty( $field['key'] ) ) {
 						$keys[] = $field['key'];
 					}
@@ -600,7 +600,7 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 			$post_id = $args['post_id'];
 
 			// Prevent ACF from loading values for "new_post".
-			if ( $post_id === 'new_post' ) {
+			if ( 'new_post' === $post_id ) {
 				$post_id = false;
 			}
 
@@ -616,9 +616,9 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 				if ( ! isset( $field['key'] ) ) {
 					continue;
 				}
-				if ( $field['key'] === '_post_title' ) {
+				if ( '_post_title' === $field['key'] ) {
 					$field['value'] = $post_id ? get_post_field( 'post_title', $post_id ) : '';
-				} elseif ( $field['key'] === '_post_content' ) {
+				} elseif ( '_post_content' === $field['key'] ) {
 					$field['value'] = $post_id ? get_post_field( 'post_content', $post_id ) : '';
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "secure-custom-fields",
+	"name": "release-6.8.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,14 @@ This plugin builds upon and is a fork of the previous work done by the contribut
 
 
 == Changelog ==
+= 6.8.6 =
+*Release Date - TBD*
+
+*Security*
+
+- Hardened authorization on the oEmbed field's AJAX search endpoint. The endpoint now requires an authenticated user with content-authoring capability; the legacy unauthenticated entry point is deprecated and will be removed in a future release.
+- Hardened front-end `acf_form()` submission processing so the `post_title` and `post_content` form options are respected on save, and the save pipeline only accepts values for fields the rendered form exposed. A new `acf/form/allowed_field_keys` filter is available for sites that legitimately extend a form at runtime. Ported from Advanced Custom Fields.
+
 = 6.8.5 =
 *Release Date 19th May 2026*
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: fields, custom fields, meta, scf
 Requires at least: 6.2
 Tested up to: 6.9.1
 Requires PHP: 7.4
-Stable tag: 6.8.5
+Stable tag: 6.8.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -52,12 +52,12 @@ This plugin builds upon and is a fork of the previous work done by the contribut
 
 == Changelog ==
 = 6.8.6 =
-*Release Date - TBD*
+*Release Date 27th May 2026*
 
 *Security*
 
 - Hardened authorization on the oEmbed field's AJAX search endpoint. The endpoint now requires an authenticated user with content-authoring capability; the legacy unauthenticated entry point is deprecated and will be removed in a future release.
-- Hardened front-end `acf_form()` submission processing so the `post_title` and `post_content` form options are respected on save, and the save pipeline only accepts values for fields the rendered form exposed. A new `acf/form/allowed_field_keys` filter is available for sites that legitimately extend a form at runtime. Ported from Advanced Custom Fields.
+- Hardened front-end `acf_form()` submission processing so the `post_title` and `post_content` form options are respected on save, and the save pipeline only accepts values for fields the rendered form exposed. A new `acf/form/allowed_field_keys` filter is available for sites that legitimately extend a form at runtime.
 
 = 6.8.5 =
 *Release Date 19th May 2026*

--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -6,7 +6,7 @@
  * Plugin Name:       Secure Custom Fields
  * Plugin URI:        https://developer.wordpress.org/secure-custom-fields/
  * Description:       Secure Custom Fields (SCF) offers an intuitive way for developers to enhance WordPress content management by adding extra fields and options without coding requirements.
- * Version:           6.8.5
+ * Version:           6.8.6
  * Author:            WordPress.org
  * Author URI:        https://wordpress.org/
  * Text Domain:       secure-custom-fields
@@ -33,7 +33,7 @@ if ( ! class_exists( 'ACF' ) ) {
 		 *
 		 * @var string
 		 */
-		public $version = '6.8.5';
+		public $version = '6.8.6';
 
 		/**
 		 * The plugin settings array.

--- a/tests/php/includes/fields/test-acf-field-oembed-ajax-security.php
+++ b/tests/php/includes/fields/test-acf-field-oembed-ajax-security.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Tests for the oEmbed field type AJAX authorization surface.
+ *
+ * Covers the registration of the oEmbed search AJAX hooks and (in later
+ * additions) the capability-gated rejection behaviour of the handler.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+// Load the oEmbed field type so its initialize() runs and the AJAX
+// action registrations are present in the global hook table before
+// WorDBless snapshots hook state on the first test.
+acf_include( 'includes/fields/class-acf-field-oembed.php' );
+
+/**
+ * Class Test_ACF_Field_Oembed_Ajax_Security
+ *
+ * Verifies that the oEmbed search AJAX action is registered only for
+ * authenticated requests, and that the handler enforces a capability
+ * check for any anonymous or low-privilege caller.
+ *
+ * @group fields
+ * @group ajax
+ * @group security
+ */
+class Test_ACF_Field_Oembed_Ajax_Security extends BaseTestCase {
+
+	/**
+	 * Administrator user ID created in set_up().
+	 *
+	 * @var int
+	 */
+	private $admin_user_id;
+
+	/**
+	 * Subscriber user ID created in set_up().
+	 *
+	 * @var int
+	 */
+	private $subscriber_user_id;
+
+	/**
+	 * Set up test fixtures.
+	 *
+	 * Creates one administrator and one subscriber user, registers a
+	 * minimal local oEmbed field used by the handler-level tests, and
+	 * resets the request superglobals so each test starts from a known
+	 * empty request state.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		// Create an admin user.
+		$this->admin_user_id = wp_insert_user(
+			array(
+				'user_login' => 'admin_user',
+				'user_pass'  => 'password',
+				'user_email' => 'admin@example.com',
+				'role'       => 'administrator',
+			)
+		);
+
+		// Create a subscriber user.
+		$this->subscriber_user_id = wp_insert_user(
+			array(
+				'user_login' => 'subscriber_user',
+				'user_pass'  => 'password',
+				'user_email' => 'subscriber@example.com',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Register the shared test oEmbed field so handler tests have a
+		// stable field key to reference.
+		acf_add_local_field(
+			array(
+				'key'  => 'field_test_oembed',
+				'name' => 'test_oembed',
+				'type' => 'oembed',
+			)
+		);
+
+		// Clear any existing request data.
+		$_REQUEST = array();
+		$_POST    = array();
+		$_GET     = array();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 *
+	 * Resets the current user, clears request superglobals, removes the
+	 * locally registered test field, and removes any one-shot
+	 * `pre_http_request` filter a handler test may have installed so
+	 * subsequent tests start from a clean global state.
+	 *
+	 * @return void
+	 */
+	public function tear_down(): void {
+		// Clear user.
+		wp_set_current_user( 0 );
+
+		// Clear request globals.
+		$_REQUEST = array();
+		$_POST    = array();
+		$_GET     = array();
+
+		// De-register the shared test field so the local-field registry
+		// is shaped the same after each test as before it.
+		acf_remove_local_field( 'field_test_oembed' );
+
+		// Remove any one-shot pre_http_request filter a handler test may
+		// have installed (handler tests are added in a later task; this
+		// keeps tear_down defensive against cross-test contamination).
+		remove_all_filters( 'pre_http_request' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * The unauthenticated AJAX action for the oEmbed search must not be
+	 * registered. Visitors without a session must have no entry point
+	 * into the handler at the WordPress action layer.
+	 *
+	 * @return void
+	 */
+	public function test_nopriv_hook_is_not_registered() {
+		$this->assertFalse(
+			has_action( 'wp_ajax_nopriv_acf/fields/oembed/search' ),
+			'The wp_ajax_nopriv_acf/fields/oembed/search action must not be registered.'
+		);
+	}
+
+	/**
+	 * The authenticated AJAX action for the oEmbed search must remain
+	 * registered so legitimate logged-in editors continue to receive
+	 * embed previews.
+	 *
+	 * @return void
+	 */
+	public function test_authenticated_hook_is_registered() {
+		$this->assertNotFalse(
+			has_action( 'wp_ajax_acf/fields/oembed/search' ),
+			'The wp_ajax_acf/fields/oembed/search action must remain registered.'
+		);
+	}
+}

--- a/tests/php/includes/fields/test-acf-field-oembed-ajax-security.php
+++ b/tests/php/includes/fields/test-acf-field-oembed-ajax-security.php
@@ -149,4 +149,201 @@ class Test_ACF_Field_Oembed_Ajax_Security extends BaseTestCase {
 			'The wp_ajax_acf/fields/oembed/search action must remain registered.'
 		);
 	}
+
+	/**
+	 * Invokes the oEmbed field-type ajax_query() handler under output
+	 * buffering and returns the JSON-decoded response payload.
+	 *
+	 * The handler is reached via the singleton already registered by the
+	 * plugin (`acf_get_field_type( 'oembed' )`); instantiating the class
+	 * directly would re-run `initialize()` and pollute the global hook
+	 * table that the registration tests in this class assert against.
+	 *
+	 * Two filters are installed for the duration of the call:
+	 *
+	 * - `wp_doing_ajax` is forced to true so `wp_send_json()` and
+	 *   `wp_send_json_error()` route their terminal exit through
+	 *   `wp_die()` (writing JSON) instead of bare `die` (which would
+	 *   terminate PHPUnit itself).
+	 * - `wp_die_ajax_handler` and `wp_die_json_handler` are replaced
+	 *   with a handler that throws a sentinel-tagged \RuntimeException.
+	 *   WorDBless installs its own handler that merely sets
+	 *   `exit => false` and returns, which leaves the calling handler
+	 *   free to keep running past its intended termination point and
+	 *   emit a second JSON payload (corrupting the captured buffer).
+	 *   Throwing models the real "exits here" semantics of production
+	 *   WP without terminating the test process; the caught exception
+	 *   is identified by message so unrelated runtime exceptions still
+	 *   surface as failures.
+	 *
+	 * @return mixed The JSON-decoded response payload (associative array
+	 *               on success/rejection) or null if the captured buffer
+	 *               did not contain valid JSON.
+	 *
+	 * @throws \RuntimeException Re-thrown when an unrelated runtime
+	 *                           exception bubbles out of the handler;
+	 *                           the sentinel-tagged halt exception is
+	 *                           consumed internally.
+	 */
+	private function invoke_ajax_query() {
+		$halt_marker  = 'acf_oembed_ajax_halt';
+		$force_ajax   = static function () {
+			return true;
+		};
+		$halt_handler = static function () use ( $halt_marker ) {
+			return static function () use ( $halt_marker ) {
+				throw new \RuntimeException( esc_html( $halt_marker ) );
+			};
+		};
+
+		add_filter( 'wp_doing_ajax', $force_ajax );
+		add_filter( 'wp_die_ajax_handler', $halt_handler, 100 );
+		add_filter( 'wp_die_json_handler', $halt_handler, 100 );
+
+		$output    = '';
+		$unrelated = null;
+
+		ob_start();
+		try {
+			acf_get_field_type( 'oembed' )->ajax_query();
+		} catch ( \RuntimeException $halt ) {
+			if ( $halt->getMessage() !== $halt_marker ) {
+				$unrelated = $halt;
+			}
+		} finally {
+			$output = ob_get_clean();
+			remove_filter( 'wp_die_json_handler', $halt_handler, 100 );
+			remove_filter( 'wp_die_ajax_handler', $halt_handler, 100 );
+			remove_filter( 'wp_doing_ajax', $force_ajax );
+		}
+
+		if ( null !== $unrelated ) {
+			throw $unrelated;
+		}
+
+		return json_decode( $output, true );
+	}
+
+	/**
+	 * An anonymous request to the oEmbed search handler must be rejected
+	 * with the wp_send_json_error() JSON envelope. The capability clause
+	 * of the combined guard short-circuits before any oEmbed work runs,
+	 * so no outbound HTTP path is reachable and no stub is required.
+	 *
+	 * @return void
+	 */
+	public function test_ajax_query_rejects_unauthenticated_user() {
+		wp_set_current_user( 0 );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test populates request superglobals to drive acf_request_args(); the handler under test is the one that performs nonce verification.
+		$_POST = array(
+			's'         => 'https://example.invalid/test',
+			'field_key' => 'field_test_oembed',
+			'nonce'     => 'irrelevant',
+		);
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Mirror of $_POST for handlers that read from $_REQUEST; the handler under test is the one that performs nonce verification.
+		$_REQUEST = $_POST;
+
+		$payload = $this->invoke_ajax_query();
+
+		$this->assertSame(
+			array( 'success' => false ),
+			$payload,
+			'Anonymous callers must receive the wp_send_json_error() rejection envelope.'
+		);
+		$this->assertArrayNotHasKey( 'url', (array) $payload, 'Rejection payload must not leak a url key.' );
+		$this->assertArrayNotHasKey( 'html', (array) $payload, 'Rejection payload must not leak an html key.' );
+	}
+
+	/**
+	 * An authenticated subscriber (who lacks `edit_posts`) submitting a
+	 * genuinely valid nonce must still be rejected. The valid nonce is
+	 * load-bearing: it forces the `acf_verify_ajax()` clause of the
+	 * combined guard to evaluate true so the rejection must originate
+	 * from the capability clause, proving the capability check is the
+	 * gate and not the nonce check.
+	 *
+	 * @return void
+	 */
+	public function test_ajax_query_rejects_subscriber() {
+		wp_set_current_user( $this->subscriber_user_id );
+
+		$nonce = wp_create_nonce( 'acf_field_oembed_field_test_oembed' );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test populates request superglobals to drive acf_request_args(); the handler under test is the one that performs nonce verification.
+		$_POST = array(
+			's'         => 'https://example.invalid/test',
+			'field_key' => 'field_test_oembed',
+			'nonce'     => $nonce,
+		);
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Mirror of $_POST for handlers that read from $_REQUEST; the handler under test is the one that performs nonce verification.
+		$_REQUEST = $_POST;
+
+		$payload = $this->invoke_ajax_query();
+
+		$this->assertSame(
+			array( 'success' => false ),
+			$payload,
+			'Subscribers lacking edit_posts must receive the wp_send_json_error() rejection envelope even with a valid nonce.'
+		);
+	}
+
+	/**
+	 * An administrator submitting a valid nonce reaches the oEmbed
+	 * lookup and receives the success contract (`url` and `html` keys).
+	 * A one-shot `pre_http_request` filter stubs the underlying HTTP
+	 * call so the test is deterministic and performs no real outbound
+	 * traffic; the filter is removed before assertions so it cannot
+	 * leak to other tests, and `tear_down()` defensively clears all
+	 * `pre_http_request` filters as a safety net.
+	 *
+	 * @return void
+	 */
+	public function test_ajax_query_succeeds_for_admin() {
+		wp_set_current_user( $this->admin_user_id );
+
+		$nonce = wp_create_nonce( 'acf_field_oembed_field_test_oembed' );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test populates request superglobals to drive acf_request_args(); the handler under test is the one that performs nonce verification.
+		$_POST = array(
+			's'         => 'https://example.invalid/test',
+			'field_key' => 'field_test_oembed',
+			'nonce'     => $nonce,
+		);
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Mirror of $_POST for handlers that read from $_REQUEST; the handler under test is the one that performs nonce verification.
+		$_REQUEST = $_POST;
+
+		// One-shot stub for the only HTTP path the handler can reach.
+		$stub = static function () {
+			return array(
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'body'     => '',
+				'headers'  => array(),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $stub );
+
+		try {
+			$payload = $this->invoke_ajax_query();
+		} finally {
+			remove_filter( 'pre_http_request', $stub );
+		}
+
+		$this->assertIsArray( $payload, 'Success response must decode to an associative array.' );
+		$this->assertArrayHasKey( 'url', $payload, 'Success response must include a url key.' );
+		$this->assertArrayHasKey( 'html', $payload, 'Success response must include an html key.' );
+
+		// After removal, no pre_http_request filter callback should
+		// remain so subsequent tests in this class and other test
+		// classes cannot inherit the stub.
+		$this->assertFalse(
+			has_filter( 'pre_http_request', $stub ),
+			'The pre_http_request stub must be removed before the test exits.'
+		);
+	}
 }

--- a/tests/php/includes/fields/test-acf-field-oembed-ajax-security.php
+++ b/tests/php/includes/fields/test-acf-field-oembed-ajax-security.php
@@ -43,6 +43,14 @@ class Test_ACF_Field_Oembed_Ajax_Security extends BaseTestCase {
 	private $subscriber_user_id;
 
 	/**
+	 * Captured `_doing_it_wrong()` invocations during the current test.
+	 * Populated by `capture_doing_it_wrong()` and cleared in `tear_down()`.
+	 *
+	 * @var array<int, array{function: string, message: string, version: string}>
+	 */
+	private $doing_it_wrong_calls = array();
+
+	/**
 	 * Set up test fixtures.
 	 *
 	 * Creates one administrator and one subscriber user, registers a
@@ -89,6 +97,38 @@ class Test_ACF_Field_Oembed_Ajax_Security extends BaseTestCase {
 		$_REQUEST = array();
 		$_POST    = array();
 		$_GET     = array();
+
+		// Suppress the PHP notice that _doing_it_wrong() would emit under
+		// WP_DEBUG so PHPUnit does not convert it into a test failure.
+		// Tests that need to observe the deprecation call hook the
+		// `doing_it_wrong_run` action directly.
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+
+		$this->doing_it_wrong_calls = array();
+		add_action(
+			'doing_it_wrong_run',
+			array( $this, 'capture_doing_it_wrong' ),
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Captures `_doing_it_wrong()` invocations triggered during a test so
+	 * tests can assert that the deprecation notice was (or was not)
+	 * emitted by the handler.
+	 *
+	 * @param string $function_name The function being called incorrectly.
+	 * @param string $message       The deprecation / incorrect-usage message.
+	 * @param string $version       The version the incorrect usage was first noted in.
+	 * @return void
+	 */
+	public function capture_doing_it_wrong( $function_name, $message, $version ) {
+		$this->doing_it_wrong_calls[] = array(
+			'function' => $function_name,
+			'message'  => $message,
+			'version'  => $version,
+		);
 	}
 
 	/**
@@ -119,20 +159,28 @@ class Test_ACF_Field_Oembed_Ajax_Security extends BaseTestCase {
 		// keeps tear_down defensive against cross-test contamination).
 		remove_all_filters( 'pre_http_request' );
 
+		// Remove the doing_it_wrong capture hooks installed in set_up().
+		remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		remove_action( 'doing_it_wrong_run', array( $this, 'capture_doing_it_wrong' ), 10 );
+		$this->doing_it_wrong_calls = array();
+
 		parent::tear_down();
 	}
 
 	/**
-	 * The unauthenticated AJAX action for the oEmbed search must not be
-	 * registered. Visitors without a session must have no entry point
-	 * into the handler at the WordPress action layer.
+	 * The unauthenticated AJAX action for the oEmbed search remains
+	 * registered during the deprecation window so callers receive a
+	 * predictable JSON error (and a `_doing_it_wrong` notice in dev
+	 * environments) instead of the silent `0` an unregistered action
+	 * would produce. The handler enforces the authorization check
+	 * regardless of which hook delivered the request.
 	 *
 	 * @return void
 	 */
-	public function test_nopriv_hook_is_not_registered() {
-		$this->assertFalse(
+	public function test_nopriv_hook_remains_registered_for_deprecation() {
+		$this->assertNotFalse(
 			has_action( 'wp_ajax_nopriv_acf/fields/oembed/search' ),
-			'The wp_ajax_nopriv_acf/fields/oembed/search action must not be registered.'
+			'The wp_ajax_nopriv_acf/fields/oembed/search action must remain registered so unauthenticated callers receive a documented rejection during the deprecation window.'
 		);
 	}
 
@@ -253,6 +301,17 @@ class Test_ACF_Field_Oembed_Ajax_Security extends BaseTestCase {
 		);
 		$this->assertArrayNotHasKey( 'url', (array) $payload, 'Rejection payload must not leak a url key.' );
 		$this->assertArrayNotHasKey( 'html', (array) $payload, 'Rejection payload must not leak an html key.' );
+
+		// Anonymous callers must also receive the deprecation notice
+		// indicating the nopriv entry point is going away.
+		$this->assertCount(
+			1,
+			$this->doing_it_wrong_calls,
+			'Anonymous calls must trigger exactly one _doing_it_wrong() notice.'
+		);
+		$this->assertStringContainsString( 'ajax_query', $this->doing_it_wrong_calls[0]['function'] );
+		$this->assertSame( '6.8.5', $this->doing_it_wrong_calls[0]['version'] );
+		$this->assertStringContainsString( 'wp_ajax_nopriv_acf/fields/oembed/search', $this->doing_it_wrong_calls[0]['message'] );
 	}
 
 	/**
@@ -285,6 +344,15 @@ class Test_ACF_Field_Oembed_Ajax_Security extends BaseTestCase {
 			array( 'success' => false ),
 			$payload,
 			'Subscribers lacking edit_posts must receive the wp_send_json_error() rejection envelope even with a valid nonce.'
+		);
+
+		// Logged-in callers (even under-privileged ones) must not trigger
+		// the nopriv-deprecation notice — the deprecation only applies to
+		// requests that arrived through the unauthenticated entry point.
+		$this->assertSame(
+			array(),
+			$this->doing_it_wrong_calls,
+			'Authenticated callers must not trigger the nopriv-deprecation _doing_it_wrong() notice.'
 		);
 	}
 

--- a/tests/php/includes/forms/test-form-front.php
+++ b/tests/php/includes/forms/test-form-front.php
@@ -582,4 +582,256 @@ class Test_Form_Front extends BaseTestCase {
 		wp_delete_post( $post_id, true );
 		unset( $GLOBALS['acf_form'] ); // @phpstan-ignore-line -- Cleanup global in test.
 	}
+
+	/**
+	 * pre_save_post() must NOT apply $_POST['acf']['_post_title'] when the form was
+	 * not rendered with `post_title` enabled. This blocks a submitter from injecting
+	 * a post_title value into a form that did not expose the post title field.
+	 */
+	public function test_pre_save_post_ignores_post_title_when_form_disables_it() {
+		$form_front = new acf_form_front();
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Original Title',
+				'post_status' => 'draft',
+			)
+		);
+
+		// Form config explicitly disables post_title rendering.
+		$form = array(
+			'post_id'      => $post_id,
+			'post_title'   => false,
+			'post_content' => false,
+			'new_post'     => false,
+		);
+
+		// Attacker injects _post_title into submission payload.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test populates request superglobals to drive pre_save_post(); nonce verification is the responsibility of check_submit_form() upstream.
+		$_POST['acf'] = array( '_post_title' => 'Injected Title' );
+
+		$form_front->pre_save_post( $post_id, $form );
+
+		$post_after = get_post( $post_id );
+		$this->assertSame(
+			'Original Title',
+			$post_after->post_title,
+			'post_title must not change when the form did not enable post_title editing.'
+		);
+
+		$_POST = array(); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test cleanup.
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * pre_save_post() must apply $_POST['acf']['_post_title'] when the form was
+	 * rendered with `post_title` enabled. Regression check for legitimate use.
+	 */
+	public function test_pre_save_post_applies_post_title_when_form_enables_it() {
+		$form_front = new acf_form_front();
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Original Title',
+				'post_status' => 'draft',
+			)
+		);
+
+		$form = array(
+			'post_id'      => $post_id,
+			'post_title'   => true,
+			'post_content' => false,
+			'new_post'     => false,
+		);
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test populates request superglobals; nonce verified upstream.
+		$_POST['acf'] = array( '_post_title' => 'Legitimate New Title' );
+
+		$form_front->pre_save_post( $post_id, $form );
+
+		$post_after = get_post( $post_id );
+		$this->assertSame(
+			'Legitimate New Title',
+			$post_after->post_title,
+			'post_title must update when the form enabled post_title editing.'
+		);
+
+		$_POST = array(); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test cleanup.
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * pre_save_post() must NOT apply $_POST['acf']['_post_content'] when the form
+	 * was not rendered with `post_content` enabled. Mirrors the post_title check.
+	 */
+	public function test_pre_save_post_ignores_post_content_when_form_disables_it() {
+		$form_front = new acf_form_front();
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Original Content',
+				'post_status'  => 'draft',
+			)
+		);
+
+		$form = array(
+			'post_id'      => $post_id,
+			'post_title'   => false,
+			'post_content' => false,
+			'new_post'     => false,
+		);
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test populates request superglobals; nonce verified upstream.
+		$_POST['acf'] = array( '_post_content' => 'Injected Content' );
+
+		$form_front->pre_save_post( $post_id, $form );
+
+		$post_after = get_post( $post_id );
+		$this->assertSame(
+			'Original Content',
+			$post_after->post_content,
+			'post_content must not change when the form did not enable post_content editing.'
+		);
+
+		$_POST = array(); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test cleanup.
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * get_allowed_field_keys() must return only the field keys the form actually
+	 * exposed through its `fields` configuration. Fields not in the configuration
+	 * must not be accepted on save.
+	 */
+	public function test_get_allowed_field_keys_limits_to_form_fields_configuration() {
+		$form_front = new acf_form_front();
+
+		// Register two local fields; only one is exposed by the form.
+		acf_add_local_field(
+			array(
+				'key'  => 'field_allowed_text',
+				'name' => 'allowed_text',
+				'type' => 'text',
+			)
+		);
+		acf_add_local_field(
+			array(
+				'key'  => 'field_secret_meta',
+				'name' => 'secret_meta',
+				'type' => 'text',
+			)
+		);
+
+		$form = array(
+			'post_id'      => 0,
+			'post_title'   => false,
+			'post_content' => false,
+			'fields'       => array( 'field_allowed_text' ),
+			'field_groups' => false,
+			'new_post'     => false,
+			'honeypot'     => false,
+		);
+
+		$keys = $form_front->get_allowed_field_keys( $form );
+
+		$this->assertContains( 'field_allowed_text', $keys, 'Allowed field key must appear in the allowlist.' );
+		$this->assertNotContains( 'field_secret_meta', $keys, 'Unconfigured field key must NOT appear in the allowlist.' );
+
+		acf_remove_local_field( 'field_allowed_text' );
+		acf_remove_local_field( 'field_secret_meta' );
+	}
+
+	/**
+	 * Filter `acf/form/allowed_field_keys` must be able to extend the allowlist
+	 * (for sites that legitimately inject extra fields via JS at runtime).
+	 */
+	public function test_allowed_field_keys_filter_can_extend_set() {
+		$form_front = new acf_form_front();
+
+		acf_add_local_field(
+			array(
+				'key'  => 'field_base_allowed',
+				'name' => 'base_allowed',
+				'type' => 'text',
+			)
+		);
+
+		$form = array(
+			'post_id'      => 0,
+			'post_title'   => false,
+			'post_content' => false,
+			'fields'       => array( 'field_base_allowed' ),
+			'field_groups' => false,
+			'new_post'     => false,
+			'honeypot'     => false,
+		);
+
+		$extra_key = 'field_injected_via_filter';
+		add_filter(
+			'acf/form/allowed_field_keys',
+			static function ( $keys ) use ( $extra_key ) {
+				$keys[] = $extra_key;
+				return $keys;
+			}
+		);
+
+		$keys = $form_front->get_allowed_field_keys( $form );
+
+		$this->assertContains( 'field_base_allowed', $keys );
+		$this->assertContains( $extra_key, $keys );
+
+		remove_all_filters( 'acf/form/allowed_field_keys' );
+		acf_remove_local_field( 'field_base_allowed' );
+	}
+
+	/**
+	 * Filter `acf/form/allowed_field_keys` must defensively normalize the return
+	 * value: a misbehaving callback returning non-scalar values must not break the
+	 * downstream array_flip() in submit_form().
+	 */
+	public function test_allowed_field_keys_filter_normalizes_bad_return() {
+		$form_front = new acf_form_front();
+
+		acf_add_local_field(
+			array(
+				'key'  => 'field_normalize_test',
+				'name' => 'normalize_test',
+				'type' => 'text',
+			)
+		);
+
+		$form = array(
+			'post_id'      => 0,
+			'post_title'   => false,
+			'post_content' => false,
+			'fields'       => array( 'field_normalize_test' ),
+			'field_groups' => false,
+			'new_post'     => false,
+			'honeypot'     => false,
+		);
+
+		add_filter(
+			'acf/form/allowed_field_keys',
+			static function () {
+				return array(
+					'field_normalize_test',
+					'field_normalize_test', // duplicate
+					'',                     // empty
+					null,                   // non-scalar will survive earlier filter only after cast
+					array( 'nested' ),      // non-scalar
+				);
+			}
+		);
+
+		$keys = $form_front->get_allowed_field_keys( $form );
+
+		$this->assertSame(
+			array( 'field_normalize_test' ),
+			$keys,
+			'Allowlist must drop duplicates, empties, and non-scalar entries returned by filter callbacks.'
+		);
+
+		remove_all_filters( 'acf/form/allowed_field_keys' );
+		acf_remove_local_field( 'field_normalize_test' );
+	}
 }

--- a/tests/php/includes/forms/test-form-front.php
+++ b/tests/php/includes/forms/test-form-front.php
@@ -594,9 +594,12 @@ class Test_Form_Front extends BaseTestCase {
 	}
 
 	/**
-	 * pre_save_post() must NOT apply $_POST['acf']['_post_title'] when the form was
-	 * not rendered with `post_title` enabled. This blocks a submitter from injecting
-	 * a post_title value into a form that did not expose the post title field.
+	 * Rejects injected post_title when form disables post_title editing.
+	 *
+	 * Asserts pre_save_post() does NOT apply $_POST['acf']['_post_title'] when the
+	 * form was not rendered with `post_title` enabled. This blocks a submitter from
+	 * injecting a post_title value into a form that did not expose the post title
+	 * field.
 	 */
 	public function test_pre_save_post_ignores_post_title_when_form_disables_it() {
 		$form_front = new acf_form_front();
@@ -634,8 +637,10 @@ class Test_Form_Front extends BaseTestCase {
 	}
 
 	/**
-	 * pre_save_post() must apply $_POST['acf']['_post_title'] when the form was
-	 * rendered with `post_title` enabled. Regression check for legitimate use.
+	 * Applies post_title when form enables post_title editing.
+	 *
+	 * Asserts pre_save_post() applies $_POST['acf']['_post_title'] when the form
+	 * was rendered with `post_title` enabled. Regression check for legitimate use.
 	 */
 	public function test_pre_save_post_applies_post_title_when_form_enables_it() {
 		$form_front = new acf_form_front();
@@ -671,8 +676,11 @@ class Test_Form_Front extends BaseTestCase {
 	}
 
 	/**
-	 * pre_save_post() must NOT apply $_POST['acf']['_post_content'] when the form
-	 * was not rendered with `post_content` enabled. Mirrors the post_title check.
+	 * Rejects injected post_content when form disables post_content editing.
+	 *
+	 * Asserts pre_save_post() does NOT apply $_POST['acf']['_post_content'] when
+	 * the form was not rendered with `post_content` enabled. Mirrors the
+	 * post_title check.
 	 */
 	public function test_pre_save_post_ignores_post_content_when_form_disables_it() {
 		$form_front = new acf_form_front();
@@ -709,9 +717,11 @@ class Test_Form_Front extends BaseTestCase {
 	}
 
 	/**
-	 * get_allowed_field_keys() must return only the field keys the form actually
-	 * exposed through its `fields` configuration. Fields not in the configuration
-	 * must not be accepted on save.
+	 * Returns only the field keys the form exposed via `fields` configuration.
+	 *
+	 * Asserts get_allowed_field_keys() returns only the field keys the form
+	 * actually exposed through its `fields` configuration. Fields not in the
+	 * configuration must not be accepted on save.
 	 */
 	public function test_get_allowed_field_keys_limits_to_form_fields_configuration() {
 		$form_front = new acf_form_front();

--- a/tests/php/includes/forms/test-form-front.php
+++ b/tests/php/includes/forms/test-form-front.php
@@ -497,9 +497,12 @@ class Test_Form_Front extends BaseTestCase {
 			)
 		);
 
-		$form = array(
-			'post_id' => $post_id,
-			'return'  => '',
+		// validate_form() applies the defaults that get_form_fields() relies on.
+		$form = $form_front->validate_form(
+			array(
+				'post_id' => $post_id,
+				'return'  => '',
+			)
 		);
 
 		$form_front->submit_form( $form );
@@ -536,9 +539,12 @@ class Test_Form_Front extends BaseTestCase {
 			)
 		);
 
-		$form = array(
-			'post_id' => $post_id,
-			'return'  => '', // Empty to avoid redirect.
+		// validate_form() applies the defaults that get_form_fields() relies on.
+		$form = $form_front->validate_form(
+			array(
+				'post_id' => $post_id,
+				'return'  => '', // Empty to avoid redirect.
+			)
 		);
 
 		$form_front->submit_form( $form );
@@ -567,11 +573,15 @@ class Test_Form_Front extends BaseTestCase {
 			)
 		);
 
-		$form = array(
-			'post_id'     => $post_id,
-			'return'      => '',
-			'custom_data' => 'test_value',
+		// validate_form() applies the defaults that get_form_fields() relies on.
+		$form = $form_front->validate_form(
+			array(
+				'post_id' => $post_id,
+				'return'  => '',
+			)
 		);
+		// Preserve the test's custom marker after validation.
+		$form['custom_data'] = 'test_value';
 
 		$form_front->submit_form( $form );
 


### PR DESCRIPTION
*Release Date 27th May 2026*

*Security*

- Hardened authorization on the oEmbed field's AJAX search endpoint. The endpoint now requires an authenticated user with content-authoring capability; the legacy unauthenticated entry point is deprecated and will be removed in a future release.
- Hardened front-end  submission processing so the  and  form options are respected on save, and the save pipeline only accepts values for fields the rendered form exposed. A new  filter is available for sites that legitimately extend a form at runtime.