### PR TITLE
Backport: 6.8.4 changes

### DIFF
--- a/assets/src/js/_acf-field-tab.js
+++ b/assets/src/js/_acf-field-tab.js
@@ -333,6 +333,11 @@
 
 			// set active
 			this.setActive( tab );
+
+			// Recalculate admin menu pinning so a previously taller tab (e.g. one
+			// containing WYSIWYG fields) doesn't leave the menu pinned against a
+			// shorter page, which can lock page scroll.
+			$( document ).trigger( 'wp-pin-menu' );
 		},
 
 		closeTab: function ( tab ) {

--- a/assets/src/js/pro/blocks-v3/components/block-edit.js
+++ b/assets/src/js/pro/blocks-v3/components/block-edit.js
@@ -353,26 +353,52 @@ export const BlockEdit = ( props ) => {
 			return false;
 		}
 
-		const preloadedBlocks = acf.get( 'preloadedBlocks' );
-		if ( ! preloadedBlocks || ! preloadedBlocks[ hash ] ) {
+		const data = getPreloadedBlockData(
+			hash,
+			clientId,
+			acf.get( 'preloadedBlocks' )
+		);
+
+		if ( ! data ) {
 			acf.debug( 'Preload failed: not preloaded.' );
 			return false;
 		}
 
-		const data = preloadedBlocks[ hash ];
+		acf.debug( 'Preload successful', data );
+		return data;
+	}
+
+	/**
+	 * Returns a copy of a preloaded block entry with the placeholder hash
+	 * replaced by the actual client ID.
+	 *
+	 * Works on a deep clone so the shared preloaded entry is never mutated —
+	 * duplicating a block with identical attributes reuses the same hash, and
+	 * an in-place replacement would corrupt the entry for the duplicate.
+	 *
+	 * @param {string} hash            - Attributes hash
+	 * @param {string} blockClientId   - Block client ID
+	 * @param {Object} preloadedBlocks - The preloaded blocks store
+	 * @return {Object|boolean} - Preloaded data or false
+	 */
+	function getPreloadedBlockData( hash, blockClientId, preloadedBlocks ) {
+		if ( ! preloadedBlocks || ! preloadedBlocks[ hash ] ) {
+			return false;
+		}
+
+		const data = JSON.parse( JSON.stringify( preloadedBlocks[ hash ] ) );
 
 		// Replace placeholder client ID with actual client ID
-		data.html = data.html.replaceAll( hash, clientId );
-		data.form = data.form.replaceAll( hash, clientId );
+		data.html = data.html.replaceAll( hash, blockClientId );
+		data.form = data.form.replaceAll( hash, blockClientId );
 
-		if ( data?.validation && data?.validation.errors ) {
+		if ( data?.validation?.errors ) {
 			data.validation.errors = data.validation.errors.map( ( error ) => {
-				error.input = error.input.replaceAll( hash, clientId );
+				error.input = error.input.replaceAll( hash, blockClientId );
 				return error;
 			} );
 		}
 
-		acf.debug( 'Preload successful', data );
 		return data;
 	}
 

--- a/includes/api/api-helpers.php
+++ b/includes/api/api-helpers.php
@@ -3813,12 +3813,12 @@ function acf_encrypt( $data = '' ) {
 function acf_decrypt( $data = '' ) {
 	// bail early if no decrypt function
 	if ( ! function_exists( 'openssl_decrypt' ) ) {
-		return base64_decode( (string) $data );
+		return base64_decode( (string) $data ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding our own encrypted payload.
 	}
 
 	// Treat malformed input as a decrypt failure: list() destructuring below would
 	// otherwise warn on PHP 8 when the payload isn't the "base64(data::iv)" shape.
-	$raw = base64_decode( (string) $data, true );
+	$raw = base64_decode( (string) $data, true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding our own encrypted payload.
 	if ( false === $raw || strpos( $raw, '::' ) === false ) {
 		return false;
 	}

--- a/includes/api/api-helpers.php
+++ b/includes/api/api-helpers.php
@@ -698,12 +698,13 @@ function acf_verify_nonce( $value ) {
  *
  * @since   ACF 5.2.3
  *
- * @param string $nonce  The nonce to check.
- * @param string $action The action of the nonce.
- * @param bool   $action_is_field Whether the action is a field key or not. Defaults to false.
+ * @param string $nonce               The nonce to check.
+ * @param string $action              The action of the nonce.
+ * @param bool   $action_is_field     Whether the action is a field key or not. Defaults to false.
+ * @param string $expected_field_type Optional field type the resolved field must be when $action_is_field is true. Prevents a nonce minted for one field type from being accepted by an AJAX handler that expects a different one. Defaults to empty (no type validation).
  * @return boolean
  */
-function acf_verify_ajax( $nonce = '', $action = '', $action_is_field = false ) {
+function acf_verify_ajax( $nonce = '', $action = '', $action_is_field = false, $expected_field_type = '' ) {
 
 	// Bail early if we don't have a nonce to check.
 	if ( empty( $nonce ) && empty( $_REQUEST['nonce'] ) ) {
@@ -719,6 +720,10 @@ function acf_verify_ajax( $nonce = '', $action = '', $action_is_field = false ) 
 		$field = acf_get_field( $action );
 
 		if ( empty( $field['type'] ) ) {
+			return false;
+		}
+
+		if ( ! empty( $expected_field_type ) && $field['type'] !== $expected_field_type ) {
 			return false;
 		}
 
@@ -3797,28 +3802,32 @@ function acf_encrypt( $data = '' ) {
 }
 
 /**
- * acf_decrypt
- *
- * This function will decrypt an encrypted string using PHP
+ * Decrypts an encrypted string using PHP.
  * https://bhoover.com/using-php-openssl_encrypt-openssl_decrypt-encrypt-decrypt-data/
  *
  * @since   ACF 5.5.8
  *
- * @param   $data (string)
- * @return  (string)
+ * @param string $data The string to decrypt.
+ * @return string|false Decrypted string, or false if the payload is malformed or decryption fails.
  */
 function acf_decrypt( $data = '' ) {
-
 	// bail early if no decrypt function
 	if ( ! function_exists( 'openssl_decrypt' ) ) {
-		return base64_decode( $data );
+		return base64_decode( (string) $data );
+	}
+
+	// Treat malformed input as a decrypt failure: list() destructuring below would
+	// otherwise warn on PHP 8 when the payload isn't the "base64(data::iv)" shape.
+	$raw = base64_decode( (string) $data, true );
+	if ( false === $raw || strpos( $raw, '::' ) === false ) {
+		return false;
 	}
 
 	// generate a key
 	$key = wp_hash( 'acf_encrypt' );
 
 	// To decrypt, split the encrypted data from our IV - our unique separator used was "::"
-	list($encrypted_data, $iv) = explode( '::', base64_decode( $data ), 2 );
+	list( $encrypted_data, $iv ) = explode( '::', $raw, 2 );
 
 	// decrypt
 	return openssl_decrypt( $encrypted_data, 'aes-256-cbc', $key, 0, $iv );

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -1975,7 +1975,7 @@ function acf_get_block_meta_values_to_save( $content = '' ) {
 
 
 /**
- * Helper function that returns the HTML attributes required for toolbar inline editing as a string, escaped and ready for output.
+ * Helper function that returns the HTML attributes required for toolbar inline editing as a string or array.
  *
  * Required. A list of the fields, each of which will be displayed in the popup toolbar.
  * Each field can be passed as one of the following.
@@ -1992,36 +1992,45 @@ function acf_get_block_meta_values_to_save( $content = '' ) {
  * @param array $fields List of fields.
  * @param array $args   Additional options controlling toolbar display and behavior.
  *
- * @type string $toolbar_icon  Optional. An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
- * @type string $toolbar_title Optional. A string to be used as the toolbar title. If not passed, the name of the first field will be used.
- * @type string $uid           Optional. A unique identifier that isn't used by any other inline fields in this block. Pass if you have 2 elements that conflict.
+ * @type string  $toolbar_icon  Optional. An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
+ * @type string  $toolbar_title Optional. A string to be used as the toolbar title. If not passed, the name of the first field will be used.
+ * @type string  $uid           Optional. A unique identifier that isn't used by any other inline fields in this block. Pass if you have 2 elements that conflict.
+ * @type boolean $return_array  Optional. If true, returns an array of attributes suitable for wp_get_attachment_image(). Default false.
  *
- * @return string A string containing the attributes.
+ * @return string|array When $args['return_array'] is false (default): Returns a string of escaped HTML attributes ready for output.
+ *                      When $args['return_array'] is true: Returns an associative array of attribute names and escaped values.
+ *                      When using the array return value with wp_get_attachment_image(), no element will be rendered if
+ *                      the image field is empty. If users need an inline editing target for selecting an image, render a fallback element
+ *                      with the attributes returned by this function.
  */
-function acf_inline_toolbar_editing_attrs( $fields, $args = array() ): string {
-
-	if ( empty( $fields ) ) {
-		return '';
-	}
+function acf_inline_toolbar_editing_attrs( $fields, $args = array() ) {
 
 	$default_args = array(
 		'toolbar_icon'  => null,
 		'toolbar_title' => null,
 		'uid'           => null,
+		'return_array'  => false,
 	);
 
 	$args = wp_parse_args( $args, $default_args );
 
+	// Helper for consistent early returns based on return format
+	$empty_return = $args['return_array'] ? array() : '';
+
+	if ( empty( $fields ) ) {
+		return $empty_return;
+	}
+
 	$acf_block_version = acf_get_data( 'acf_current_block_version' );
 
 	if ( ! $acf_block_version || $acf_block_version <= 2 ) {
-		return '';
+		return $empty_return;
 	}
 
 	$render = acf_get_data( 'acf_doing_block_preview' );
 
 	if ( ! $render ) {
-		return '';
+		return $empty_return;
 	}
 
 	// Get the block id.
@@ -2029,7 +2038,7 @@ function acf_inline_toolbar_editing_attrs( $fields, $args = array() ): string {
 	$block_id      = $meta_instance->post_id;
 
 	if ( empty( $block_id ) || strpos( $block_id, 'block_' ) !== 0 ) {
-		return '';
+		return $empty_return;
 	}
 
 	// Prefix the generated uid with the blockid.
@@ -2112,15 +2121,33 @@ function acf_inline_toolbar_editing_attrs( $fields, $args = array() ): string {
 		$args['uid'] = $generated_uid;
 	}
 
+	// Build the attributes array.
+	$attributes = array(
+		'data-acf-inline-fields-uid' => $args['uid'],
+		'data-acf-inline-fields'     => wp_json_encode( $fields_processed ),
+		'role'                       => 'button',
+		'tabindex'                   => '0',
+	);
+
 	if ( ! empty( $args['toolbar_icon'] ) ) {
-		$args['toolbar_icon'] = 'data-acf-toolbar-icon="' . esc_attr( $args['toolbar_icon'] ) . '" ';
+		$attributes['data-acf-toolbar-icon'] = $args['toolbar_icon'];
 	}
 
 	if ( ! empty( $args['toolbar_title'] ) ) {
-		$args['toolbar_title'] = 'data-acf-toolbar-title="' . esc_attr( $args['toolbar_title'] ) . '" ';
+		$attributes['data-acf-toolbar-title'] = $args['toolbar_title'];
 	}
 
-	return 'data-acf-inline-fields-uid="' . esc_attr( $args['uid'] ) . '" data-acf-inline-fields="' . esc_attr( wp_json_encode( $fields_processed ) ) . '" ' . $args['toolbar_icon'] . $args['toolbar_title'] . 'role="button" tabindex="0"';
+	// Return as array if requested.
+	if ( $args['return_array'] ) {
+		return array_map( 'esc_attr', $attributes );
+	}
+
+	// Build and return as string (default behavior).
+	$output = '';
+	foreach ( $attributes as $key => $value ) {
+		$output .= $key . '="' . esc_attr( $value ) . '" ';
+	}
+	return rtrim( $output );
 }
 
 /**

--- a/includes/fields/class-acf-field-flexible-content.php
+++ b/includes/fields/class-acf-field-flexible-content.php
@@ -1334,7 +1334,7 @@ if ( ! class_exists( 'acf_field_flexible_content' ) ) :
 				)
 			);
 
-			if ( ! acf_verify_ajax( $options['nonce'], $options['field_key'], true ) ) {
+			if ( ! acf_verify_ajax( $options['nonce'], $options['field_key'], true, 'flexible_content' ) ) {
 				die();
 			}
 

--- a/includes/fields/class-acf-field-gallery.php
+++ b/includes/fields/class-acf-field-gallery.php
@@ -97,7 +97,7 @@ if ( ! class_exists( 'acf_field_gallery' ) ) :
 			);
 
 			// Validate request.
-			if ( ! acf_verify_ajax( $args['nonce'], $args['field_key'] ) ) {
+			if ( ! acf_verify_ajax( $args['nonce'], $args['field_key'], true, 'gallery' ) ) {
 				die();
 			}
 
@@ -135,7 +135,7 @@ if ( ! class_exists( 'acf_field_gallery' ) ) :
 				)
 			);
 
-			if ( ! acf_verify_ajax( $args['nonce'], $args['field_key'] ) ) {
+			if ( ! acf_verify_ajax( $args['nonce'], $args['field_key'], true, 'gallery' ) ) {
 				wp_send_json_error();
 			}
 
@@ -214,7 +214,7 @@ if ( ! class_exists( 'acf_field_gallery' ) ) :
 				)
 			);
 
-			if ( ! acf_verify_ajax( $args['nonce'], $args['field_key'] ) ) {
+			if ( ! acf_verify_ajax( $args['nonce'], $args['field_key'], true, 'gallery' ) ) {
 				wp_send_json_error();
 			}
 
@@ -389,7 +389,7 @@ if ( ! class_exists( 'acf_field_gallery' ) ) :
 				'data-mime_types'   => $field['mime_types'],
 				'data-insert'       => $field['insert'],
 				'data-columns'      => 4,
-				'data-nonce'        => wp_create_nonce( $field['key'] ),
+				'data-nonce'        => wp_create_nonce( 'acf_field_' . $this->name . '_' . $field['key'] ),
 			);
 
 			// Set gallery height with default of 400px and minimum of 200px.

--- a/includes/fields/class-acf-field-oembed.php
+++ b/includes/fields/class-acf-field-oembed.php
@@ -138,12 +138,7 @@ if ( ! class_exists( 'acf_field_oembed' ) ) :
 				)
 			);
 
-			if ( ! acf_verify_ajax( $args['nonce'], $args['field_key'], true ) ) {
-				die();
-			}
-
-			$field = acf_get_field( $args['field_key'] );
-			if ( ! $field || 'oembed' !== ( $field['type'] ?? '' ) ) {
+			if ( ! acf_verify_ajax( $args['nonce'], $args['field_key'], true, 'oembed' ) ) {
 				die();
 			}
 

--- a/includes/fields/class-acf-field-page_link.php
+++ b/includes/fields/class-acf-field-page_link.php
@@ -82,7 +82,7 @@ if ( ! class_exists( 'acf_field_page_link' ) ) :
 				$key   = '';
 			}
 
-			if ( ! acf_verify_ajax( $nonce, $key, ! $conditional_logic ) ) {
+			if ( ! acf_verify_ajax( $nonce, $key, ! $conditional_logic, 'page_link' ) ) {
 				die();
 			}
 

--- a/includes/fields/class-acf-field-post_object.php
+++ b/includes/fields/class-acf-field-post_object.php
@@ -78,7 +78,7 @@ if ( ! class_exists( 'acf_field_post_object' ) ) :
 				$key   = '';
 			}
 
-			if ( ! acf_verify_ajax( $nonce, $key, ! $conditional_logic ) ) {
+			if ( ! acf_verify_ajax( $nonce, $key, ! $conditional_logic, 'post_object' ) ) {
 				die();
 			}
 

--- a/includes/fields/class-acf-field-relationship.php
+++ b/includes/fields/class-acf-field-relationship.php
@@ -104,7 +104,7 @@ if ( ! class_exists( 'acf_field_relationship' ) ) :
 				$key   = '';
 			}
 
-			if ( ! acf_verify_ajax( $nonce, $key, ! $conditional_logic ) ) {
+			if ( ! acf_verify_ajax( $nonce, $key, ! $conditional_logic, 'relationship' ) ) {
 				die();
 			}
 

--- a/includes/fields/class-acf-field-repeater.php
+++ b/includes/fields/class-acf-field-repeater.php
@@ -1090,7 +1090,7 @@ if ( ! class_exists( 'acf_field_repeater' ) ) :
 				)
 			);
 
-			if ( ! acf_verify_ajax( $args['nonce'], $args['field_key'], true ) ) {
+			if ( ! acf_verify_ajax( $args['nonce'], $args['field_key'], true, 'repeater' ) ) {
 				$error = array( 'error' => __( 'Invalid nonce.', 'secure-custom-fields' ) );
 				wp_send_json_error( $error, 401 );
 			}

--- a/includes/fields/class-acf-field-select.php
+++ b/includes/fields/class-acf-field-select.php
@@ -131,7 +131,7 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 				$key   = '';
 			}
 
-			if ( ! acf_verify_ajax( $nonce, $key, $is_field_key ) ) {
+			if ( ! acf_verify_ajax( $nonce, $key, $is_field_key, 'select' ) ) {
 				die();
 			}
 

--- a/includes/fields/class-acf-field-taxonomy.php
+++ b/includes/fields/class-acf-field-taxonomy.php
@@ -72,7 +72,7 @@ if ( ! class_exists( 'acf_field_taxonomy' ) ) :
 				$key   = '';
 			}
 
-			if ( ! acf_verify_ajax( $nonce, $key, ! $conditional_logic ) ) {
+			if ( ! acf_verify_ajax( $nonce, $key, ! $conditional_logic, 'taxonomy' ) ) {
 				die();
 			}
 
@@ -781,7 +781,7 @@ if ( ! class_exists( 'acf_field_taxonomy' ) ) :
 				)
 			);
 
-			if ( ! acf_verify_ajax( $args['nonce'], $args['field_key'], true ) ) {
+			if ( ! acf_verify_ajax( $args['nonce'], $args['field_key'], true, 'taxonomy' ) ) {
 				die();
 			}
 

--- a/includes/fields/class-acf-field-user.php
+++ b/includes/fields/class-acf-field-user.php
@@ -409,7 +409,7 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 			$nonce = acf_request_arg( 'nonce', '' );
 			$key   = acf_request_arg( 'field_key', '' );
 
-			if ( ! acf_verify_ajax( $nonce, $key, true ) ) {
+			if ( ! acf_verify_ajax( $nonce, $key, true, 'user' ) ) {
 				$query->send( new WP_Error( 'acf_invalid_request', __( 'Invalid request.', 'secure-custom-fields' ), array( 'status' => 404 ) ) );
 			}
 		}

--- a/includes/forms/form-front.php
+++ b/includes/forms/form-front.php
@@ -22,6 +22,13 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 		public $fields = array();
 
 		/**
+		 * Per-request render id, shared across every render_form() call in this request.
+		 *
+		 * @var string|null
+		 */
+		private $render_id = null;
+
+		/**
 		 * Constructs the class.
 		 *
 		 * @since ACF 5.0.0
@@ -358,6 +365,8 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 				}
 			}
 
+			$form = $this->merge_form_meta( $form );
+
 			// Run kses on all $_POST data.
 			if ( $form['kses'] && isset( $_POST['acf'] ) ) {
 				$_POST['acf'] = wp_kses_post_deep( $_POST['acf'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- False positive.
@@ -430,6 +439,136 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 			}
 		}
 
+		/**
+		 * Returns the per-request render ID, generating one if necessary.
+		 *
+		 * @since SCF 6.8.8
+		 *
+		 * @return string
+		 */
+		protected function get_render_id(): string {
+			if ( null === $this->render_id ) {
+				$this->render_id = wp_generate_uuid4();
+			}
+			return $this->render_id;
+		}
+
+		/**
+		 * Folds metadata from `_acf_form_meta[]` inputs into the primary form
+		 * configuration so the multi-`acf_form()`-in-one-outer-`<form>` pattern works.
+		 *
+		 * Non-field request-level args (`post_id`, `return`, `new_post`, `kses`) stay
+		 * "last wins" via the primary form.
+		 *
+		 * @since SCF 6.8.8
+		 *
+		 * @param array $form The primary form configuration loaded from `_acf_form`.
+		 * @return array The primary form with allowed-key extras and OR'd title/content flags.
+		 */
+		protected function merge_form_meta( array $form ): array {
+			// phpcs:disable WordPress.Security.NonceVerification.Missing -- Verified above in check_submit_form().
+			if ( empty( $_POST['_acf_form_meta'] ) || ! is_array( $_POST['_acf_form_meta'] ) ) {
+				return $form;
+			}
+
+			if ( empty( $_POST['_acf_render_id'] ) || ! is_scalar( $_POST['_acf_render_id'] ) ) {
+				return $form;
+			}
+			$expected_render_id = sanitize_text_field( wp_unslash( $_POST['_acf_render_id'] ) );
+
+			// wp_unslash only — sanitize_text_field would desync from the raw
+			// $acf_form_value hashed render-side.
+			$primary_form_value = ( isset( $_POST['_acf_form'] ) && is_scalar( $_POST['_acf_form'] ) )
+				? (string) wp_unslash( $_POST['_acf_form'] ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Must match render-side bytes hashed into the form anchor.
+				: '';
+
+			$expected_anchor = hash( 'sha256', $primary_form_value );
+			$primary_post_id = isset( $form['post_id'] ) ? (string) $form['post_id'] : '';
+
+			/**
+			 * Filters how long a `_acf_form_meta[]` payload remains valid after the page that
+			 * emitted it was rendered.
+			 *
+			 * @since SCF 6.8.8
+			 *
+			 * @param int $ttl Allowed age of a meta payload, in seconds.
+			 */
+			$ttl = (int) apply_filters( 'acf/form/meta_ttl', DAY_IN_SECONDS );
+			$now = time();
+
+			$valid_metas     = array();
+			$primary_present = false;
+
+			foreach ( $_POST['_acf_form_meta'] as $token ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Each $token is sanitized below before use.
+				if ( ! is_scalar( $token ) ) {
+					continue;
+				}
+
+				$decoded = json_decode( acf_decrypt( sanitize_text_field( $token ) ), true );
+				if ( ! is_array( $decoded ) ) {
+					continue;
+				}
+
+				if ( empty( $decoded['render_id'] ) || ! is_string( $decoded['render_id'] ) ) {
+					continue;
+				}
+
+				if ( ! hash_equals( $expected_render_id, $decoded['render_id'] ) ) {
+					continue;
+				}
+
+				if ( ! isset( $decoded['issued_at'] ) || ! is_numeric( $decoded['issued_at'] ) ) {
+					continue;
+				}
+				if ( ( $now - (int) $decoded['issued_at'] ) >= $ttl ) {
+					continue;
+				}
+
+				if ( ! empty( $decoded['form_anchor'] )
+					&& is_string( $decoded['form_anchor'] )
+					&& hash_equals( $expected_anchor, $decoded['form_anchor'] )
+				) {
+					$primary_present = true;
+				}
+
+				$valid_metas[] = $decoded;
+			}
+
+			if ( ! $primary_present ) {
+				return $form;
+			}
+
+			$extra_keys = array();
+
+			foreach ( $valid_metas as $decoded ) {
+				$target_post_id = isset( $decoded['target_post_id'] ) ? (string) $decoded['target_post_id'] : '';
+				if ( ! hash_equals( $primary_post_id, $target_post_id ) ) {
+					continue;
+				}
+
+				if ( ! empty( $decoded['allowed_field_keys'] ) && is_array( $decoded['allowed_field_keys'] ) ) {
+					foreach ( $decoded['allowed_field_keys'] as $key ) {
+						if ( is_scalar( $key ) ) {
+							$extra_keys[] = (string) $key;
+						}
+					}
+				}
+
+				if ( ! empty( $decoded['post_title'] ) ) {
+					$form['post_title'] = true;
+				}
+				if ( ! empty( $decoded['post_content'] ) ) {
+					$form['post_content'] = true;
+				}
+			}
+			// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+			if ( $extra_keys ) {
+				$form['_additional_allowed_field_keys'] = array_values( array_unique( $extra_keys ) );
+			}
+
+			return $form;
+		}
 
 		/**
 		 * Returns the fields a given form configuration will expose, mirroring the
@@ -471,10 +610,16 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 
 			// Load specific fields.
 			if ( $args['fields'] ) {
-
-				// Lookup fields using $strict = false for better compatibility with field names.
 				foreach ( $args['fields'] as $selector ) {
-					$fields[] = acf_maybe_get_field( $selector, $post_id, false );
+					if ( $post_id ) {
+						// Lookup fields using $strict = false for better compatibility with field names.
+						$fields[] = acf_maybe_get_field( $selector, $post_id, false );
+					} else {
+						// No post to resolve meta references against — skip acf_maybe_get_field()'s
+						// post_id resolution, which can fatal in get_queried_object() if submit_form()
+						// runs before WordPress's main query is built.
+						$fields[] = acf_get_field( $selector );
+					}
 				}
 
 				// Load specific field groups.
@@ -526,13 +671,16 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 		 *
 		 * @since SCF 6.8.5
 		 *
-		 * @param array $form The validated form configuration.
+		 * @param array $form   The validated form configuration.
+		 * @param array $fields Optional pre-discovered fields for this form to avoid a
+		 *                      redundant get_form_fields() call when the caller already has them.
 		 * @return array
 		 */
-		public function get_allowed_field_keys( array $form ): array {
-			$keys = array();
+		public function get_allowed_field_keys( array $form, array $fields = array() ): array {
+			$keys   = array();
+			$fields = ! empty( $fields ) ? $fields : $this->get_form_fields( $form );
 
-			foreach ( $this->get_form_fields( $form ) as $field ) {
+			foreach ( $fields as $field ) {
 				$prefix = $field['prefix'] ?? 'acf';
 
 				if ( 'acf' === $prefix ) {
@@ -542,6 +690,11 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 				} elseif ( preg_match( '/^acf\[([^]]+)]$/', $prefix, $matches ) ) {
 					$keys[] = $matches[1];
 				}
+			}
+
+			// Include keys folded in from sibling acf_form() calls on the same page.
+			if ( ! empty( $form['_additional_allowed_field_keys'] ) && is_array( $form['_additional_allowed_field_keys'] ) ) {
+				$keys = array_merge( $keys, $form['_additional_allowed_field_keys'] );
 			}
 
 			$keys = array_values( array_unique( array_filter( $keys ) ) );
@@ -635,12 +788,40 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 				<?php
 			endif;
 
-			// Render hidde form data.
+			// Render hidden form data.
+			$render_id      = $this->get_render_id();
+			$acf_form_value = $is_registered ? $args['id'] : acf_encrypt( wp_json_encode( $args ) );
 			acf_form_data(
 				array(
-					'screen'  => 'acf_form',
-					'post_id' => $args['post_id'],
-					'form'    => $is_registered ? $args['id'] : acf_encrypt( json_encode( $args ) ),
+					'screen'    => 'acf_form',
+					'post_id'   => $args['post_id'],
+					'form'      => $acf_form_value,
+					'render_id' => $render_id,
+				)
+			);
+
+			/**
+			 * Emit a per-form metadata token. PHP keeps only the last `_acf_form` input
+			 * after browser-level dedup, so multiple acf_form() calls inside a single
+			 * outer <form> would otherwise lose all but one form's allow-list —
+			 * `_acf_form_meta[]` uses the array form to survive that and carries each
+			 * form's contribution.
+			 */
+			$meta = wp_json_encode(
+				array(
+					'render_id'          => $render_id,
+					'form_anchor'        => hash( 'sha256', (string) $acf_form_value ),
+					'target_post_id'     => (string) $args['post_id'],
+					'issued_at'          => time(),
+					'allowed_field_keys' => $this->get_allowed_field_keys( $args, $fields ),
+					'post_title'         => (bool) $args['post_title'],
+					'post_content'       => (bool) $args['post_content'],
+				)
+			);
+			acf_hidden_input(
+				array(
+					'name'  => '_acf_form_meta[]',
+					'value' => acf_encrypt( $meta ),
 				)
 			);
 

--- a/tests/php/includes/forms/test-form-front-merge-form-meta.php
+++ b/tests/php/includes/forms/test-form-front-merge-form-meta.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Tests for acf_form_front::merge_form_meta().
+ *
+ * Covers the upstream 6.8.4 backport fixing silent data loss when multiple
+ * acf_form() instances share a single outer form tag: per-form metadata
+ * tokens are folded into the primary form configuration when they validate.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+acf_include( 'includes/forms/form-front.php' );
+
+/**
+ * Class Test_Form_Front_Merge_Form_Meta
+ *
+ * @group forms
+ * @group security
+ */
+class Test_Form_Front_Merge_Form_Meta extends BaseTestCase {
+
+	/**
+	 * The render id used by tokens in these tests.
+	 *
+	 * @var string
+	 */
+	private $render_id = 'render-id-test';
+
+	/**
+	 * The raw primary _acf_form value submitted with the request.
+	 *
+	 * @var string
+	 */
+	private $primary_form_value = 'encrypted-primary-form-value';
+
+	/**
+	 * Set up test fixtures.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$_POST = array();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 *
+	 * @return void
+	 */
+	public function tear_down(): void {
+		$_POST = array();
+		parent::tear_down();
+	}
+
+	/**
+	 * Invokes the protected merge_form_meta() method.
+	 *
+	 * @param array $form The primary form configuration.
+	 * @return array
+	 */
+	private function merge_form_meta( array $form ): array {
+		$method = new ReflectionMethod( 'acf_form_front', 'merge_form_meta' );
+		$method->setAccessible( true );
+
+		return $method->invoke( acf()->form_front, $form );
+	}
+
+	/**
+	 * Builds an encrypted _acf_form_meta token.
+	 *
+	 * @param array $overrides Values overriding the valid defaults.
+	 * @return string
+	 */
+	private function build_token( array $overrides = array() ): string {
+		$meta = array_merge(
+			array(
+				'render_id'          => $this->render_id,
+				'form_anchor'        => hash( 'sha256', $this->primary_form_value ),
+				'target_post_id'     => '123',
+				'issued_at'          => time(),
+				'allowed_field_keys' => array(),
+				'post_title'         => false,
+				'post_content'       => false,
+			),
+			$overrides
+		);
+
+		return acf_encrypt( wp_json_encode( $meta ) );
+	}
+
+	/**
+	 * Populates $_POST with a submission carrying the given meta tokens.
+	 *
+	 * @param array $tokens The _acf_form_meta token list.
+	 * @return void
+	 */
+	private function set_up_request( array $tokens ): void {
+		$_POST['_acf_form']      = $this->primary_form_value;
+		$_POST['_acf_render_id'] = $this->render_id;
+		$_POST['_acf_form_meta'] = $tokens;
+	}
+
+	/**
+	 * Sibling form keys are folded into the primary form when tokens validate.
+	 *
+	 * @return void
+	 */
+	public function test_folds_sibling_keys_and_flags_into_primary_form() {
+		$this->set_up_request(
+			array(
+				// Token anchoring the primary form.
+				$this->build_token( array( 'allowed_field_keys' => array( 'field_primary' ) ) ),
+				// Sibling form on the same page targeting the same post.
+				$this->build_token(
+					array(
+						'form_anchor'        => hash( 'sha256', 'sibling-form-value' ),
+						'allowed_field_keys' => array( 'field_sibling' ),
+						'post_title'         => true,
+					)
+				),
+			)
+		);
+
+		$form = $this->merge_form_meta(
+			array(
+				'post_id'    => '123',
+				'post_title' => false,
+			)
+		);
+
+		$this->assertSame(
+			array( 'field_primary', 'field_sibling' ),
+			$form['_additional_allowed_field_keys']
+		);
+		$this->assertTrue( $form['post_title'] );
+	}
+
+	/**
+	 * Tokens are ignored when the request render id does not match.
+	 *
+	 * @return void
+	 */
+	public function test_ignores_tokens_with_mismatched_render_id() {
+		$this->set_up_request(
+			array(
+				$this->build_token(
+					array(
+						'render_id'          => 'some-other-render-id',
+						'allowed_field_keys' => array( 'field_injected' ),
+					)
+				),
+			)
+		);
+
+		$form = $this->merge_form_meta( array( 'post_id' => '123' ) );
+
+		$this->assertArrayNotHasKey( '_additional_allowed_field_keys', $form );
+	}
+
+	/**
+	 * Nothing is merged when no token anchors the submitted primary form.
+	 *
+	 * @return void
+	 */
+	public function test_requires_a_token_anchoring_the_primary_form() {
+		$this->set_up_request(
+			array(
+				$this->build_token(
+					array(
+						'form_anchor'        => hash( 'sha256', 'unrelated-form-value' ),
+						'allowed_field_keys' => array( 'field_injected' ),
+					)
+				),
+			)
+		);
+
+		$form = $this->merge_form_meta( array( 'post_id' => '123' ) );
+
+		$this->assertArrayNotHasKey( '_additional_allowed_field_keys', $form );
+	}
+
+	/**
+	 * Tokens targeting a different post id contribute nothing.
+	 *
+	 * @return void
+	 */
+	public function test_skips_tokens_for_other_target_post_id() {
+		$this->set_up_request(
+			array(
+				$this->build_token( array( 'allowed_field_keys' => array( 'field_primary' ) ) ),
+				$this->build_token(
+					array(
+						'form_anchor'        => hash( 'sha256', 'sibling-form-value' ),
+						'target_post_id'     => '456',
+						'allowed_field_keys' => array( 'field_other_post' ),
+						'post_content'       => true,
+					)
+				),
+			)
+		);
+
+		$form = $this->merge_form_meta(
+			array(
+				'post_id'      => '123',
+				'post_content' => false,
+			)
+		);
+
+		$this->assertSame(
+			array( 'field_primary' ),
+			$form['_additional_allowed_field_keys']
+		);
+		$this->assertFalse( $form['post_content'] );
+	}
+
+	/**
+	 * Expired tokens are ignored.
+	 *
+	 * @return void
+	 */
+	public function test_ignores_expired_tokens() {
+		$this->set_up_request(
+			array(
+				$this->build_token(
+					array(
+						'issued_at'          => time() - ( 2 * DAY_IN_SECONDS ),
+						'allowed_field_keys' => array( 'field_primary' ),
+					)
+				),
+			)
+		);
+
+		$form = $this->merge_form_meta( array( 'post_id' => '123' ) );
+
+		$this->assertArrayNotHasKey( '_additional_allowed_field_keys', $form );
+	}
+
+	/**
+	 * The form is returned unchanged when no meta inputs are present.
+	 *
+	 * @return void
+	 */
+	public function test_returns_form_unchanged_without_meta_inputs() {
+		$form = array( 'post_id' => '123' );
+
+		$this->assertSame( $form, $this->merge_form_meta( $form ) );
+	}
+}

--- a/tests/php/includes/functions/test-acf-verify-ajax-field-type.php
+++ b/tests/php/includes/functions/test-acf-verify-ajax-field-type.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Tests for the acf_verify_ajax() field type validation and acf_decrypt() hardening.
+ *
+ * Covers the upstream 6.8.4 security backport: AJAX field handlers validate
+ * that the request nonce was created for the expected field type, and
+ * acf_decrypt() treats malformed payloads as a decrypt failure.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Class Test_ACF_Verify_Ajax_Field_Type
+ *
+ * @group ajax
+ * @group security
+ */
+class Test_ACF_Verify_Ajax_Field_Type extends BaseTestCase {
+
+	/**
+	 * Set up test fixtures.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		acf_add_local_field(
+			array(
+				'key'  => 'field_test_select_type',
+				'name' => 'test_select_type',
+				'type' => 'select',
+			)
+		);
+
+		acf_add_local_field(
+			array(
+				'key'  => 'field_test_oembed_type',
+				'name' => 'test_oembed_type',
+				'type' => 'oembed',
+			)
+		);
+
+		$_REQUEST = array();
+		$_POST    = array();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 *
+	 * @return void
+	 */
+	public function tear_down(): void {
+		acf_remove_local_field( 'field_test_select_type' );
+		acf_remove_local_field( 'field_test_oembed_type' );
+
+		$_REQUEST = array();
+		$_POST    = array();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * A typed field nonce passes when the resolved field matches the expected type.
+	 *
+	 * @return void
+	 */
+	public function test_verify_ajax_accepts_matching_field_type() {
+		$nonce = wp_create_nonce( 'acf_field_select_field_test_select_type' );
+
+		$this->assertTrue(
+			acf_verify_ajax( $nonce, 'field_test_select_type', true, 'select' )
+		);
+	}
+
+	/**
+	 * A nonce minted for one field type is rejected by a handler expecting another.
+	 *
+	 * @return void
+	 */
+	public function test_verify_ajax_rejects_mismatched_field_type() {
+		// Valid typed nonce for the select field, replayed against a handler
+		// that expects an oembed field.
+		$nonce = wp_create_nonce( 'acf_field_select_field_test_select_type' );
+
+		$this->assertFalse(
+			acf_verify_ajax( $nonce, 'field_test_select_type', true, 'oembed' )
+		);
+	}
+
+	/**
+	 * The expected type is compared against the resolved field, not the action string.
+	 *
+	 * @return void
+	 */
+	public function test_verify_ajax_rejects_field_of_other_type_with_own_valid_nonce() {
+		// Even a valid oembed-typed nonce for an oembed field must be rejected
+		// when the handler expects a select field.
+		$nonce = wp_create_nonce( 'acf_field_oembed_field_test_oembed_type' );
+
+		$this->assertFalse(
+			acf_verify_ajax( $nonce, 'field_test_oembed_type', true, 'select' )
+		);
+	}
+
+	/**
+	 * Omitting the expected type keeps the previous behavior.
+	 *
+	 * @return void
+	 */
+	public function test_verify_ajax_without_expected_type_is_backward_compatible() {
+		$nonce = wp_create_nonce( 'acf_field_select_field_test_select_type' );
+
+		$this->assertTrue(
+			acf_verify_ajax( $nonce, 'field_test_select_type', true )
+		);
+	}
+
+	/**
+	 * An invalid nonce still fails regardless of the expected type matching.
+	 *
+	 * @return void
+	 */
+	public function test_verify_ajax_rejects_invalid_nonce_with_matching_type() {
+		$this->assertFalse(
+			acf_verify_ajax( 'not-a-valid-nonce', 'field_test_select_type', true, 'select' )
+		);
+	}
+
+	/**
+	 * The acf_decrypt() function round-trips acf_encrypt() output.
+	 *
+	 * @return void
+	 */
+	public function test_decrypt_round_trips_encrypted_data() {
+		$data = '{"post_id":123,"fields":["field_abc"]}';
+
+		$this->assertSame( $data, acf_decrypt( acf_encrypt( $data ) ) );
+	}
+
+	/**
+	 * The acf_decrypt() function returns false for input that is not valid base64.
+	 *
+	 * @return void
+	 */
+	public function test_decrypt_returns_false_for_non_base64_input() {
+		$this->assertFalse( acf_decrypt( '!!! not base64 !!!' ) );
+	}
+
+	/**
+	 * The acf_decrypt() function returns false when the payload lacks the data::iv separator.
+	 *
+	 * @return void
+	 */
+	public function test_decrypt_returns_false_for_payload_without_separator() {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Building a malformed test fixture.
+		$payload = base64_encode( 'payload-without-separator' );
+
+		$this->assertFalse( acf_decrypt( $payload ) );
+	}
+
+	/**
+	 * The acf_decrypt() function returns false for an empty payload.
+	 *
+	 * @return void
+	 */
+	public function test_decrypt_returns_false_for_empty_payload() {
+		$this->assertFalse( acf_decrypt( '' ) );
+	}
+}


### PR DESCRIPTION
This backports the upstream 6.8.4 changes, covering one security fix, two enhancements (one of which was already implemented here), and four bug fixes.

## Security

- AJAX field handlers now validate that the request nonce was created for the expected field type. `acf_verify_ajax()` gains an optional `$expected_field_type` parameter, and the oembed, page link, post object, relationship, select, taxonomy, user, flexible content, gallery and repeater handlers pass their type, so a nonce minted for one field type can no longer be replayed against another field type's handler.
- While applying the above, the gallery field was aligned with the typed nonce scheme every other AJAX field already uses (it still minted `wp_create_nonce( $field['key'] )` and verified without `$action_is_field`).
- `acf_decrypt()` now treats malformed payloads (non-base64 input or a missing `data::iv` separator) as a decrypt failure and returns `false`, instead of emitting PHP 8 warnings from `list()` destructuring.

## Enhancements

- `acf_inline_toolbar_editing_attrs()` accepts a new `return_array` argument that returns the attributes as an escaped array suitable for use with `wp_get_attachment_image()`.
- The upstream plugin dependency slug mapping is already covered here by `scf_map_plugin_dependency_slug()` (#414), so no change was needed.

## Bug fixes

- `acf_form()` with `'post_id' => 'new_post'` and a `fields` list of field names no longer fatals when `acf_form_head()` runs before the main query is built (`get_form_fields()` skips post-based field resolution when there is no post to resolve against).
- Multiple `acf_form()` calls wrapped inside a single outer `<form>` tag with one submit button no longer silently drop field values, `post_title` or `post_content` from the non-last forms. Each rendered form emits an encrypted `_acf_form_meta[]` token (render-scoped, anchored to the primary form, post-id-bound and time-limited via the new `acf/form/meta_ttl` filter) that folds sibling allow-list keys into the submission.
- Duplicating a V3 block with identical attributes no longer displays corrupted preview content: preloaded block entries are deep-cloned before the placeholder hash is replaced with the client ID, instead of mutating the shared preload entry in place.
- Switching between tabs containing WYSIWYG fields no longer leaves the admin menu pinned against a shorter page (which could lock page scroll): opening a tab now triggers `wp-pin-menu`.

## Tests

15 new PHPUnit tests cover the typed nonce binding (match, mismatch, backward compatibility, invalid nonce), the `acf_decrypt()` hardening, and `merge_form_meta()` token validation (render id mismatch, missing primary anchor, foreign target post id, expiry).

Skipped translation catalog churn per our translation workflow; version and stable tag bumps are left to release preparation.

## Use of AI Tools

This backport was prepared with Claude Code (Claude Fable 5): change analysis, porting, decompilation review of the minified bundles, and test authoring. All changes were human-reviewed, including a manual side-by-side review of the decompiled JavaScript bundles, and validated locally (PHPUnit, PHPStan, PHPCS, JS lint, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)