### PR TITLE
Fix WP 6.2 block E2E registration

### DIFF
--- a/tests/e2e/field-type-text-with-scf-block.spec.ts
+++ b/tests/e2e/field-type-text-with-scf-block.spec.ts
@@ -5,6 +5,7 @@ const { test, expect } = require( './fixtures' );
 
 const PLUGIN_SLUG = 'secure-custom-fields';
 const TEST_PLUGIN_SLUG = 'scf-test-plugin-get-field-movie-title-block';
+const BLOCK_NAME = 'scf/movie-title-block';
 const FIELD_GROUP_LABEL = 'Movie Details';
 const FIELD_LABEL = 'Movie Title';
 
@@ -63,7 +64,7 @@ test.describe( 'Field Type > Text', () => {
 		);
 		await page.selectOption(
 			'select[id^="acf_field_group-location-group_0-rule_0-value"]',
-			'scf/movie-title-block'
+			BLOCK_NAME
 		);
 
 		// Submit form.
@@ -92,9 +93,14 @@ test.describe( 'Field Type > Text', () => {
 
 		await admin.editPost( post.id );
 
+		await page.waitForFunction(
+			( blockName ) => window.wp?.blocks?.getBlockType( blockName ),
+			BLOCK_NAME
+		);
+
 		await editor.insertBlock( {
-			name: 'scf/movie-title-block',
-		} ); 
+			name: BLOCK_NAME,
+		} );
 
 		await page.waitForSelector(
 			'.acf-field[data-name="movie_title"] input'
@@ -104,10 +110,10 @@ test.describe( 'Field Type > Text', () => {
 			'Awesome movie'
 		);
 		// Add a blur event to trigger the field's onchange handlers.
-		await page.click('body', { position: { x: 0, y: 0 } });
-		
+		await page.click( 'body', { position: { x: 0, y: 0 } } );
+
 		// Let's also make sure we give the editor a moment to save the field data.
-		await page.waitForTimeout(500);
+		await page.waitForTimeout( 500 );
 
 		const previewPage = await editor.openPreviewPage();
 
@@ -121,6 +127,9 @@ test.describe( 'Field Type > Text', () => {
 
 /**
  * Helper function to delete the field group
+ *
+ * @param {import('@playwright/test').Page} page  Playwright page object.
+ * @param {Object}                          admin WordPress admin helper.
  */
 async function deleteFieldGroups( page, admin ) {
 	await admin.visitAdminPage( 'edit.php', 'post_type=acf-field-group' );
@@ -143,9 +152,11 @@ async function deleteFieldGroups( page, admin ) {
 	}
 }
 
-
 /**
  * Helper function to empty trash
+ *
+ * @param {import('@playwright/test').Page} page  Playwright page object.
+ * @param {Object}                          admin WordPress admin helper.
  */
 async function emptyTrash( page, admin ) {
 	await admin.visitAdminPage(

--- a/tests/e2e/plugins/blocks/scf-movie-title-block/block.json
+++ b/tests/e2e/plugins/blocks/scf-movie-title-block/block.json
@@ -2,7 +2,7 @@
 	"name": "scf/movie-title-block",
 	"title": "My Test Plugin Movie Title Block",
 	"description": "A custom block that uses SCF fields.",
-	"category": "layout",
+	"category": "text",
 	"icon": "admin-comments",
 	"keywords": [ "custom", "scf", "block" ],
 	"acf": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,7 +53,9 @@ const commonConfig = {
 					loader: 'babel-loader',
 					options: {
 						presets: [
-							[ '@babel/preset-react', { runtime: 'automatic' } ],
+							// Keep JSX output compatible with older supported WordPress versions
+							// that do not register the react-jsx-runtime script handle.
+							[ '@babel/preset-react', { runtime: 'classic' } ],
 						],
 						plugins: process.env.COVERAGE_ENABLED
 							? [ 'istanbul' ]


### PR DESCRIPTION
## What

Fixes the WP 6.2 E2E failure in the SCF block field test. The movie title block now registers in the editor before the test tries to insert it.

## Why

WP 6.2 does not provide the `react-jsx-runtime` script handle. Our blocks bundle depended on it, so WordPress skipped the script and the block never made it into `wp.blocks`.

## How

- Uses the classic React JSX runtime for the build.
- Moves the test block to a WP 6.2-safe category.
- Makes the test wait for the block registration before inserting it.

## Testing Instructions

1. Start a local WordPress 6.2 test environment.
2. Activate Secure Custom Fields and the movie title block test plugin.
3. Create a text field group assigned to the movie title block.
4. Edit a post and insert the movie title block.
5. Enter a movie title and confirm it appears in preview.

## Automated Checks

- The manual E2E workflow run for this branch passed all four WP 6.2 shards: https://github.com/WordPress/secure-custom-fields/actions/runs/27356179494
- `npm run build`
- `npm run test:e2e -- tests/e2e/field-type-text-with-scf-block.spec.ts` against WP 6.2
- `npx wp-scripts lint-js webpack.config.js tests/e2e/field-type-text-with-scf-block.spec.ts`

## Use of AI Tools

I used Codex while debugging and preparing this fix. I reviewed the diff and tested the result locally.
