### PR TITLE
Prepare 6.8.8 Release

### DIFF
--- a/docs/code-reference/META.md
+++ b/docs/code-reference/META.md
@@ -486,6 +486,12 @@ This file tracks code elements that need documentation.
 
 - `wp_nav_menu_container_allowed_tags`
 
+## fields/class-acf-field-oembed.php
+
+### Hooks
+
+- `acf/fields/oembed/allow_discovery`
+
 ## fields/class-acf-field-page_link.php
 
 ### Hooks
@@ -562,6 +568,7 @@ This file tracks code elements that need documentation.
 ### Hooks
 
 - `acf/form/allowed_field_keys`
+- `acf/form/meta_ttl`
 - `acf/pre_save_post`
 - `acf/pre_submit_form`
 - `acf/submit_form`

--- a/docs/code-reference/api/api-helpers-file.md
+++ b/docs/code-reference/api/api-helpers-file.md
@@ -284,9 +284,10 @@ Returns true if the current AJAX request is valid.
 It's action will also allow WPML to set the lang and avoid AJAX get_posts issues
 
 * @since   ACF 5.2.3
-* @param string $nonce  The nonce to check.
-* @param string $action The action of the nonce.
-* @param bool   $action_is_field Whether the action is a field key or not. Defaults to false.
+* @param string $nonce               The nonce to check.
+* @param string $action              The action of the nonce.
+* @param bool   $action_is_field     Whether the action is a field key or not. Defaults to false.
+* @param string $expected_field_type Optional field type the resolved field must be when $action_is_field is true. Prevents a nonce minted for one field type from being accepted by an AJAX handler that expects a different one. Defaults to empty (no type validation).
 * @return boolean
 
 ## `acf_get_image_sizes()`
@@ -956,13 +957,12 @@ acf_encrypt
 
 ## `acf_decrypt()`
 
-acf_decrypt
-
-* This function will decrypt an encrypted string using PHP
+Decrypts an encrypted string using PHP.
 <https://bhoover.com/using-php-openssl_encrypt-openssl_decrypt-encrypt-decrypt-data/>
+
 * @since   ACF 5.5.8
-* @param   $data (string)
-* @return (string)
+* @param string $data The string to decrypt.
+* @return string|false Decrypted string, or false if the payload is malformed or decryption fails.
 
 ## `acf_parse_markdown()`
 

--- a/docs/code-reference/blocks-file.md
+++ b/docs/code-reference/blocks-file.md
@@ -394,7 +394,7 @@ that need to be saved to post meta.
 
 ## `acf_inline_toolbar_editing_attrs()`
 
-Helper function that returns the HTML attributes required for toolbar inline editing as a string, escaped and ready for output.
+Helper function that returns the HTML attributes required for toolbar inline editing as a string or array.
 
 * Required. A list of the fields, each of which will be displayed in the popup toolbar.
 Each field can be passed as one of the following.
@@ -407,10 +407,15 @@ An associative array with specific keys:
 * @type string  $popover_min_width Enter the CSS width value to use for the popover. Default is "300px".
 * @param array $fields List of fields.
 * @param array $args   Additional options controlling toolbar display and behavior.
-* @type string $toolbar_icon  Optional. An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
-* @type string $toolbar_title Optional. A string to be used as the toolbar title. If not passed, the name of the first field will be used.
-* @type string $uid           Optional. A unique identifier that isn't used by any other inline fields in this block. Pass if you have 2 elements that conflict.
-* @return string A string containing the attributes.
+* @type string  $toolbar_icon  Optional. An html tag, can be an svg, to be used as the toolbar icon. If not passed, the icon of the first field will be used.
+* @type string  $toolbar_title Optional. A string to be used as the toolbar title. If not passed, the name of the first field will be used.
+* @type string  $uid           Optional. A unique identifier that isn't used by any other inline fields in this block. Pass if you have 2 elements that conflict.
+* @type boolean $return_array  Optional. If true, returns an array of attributes suitable for wp_get_attachment_image(). Default false.
+* @return string|array When $args['return_array'] is false (default): Returns a string of escaped HTML attributes ready for output.
+When $args['return_array'] is true: Returns an associative array of attribute names and escaped values.
+When using the array return value with wp_get_attachment_image(), no element will be rendered if
+the image field is empty. If users need an inline editing target for selecting an image, render a fallback element
+with the attributes returned by this function.
 
 ## `acf_inline_text_editing_attrs()`
 

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,25 @@ This plugin builds upon and is a fork of the previous work done by the contribut
 
 
 == Changelog ==
