### PR TITLE
Escape remaining wp_options LIKE patterns with esc_like() (parity follow-up to #462)

### DIFF
--- a/includes/forms/form-taxonomy.php
+++ b/includes/forms/form-taxonomy.php
@@ -342,13 +342,9 @@ if ( ! class_exists( 'acf_form_taxonomy' ) ) :
 			global $wpdb;
 
 			// vars
-			$search  = $taxonomy . '_' . $term . '_%';
-			$_search = '_' . $search;
-
-			// escape '_'
-			// http://stackoverflow.com/questions/2300285/how-do-i-escape-in-sql-server
-			$search  = str_replace( '_', '\_', $search );
-			$_search = str_replace( '_', '\_', $_search );
+			// esc_like() escapes %, _ and \ for the LIKE clause; append the trailing wildcard.
+			$search  = $wpdb->esc_like( "{$taxonomy}_{$term}_" ) . '%';
+			$_search = $wpdb->esc_like( "_{$taxonomy}_{$term}_" ) . '%';
 
 			// delete
 			$result = $wpdb->query(

--- a/includes/upgrades.php
+++ b/includes/upgrades.php
@@ -463,13 +463,9 @@ function acf_upgrade_550_taxonomy( $taxonomy ) {
 	global $wpdb;
 
 	// vars
-	$search  = $taxonomy . '_%';
-	$_search = '_' . $search;
-
-	// escape '_'
-	// http://stackoverflow.com/questions/2300285/how-do-i-escape-in-sql-server
-	$search  = str_replace( '_', '\_', $search );
-	$_search = str_replace( '_', '\_', $_search );
+	// esc_like() escapes %, _ and \ for the LIKE clause; append the trailing wildcard.
+	$search  = $wpdb->esc_like( "{$taxonomy}_" ) . '%';
+	$_search = $wpdb->esc_like( "_{$taxonomy}_" ) . '%';
 
 	// search
 	// results show faster query times using 2 LIKE vs 2 wildcards

--- a/tests/php/includes/test-like-escaping-parity.php
+++ b/tests/php/includes/test-like-escaping-parity.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Regression tests for the remaining hand-built wp_options LIKE queries.
+ *
+ * Two legacy code paths build wp_options LIKE patterns from a taxonomy (and
+ * term) and previously escaped only the `_` wildcard, leaving `%` and `\`
+ * active. Both now run their dynamic parts through $wpdb->esc_like(). These
+ * tests capture the generated SQL (the queries are no-ops under WorDBless)
+ * and assert the dynamic part is escaped, comparing against patterns built
+ * with the same $wpdb->prepare()/esc_like() primitives the source uses.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests that the surviving wp_options LIKE queries escape via esc_like().
+ */
+class Test_Like_Escaping_Parity extends BaseTestCase {
+
+	/**
+	 * Captured wp_options LIKE queries.
+	 *
+	 * @var array
+	 */
+	protected $captured = array();
+
+	/**
+	 * Start capturing queries.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->captured = array();
+		add_filter( 'wordbless_wpdb_query_results', array( $this, 'capture_query' ), 10, 2 );
+	}
+
+	/**
+	 * Stop capturing queries.
+	 */
+	public function tear_down() {
+		remove_filter( 'wordbless_wpdb_query_results', array( $this, 'capture_query' ), 10 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Record any wp_options LIKE query.
+	 *
+	 * @param array  $results The (empty) results array.
+	 * @param string $query   The SQL passed to wpdb::query().
+	 * @return array
+	 */
+	public function capture_query( $results, $query ) {
+		if ( false !== strpos( (string) $query, 'option_name LIKE' ) ) {
+			$this->captured[] = (string) $query;
+		}
+		return $results;
+	}
+
+	/**
+	 * The escaped fragment a correctly-escaped literal produces in the SQL.
+	 *
+	 * @param string $literal The literal portion of the LIKE pattern.
+	 * @return string
+	 */
+	protected function expected_fragment( $literal ) {
+		global $wpdb;
+		return $wpdb->prepare( '%s', $wpdb->esc_like( $literal ) . '%' );
+	}
+
+	/**
+	 * The most recent captured wp_options LIKE query.
+	 *
+	 * @return string
+	 */
+	protected function last_query() {
+		return empty( $this->captured ) ? '' : end( $this->captured );
+	}
+
+	/**
+	 * Ensures acf_upgrade_550_taxonomy() escapes the taxonomy in its SELECT.
+	 */
+	public function test_upgrade_550_taxonomy_escapes_like() {
+		global $wpdb;
+
+		// A taxonomy name carrying a % wildcard proves the escaping.
+		acf_upgrade_550_taxonomy( 'ta%x' );
+
+		$query = $this->last_query();
+		$this->assertNotEmpty( $query, 'The upgrade SELECT should have been captured.' );
+		$this->assertStringContainsString(
+			$this->expected_fragment( 'ta%x_' ),
+			$query,
+			'The taxonomy should be escaped via esc_like().'
+		);
+
+		$bad = $wpdb->prepare( '%s', str_replace( '_', '\_', 'ta%x_%' ) );
+		$this->assertStringNotContainsString(
+			$bad,
+			$query,
+			'The unescaped (active-wildcard) pattern must not be generated.'
+		);
+	}
+
+	/**
+	 * Ensures acf_form_taxonomy::delete_term() escapes the taxonomy and term
+	 * in its legacy (no-termmeta) DELETE.
+	 */
+	public function test_delete_term_escapes_like() {
+		global $wpdb;
+
+		// Force the legacy path: acf_isset_termmeta() returns false when the
+		// stored db_version predates termmeta (WP < 4.4 / db_version 34370).
+		update_option( 'db_version', 34000 );
+
+		$form = new acf_form_taxonomy();
+		$form->delete_term( 7, 0, 'ta%x', null );
+
+		$query = $this->last_query();
+		$this->assertNotEmpty( $query, 'The delete DELETE should have been captured.' );
+		$this->assertStringContainsString(
+			$this->expected_fragment( 'ta%x_7_' ),
+			$query,
+			'The taxonomy and term should be escaped via esc_like().'
+		);
+
+		$bad = $wpdb->prepare( '%s', str_replace( '_', '\_', 'ta%x_7_%' ) );
+		$this->assertStringNotContainsString(
+			$bad,
+			$query,
+			'The unescaped (active-wildcard) pattern must not be generated.'
+		);
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Secure Custom Fields (SCF)! Please have a look at the Contributing Guidelines:
https://github.com/WordPress/secure-custom-fields/blob/trunk/docs/contributing/index.md -->

## Summary

Follow-up to #462. A scoping pass found two more legacy code paths that build `wp_options` `LIKE` patterns and escape only the `_` wildcard via `str_replace( '_', '\_', … )`, leaving `%` and the `\` escape character active — the same pattern that #462 fixed:

- `includes/forms/form-taxonomy.php` — `acf_form_taxonomy::delete_term()` (a `DELETE … WHERE option_name LIKE`), on the legacy pre-termmeta path.
- `includes/upgrades.php` — `acf_upgrade_550_taxonomy()` (a one-time admin `SELECT … LIKE`).

Both migrate to `$wpdb->esc_like()`, which escapes `%`, `_` and `\`.

## Reachability

Neither is reachable with hostile wildcard bytes today: `delete_term()`'s `$term` is the integer term id passed by core's `delete_term` action and `$taxonomy` is a registered taxonomy name; `acf_upgrade_550_taxonomy()` runs only during an admin-triggered one-time DB upgrade with a registered taxonomy name. This is **parity hardening** so the whole codebase uses the correct primitive — not a fix for a live, untrusted-input-reachable issue.

## Tests

Adds `tests/php/includes/test-like-escaping-parity.php`, which captures the SQL each path generates (the queries are no-ops under WorDBless) and asserts the dynamic part is escaped through `esc_like()`. Both tests were confirmed to **fail against the pre-fix code**.

- `composer test:php`: OK (2825 tests). `composer test:phpstan`: clean. `phpcs` (changed lines): clean.

## Note

These files are derived from upstream; the same change applies there.

## Use of AI Tools

Authored by Claude Code (Claude Fable 5) under human direction.
