### PR TITLE
Guard URL field against non-scalar values

### DIFF
--- a/includes/fields/class-acf-field-url.php
+++ b/includes/fields/class-acf-field-url.php
@@ -129,6 +129,11 @@ if ( ! class_exists( 'acf_field_url' ) ) :
 				return $valid;
 			}
 
+			// A non-string value (e.g. an array from a crafted submission) is never a valid URL.
+			if ( ! is_string( $value ) ) {
+				return __( 'Value must be a valid URL', 'secure-custom-fields' );
+			}
+
 			if ( strpos( $value, '://' ) !== false ) {
 
 				// url
@@ -156,7 +161,8 @@ if ( ! class_exists( 'acf_field_url' ) ) :
 		 */
 		public function format_value( $value, $post_id, $field, $escape_html ) {
 			if ( $escape_html ) {
-				return esc_url( $value );
+				// esc_url() expects a string; treat a non-string value as empty.
+				return is_string( $value ) ? esc_url( $value ) : '';
 			}
 			return $value;
 		}

--- a/tests/php/includes/fields/test-class-acf-field-url.php
+++ b/tests/php/includes/fields/test-class-acf-field-url.php
@@ -138,6 +138,35 @@ class Test_ACF_Field_Url extends Abstract_ACF_Field_Test {
 	}
 
 	/**
+	 * Test validate_value does not crash on a non-scalar value.
+	 *
+	 * A crafted form submission can deliver an array (e.g. acf[field_key][])
+	 * as the value. The field should treat it as invalid rather than raising
+	 * a TypeError from strpos().
+	 */
+	public function test_validate_value_non_scalar() {
+		$field = $this->get_field( array( 'required' => 1 ) );
+
+		$valid = $this->field_instance->validate_value( true, array( 'a' => 'b' ), $field, 'acf[field_url_test]' );
+
+		$this->assertEquals( __( 'Value must be a valid URL', 'secure-custom-fields' ), $valid );
+	}
+
+	/**
+	 * Test format_value does not crash on a non-scalar value when escaping.
+	 *
+	 * Calling esc_url() on an array would raise a TypeError. The field should
+	 * return an empty string, matching how it treats an empty value.
+	 */
+	public function test_format_value_non_scalar_escaped() {
+		$field = $this->get_field();
+
+		$result = $this->field_instance->format_value( array( 'a' => 'b' ), $this->post_id, $field, true );
+
+		$this->assertEquals( '', $result );
+	}
+
+	/**
 	 * Test get_rest_schema returns valid schema.
 	 */
 	public function test_get_rest_schema() {


### PR DESCRIPTION
## Description

The URL field's `validate_value()` and `format_value()` methods can receive a non-scalar value (for example an array) from a form submission, since the submitted value is not guaranteed to be a string. When that happens:

- `validate_value()` calls `strpos( $value, '://' )`, which raises a `TypeError` on PHP 8 when `$value` is an array.
- `format_value()` calls `esc_url( $value )` (which internally calls `ltrim()`) when `escape_html` is true, raising a `TypeError` on an array.

A non-scalar value is never a valid URL, so the field should treat it as invalid/empty rather than raising a fatal `TypeError`. This PR adds a minimal type guard to both methods:

- `validate_value()`: a non-string value returns the existing "Value must be a valid URL" validation message.
- `format_value()`: a non-string value returns an empty string when escaping, matching how the field already treats an empty value.

Behavior for normal string values is unchanged.

This file is derived from an upstream plugin; the same change applies upstream.

## Verification

- `composer test:php` — full suite green (2266 tests), including new regression tests `test_validate_value_non_scalar` and `test_format_value_non_scalar_escaped`.
- `composer test:phpstan` — clean (no errors).
- `vendor/bin/phpcs` on the changed field class and test file — clean (no new violations introduced).

## Use of AI Tools

This change was authored by Claude Code under human direction. The human author reviewed and takes responsibility for the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