+= 6.8.8 =
+*Release Date 11th June 2026*
+
+*Security*
+
+- AJAX field handlers now validate that the request nonce was created for the expected field type, so a nonce minted for one field type can no longer be replayed against another field type's AJAX handler. The gallery field was also aligned with the typed nonce scheme used by all other AJAX fields.
+- `acf_decrypt()` now treats malformed payloads as a decrypt failure and returns `false` instead of emitting PHP 8 warnings.
+
+*Enhancements*
+
+- `acf_inline_toolbar_editing_attrs()` now accepts a `return_array` argument that returns the attributes as an escaped array suitable for use with `wp_get_attachment_image()`.
+
+*Fixes*
+
+- `acf_form()` with `'post_id' => 'new_post'` and a `fields` list of field names no longer fatal errors when `acf_form_head()` runs before WordPress's main query is built.
+- Multiple `acf_form()` calls wrapped inside a single outer form tag with one submit button no longer silently drop field values, `post_title`, or `post_content` from the non-last forms. A new `acf/form/meta_ttl` filter controls how long per-form metadata remains valid.
+- Duplicating a V3 block with identical attributes no longer displays corrupted preview content in the duplicate.
+- Switching between tabs containing WYSIWYG fields no longer leaves the admin menu pinned against a shorter page, which could lock page scroll.
+
 = 6.8.7 =
 *Release Date 8th June 2026*
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: fields, custom fields, meta, scf
 Requires at least: 6.2
 Tested up to: 6.9.1
 Requires PHP: 7.4
-Stable tag: 6.8.6
+Stable tag: 6.8.8
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -6,7 +6,7 @@
  * Plugin Name:       Secure Custom Fields
  * Plugin URI:        https://developer.wordpress.org/secure-custom-fields/
  * Description:       Secure Custom Fields (SCF) offers an intuitive way for developers to enhance WordPress content management by adding extra fields and options without coding requirements.
- * Version:           6.8.7
+ * Version:           6.8.8
  * Author:            WordPress.org
  * Author URI:        https://wordpress.org/
  * Text Domain:       secure-custom-fields
@@ -33,7 +33,7 @@ if ( ! class_exists( 'ACF' ) ) {
 		 *
 		 * @var string
 		 */
-		public $version = '6.8.7';
+		public $version = '6.8.8';
 
 		/**
 		 * The plugin settings array.


### PR DESCRIPTION
*Release Date 11th June 2026*

*Security*

- AJAX field handlers now validate that the request nonce was created for the expected field type, so a nonce minted for one field type can no longer be replayed against another field type's AJAX handler. The gallery field was also aligned with the typed nonce scheme used by all other AJAX fields.
- `acf_decrypt()` now treats malformed payloads as a decrypt failure and returns `false` instead of emitting PHP 8 warnings.

*Enhancements*

- `acf_inline_toolbar_editing_attrs()` now accepts a `return_array` argument that returns the attributes as an escaped array suitable for use with `wp_get_attachment_image()`.

*Fixes*

- `acf_form()` with `'post_id' => 'new_post'` and a `fields` list of field names no longer fatal errors when `acf_form_head()` runs before WordPress's main query is built.
- Multiple `acf_form()` calls wrapped inside a single outer form tag with one submit button no longer silently drop field values, `post_title`, or `post_content` from the non-last forms. A new `acf/form/meta_ttl` filter controls how long per-form metadata remains valid.
- Duplicating a V3 block with identical attributes no longer displays corrupted preview content in the duplicate.
- Switching between tabs containing WYSIWYG fields no longer leaves the admin menu pinned against a shorter page, which could lock page scroll.
