### PR TITLE
Hide "Edit post type" Command Palette command from users who cannot edit post types

### DIFF
--- a/assets/src/js/commands/custom-post-type-commands.js
+++ b/assets/src/js/commands/custom-post-type-commands.js
@@ -106,7 +106,13 @@ const registerPostTypeCommands = async () => {
 			} );
 		}
 
-		// Register "Edit Post Type" command
+		// Register "Edit Post Type" command. The scf_post_id field is only
+		// exposed to users who can edit the post type definition, so its
+		// absence means the command must not be offered.
+		if ( ! postType.scf_post_id ) {
+			return;
+		}
+
 		commandStore.registerCommand( {
 			name: `scf/edit-${ postType.slug }`,
 			label: sprintf(

--- a/includes/rest-api/class-acf-rest-types-endpoint.php
+++ b/includes/rest-api/class-acf-rest-types-endpoint.php
@@ -190,7 +190,7 @@ class SCF_Rest_Types_Endpoint {
 			array(
 				'get_callback' => array( $this, 'get_scf_post_id' ),
 				'schema'       => array(
-					'description' => __( 'The SCF internal post ID that defines this post type, or null if not managed by SCF.', 'secure-custom-fields' ),
+					'description' => __( 'The SCF internal post ID that defines this post type. Null if not managed by SCF or if the current user cannot edit the post type definition.', 'secure-custom-fields' ),
 					'type'        => array( 'integer', 'null' ),
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -242,10 +242,14 @@ class SCF_Rest_Types_Endpoint {
 	/**
 	 * Get the SCF internal post ID for a post type.
 	 *
+	 * Only exposed to users who can edit the post type definition, so that
+	 * consumers (e.g. Command Palette commands) can rely on its presence as
+	 * a capability check.
+	 *
 	 * @since SCF 6.8.3
 	 *
 	 * @param array $post_type_object The post type object.
-	 * @return int|null The post ID if managed by SCF, null otherwise.
+	 * @return int|null The post ID if managed by SCF and editable by the current user, null otherwise.
 	 */
 	public function get_scf_post_id( $post_type_object ) {
 		$slug           = $post_type_object['slug'];
@@ -253,6 +257,10 @@ class SCF_Rest_Types_Endpoint {
 
 		foreach ( $scf_post_types as $scf_post_type ) {
 			if ( $scf_post_type['post_type'] === $slug ) {
+				if ( ! current_user_can( 'edit_post', (int) $scf_post_type['ID'] ) ) {
+					return null;
+				}
+
 				return (int) $scf_post_type['ID'];
 			}
 		}

--- a/includes/rest-api/class-acf-rest-types-endpoint.php
+++ b/includes/rest-api/class-acf-rest-types-endpoint.php
@@ -257,11 +257,13 @@ class SCF_Rest_Types_Endpoint {
 
 		foreach ( $scf_post_types as $scf_post_type ) {
 			if ( $scf_post_type['post_type'] === $slug ) {
-				if ( ! current_user_can( 'edit_post', (int) $scf_post_type['ID'] ) ) {
+				$scf_post_id = isset( $scf_post_type['ID'] ) ? (int) $scf_post_type['ID'] : 0;
+
+				if ( ! $scf_post_id || ! current_user_can( 'edit_post', $scf_post_id ) ) {
 					return null;
 				}
 
-				return (int) $scf_post_type['ID'];
+				return $scf_post_id;
 			}
 		}
 

--- a/tests/php/includes/rest-api/test-rest-types-endpoint.php
+++ b/tests/php/includes/rest-api/test-rest-types-endpoint.php
@@ -69,7 +69,89 @@ class Test_REST_Types_Endpoint extends BaseTestCase {
 			unregister_post_type( $this->test_post_type );
 		}
 
+		// Clean up any SCF post type definitions created by tests.
+		$posts = get_posts(
+			array(
+				'post_type'   => 'acf-post-type',
+				'numberposts' => -1,
+				'post_status' => 'any',
+			)
+		);
+		foreach ( $posts as $post ) {
+			wp_delete_post( $post->ID, true );
+		}
+
+		if ( $this->load_post_types_filter ) {
+			remove_filter( 'acf/load_post_types', $this->load_post_types_filter );
+			$this->load_post_types_filter = null;
+		}
+
+		wp_set_current_user( 0 );
+
 		parent::tear_down();
+	}
+
+	/**
+	 * Filter callback injecting the test post type definition.
+	 *
+	 * @var callable|null
+	 */
+	private $load_post_types_filter;
+
+	/**
+	 * Create an SCF-managed post type definition for testing.
+	 *
+	 * WorDBless cannot query posts by post type, so the definition is also
+	 * injected via the acf/load_post_types filter to make it visible to
+	 * acf_get_acf_post_types(). The underlying post is real, so capability
+	 * checks against it behave as in production.
+	 *
+	 * @return int The internal acf-post-type post ID.
+	 */
+	private function create_scf_post_type() {
+		// Ensure ACF internal post type instances are initialized.
+		// WorDBless fires plugins_loaded and init BEFORE our plugin is loaded,
+		// so we need to fire them again to run our plugin's callbacks.
+		if ( ! acf_get_internal_post_type_instance( 'acf-post-type' ) ) {
+			do_action( 'plugins_loaded' );
+			do_action( 'init' );
+		}
+
+		$post_type = acf_update_post_type(
+			array(
+				'key'       => 'post_type_' . uniqid(),
+				'title'     => 'Test Post Type',
+				'post_type' => 'test_cpt',
+				'active'    => true,
+			)
+		);
+
+		$this->load_post_types_filter = function ( $post_types ) use ( $post_type ) {
+			$post_types[] = $post_type;
+			return $post_types;
+		};
+		add_filter( 'acf/load_post_types', $this->load_post_types_filter );
+
+		return (int) $post_type['ID'];
+	}
+
+	/**
+	 * Create a user with the given role and set it as the current user.
+	 *
+	 * @param string $role The role for the new user.
+	 * @return int The user ID.
+	 */
+	private function login_as( $role ) {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'scf_' . $role . '_' . uniqid(),
+				'user_pass'  => 'password',
+				'role'       => $role,
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		return $user_id;
 	}
 
 	/**
@@ -405,6 +487,55 @@ class Test_REST_Types_Endpoint extends BaseTestCase {
 		$fields = $this->endpoint->get_scf_fields( $post_type_object );
 
 		$this->assertIsArray( $fields );
+	}
+
+	/**
+	 * Test that get_scf_post_id returns the internal post ID for users who
+	 * can edit the post type definition.
+	 */
+	public function test_get_scf_post_id_visible_to_privileged_user() {
+		$scf_post_id = $this->create_scf_post_type();
+		$this->login_as( 'administrator' );
+
+		$result = $this->endpoint->get_scf_post_id( array( 'slug' => 'test_cpt' ) );
+
+		$this->assertSame( $scf_post_id, $result );
+	}
+
+	/**
+	 * Test that get_scf_post_id returns null for users who cannot edit the
+	 * post type definition.
+	 */
+	public function test_get_scf_post_id_hidden_from_unprivileged_user() {
+		$this->create_scf_post_type();
+		$this->login_as( 'subscriber' );
+
+		$result = $this->endpoint->get_scf_post_id( array( 'slug' => 'test_cpt' ) );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test that get_scf_post_id returns null for logged-out users.
+	 */
+	public function test_get_scf_post_id_hidden_from_logged_out_user() {
+		$this->create_scf_post_type();
+		wp_set_current_user( 0 );
+
+		$result = $this->endpoint->get_scf_post_id( array( 'slug' => 'test_cpt' ) );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test that get_scf_post_id returns null for post types not managed by SCF.
+	 */
+	public function test_get_scf_post_id_null_for_unmanaged_post_type() {
+		$this->login_as( 'administrator' );
+
+		$result = $this->endpoint->get_scf_post_id( array( 'slug' => 'post' ) );
+
+		$this->assertNull( $result );
 	}
 
 	/**


### PR DESCRIPTION
The Command Palette "Edit post type" command was registered unconditionally, so users with lesser privileges saw the command and, when selecting it, hit a "Sorry, you are not allowed to edit this item" error.

This PR gates the command on the actual capability:

- The `scf_post_id` REST field on `/wp/v2/types` now returns `null` unless the current user can `edit_post` the underlying `acf-post-type` definition post (which resolves to SCF's `capability` setting, `manage_options` by default). As a side benefit, internal definition post IDs are no longer exposed to unprivileged users.
- `custom-post-type-commands.js` only registers the "Edit post type" command when `scf_post_id` is present, mirroring how the "View All" / "Add New" commands already rely on `canUser()` checks.

Includes four new PHPUnit regression tests covering admin, subscriber, logged-out, and non-SCF post types. Since WorDBless cannot query posts by post type, the tests inject the definition via the `acf/load_post_types` filter while keeping the capability check against a real post.

Verified in wp-env: administrator receives the internal post ID, subscriber and anonymous users receive `null`, and the command no longer appears in the Command Palette for non-admins.

Closes #402

## Use of AI Tools

This PR was authored by Claude Code (Claude Fable 5), directed and reviewed by @cbravobernal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)