### PR TITLE
Fix shell interpolation of the changelog in prepare-release PR creation

### DIFF
--- a/bin/prepare-release.php
+++ b/bin/prepare-release.php
@@ -350,7 +350,7 @@ class Release_Preparation {
 		}
 
 		echo "Pushing branch {$branch} to remote...\n";
-		passthru( "git push origin {$branch}", $return );
+		passthru( 'git push origin ' . escapeshellarg( $branch ), $return );
 		if ( 0 !== $return ) {
 			echo "Error: Failed to push branch to remote\n";
 			return;
@@ -359,7 +359,17 @@ class Release_Preparation {
 		$title = "Prepare {$version} Release";
 		$body  = $changelog ? $changelog : "Changelog entry pending for {$version}";
 
-		passthru( "gh pr create --title \"{$title}\" --body \"{$body}\"" );
+		// Pass the body via a file so shell metacharacters in the changelog
+		// (backticks, quotes, redirections) are not interpreted by the shell.
+		$body_file = tempnam( sys_get_temp_dir(), 'scf-pr-body-' );
+		if ( false === $body_file || false === file_put_contents( $body_file, $body ) ) {
+			echo "Error: Could not write PR body to a temporary file\n";
+			return;
+		}
+
+		passthru( 'gh pr create --title ' . escapeshellarg( $title ) . ' --body-file ' . escapeshellarg( $body_file ) );
+
+		unlink( $body_file );
 	}
 
 	/**


### PR DESCRIPTION
While preparing the 6.8.8 release, `composer prepare-release` produced a mangled PR body: `create_pr()` interpolates the changelog into a double-quoted shell string, so backticked code spans in the `readme.txt` changelog entry were executed as command substitution. Every code span was silently dropped from the PR body, and a changelog token containing `=> 'new_post'` even created a stray file named `new_post` in the repository root via shell redirection.

This passes the PR body via `--body-file` (written to a temp file) and escapes the title and branch name with `escapeshellarg()`, so changelog content is never interpreted by the shell.

## Use of AI Tools

This fix was authored with Claude Code (Claude Fable 5) after the bug was hit during release preparation; the change was human-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
