### PR TITLE
Guard select field update_value against nested-array values

### DIFF
--- a/includes/fields/class-acf-field-select.php
+++ b/includes/fields/class-acf-field-select.php
@@ -575,8 +575,14 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 
 			// Format array of values.
 			// - Parse each value as string for SQL LIKE queries.
+			// - Guard against nested arrays (e.g. crafted POST input) by stringifying scalars only.
 			if ( is_array( $value ) ) {
-				$value = array_map( 'strval', $value );
+				$value = array_map(
+					static function ( $v ) {
+						return is_scalar( $v ) ? strval( $v ) : '';
+					},
+					$value
+				);
 			}
 
 			// Save custom options back to the field definition if configured.

--- a/tests/php/includes/fields/test-class-acf-field-select.php
+++ b/tests/php/includes/fields/test-class-acf-field-select.php
@@ -203,6 +203,31 @@ class Test_ACF_Field_Select extends Abstract_ACF_Field_Test {
 	}
 
 	/**
+	 * Test update_value handles a nested-array value without emitting
+	 * an "Array to string conversion" warning.
+	 *
+	 * A crafted POST such as acf[field_key][0][]=x produces a value where an
+	 * element is itself an array. update_value stringifies submitted values, and
+	 * array_map( 'strval', ... ) on such input triggers a PHP warning. The field
+	 * should handle this gracefully rather than emit the diagnostic.
+	 *
+	 * PHPUnit is configured with convertWarningsToExceptions, so an
+	 * "Array to string conversion" warning would surface as a test failure.
+	 */
+	public function test_update_value_nested_array() {
+		$field = $this->get_field( array( 'multiple' => 1 ) );
+
+		$result = $this->field_instance->update_value( array( array( 'x' ) ), $this->post_id, $field );
+
+		$this->assertIsArray( $result );
+
+		// Every stored value must be a scalar string; nested arrays must not leak through.
+		foreach ( $result as $stored ) {
+			$this->assertIsString( $stored );
+		}
+	}
+
+	/**
 	 * Test get_rest_schema returns valid schema.
 	 */
 	public function test_get_rest_schema() {


### PR DESCRIPTION
## Description

`ACF_Field_Select::update_value()` stringifies the submitted value via `array_map( 'strval', $value )` so that each value can be matched by SQL `LIKE` queries. This assumes every element of `$value` is a scalar.

A multi-value select can receive a value where an element is itself an array — for example via a nested POST such as `acf[field_key][0][]=x`. Passing such an element through `strval()` raises an `Array to string conversion` warning. This should be handled rather than emitting the diagnostic.

This PR makes the smallest sensible guard: stringify only scalar elements and coerce any non-scalar element to an empty string. Normal scalar arrays of values are unaffected.

```php
// Before
$value = array_map( 'strval', $value );

// After
$value = array_map(
    static function ( $v ) {
        return is_scalar( $v ) ? strval( $v ) : '';
    },
    $value
);
```

The checkbox field delegates to this method (`acf_get_field_type( 'select' )->update_value( ... )`), so it is covered by the same guard. The radio field has its own `update_value()` that operates on a scalar value and does not use this code path, so it is unaffected.

This file is upstream-derived; the same guard applies upstream.

## Verification

- New regression test `Test_ACF_Field_Select::test_update_value_nested_array` fails against the unpatched code (PHPUnit is configured with `convertWarningsToExceptions`, so the `Array to string conversion` warning surfaces as a failure) and passes with the fix.
- `composer test:php -- --filter 'Field_Select'` — green (17 tests).
- Full `composer test:php` — green (2265 tests).
- `composer test:phpstan` — clean.
- `phpcs` on the changed files introduces no new issues (the select field's pre-existing legacy warnings are unchanged; the test file is clean).

Closes <!-- #ISSUE-NUMBER -->

## Use of AI Tools

This PR was authored with Claude Code under human direction. All changes were reviewed by a human, who takes responsibility for the contribution.
