### PR TITLE
Prepare 6.8.7 Release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "release-6.8.6",
+	"name": "secure-custom-fields",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/readme.txt
+++ b/readme.txt
@@ -51,8 +51,8 @@ This plugin builds upon and is a fork of the previous work done by the contribut
 
 
 == Changelog ==
-= Next =
-*Release Date TBD*
+= 6.8.7 =
+*Release Date 8th June 2026*
 
 *Fixes*
 

--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -6,7 +6,7 @@
  * Plugin Name:       Secure Custom Fields
  * Plugin URI:        https://developer.wordpress.org/secure-custom-fields/
  * Description:       Secure Custom Fields (SCF) offers an intuitive way for developers to enhance WordPress content management by adding extra fields and options without coding requirements.
- * Version:           6.8.6
+ * Version:           6.8.7
  * Author:            WordPress.org
  * Author URI:        https://wordpress.org/
  * Text Domain:       secure-custom-fields
@@ -33,7 +33,7 @@ if ( ! class_exists( 'ACF' ) ) {
 		 *
 		 * @var string
 		 */
-		public $version = '6.8.6';
+		public $version = '6.8.7';
 
 		/**
 		 * The plugin settings array.


### PR DESCRIPTION
*Release Date 8th June 2026*

*Fixes*

- SCF's Abilities API integration for its internal post types no longer triggers PHP warnings, notices, or a fatal error (500) on block editor and REST API requests when another active plugin builds the WordPress abilities registry earlier in the request; registration is skipped cleanly in that case and normal abilities behavior is otherwise unchanged.