### PR TITLE
Add backslash coverage to wp_options LIKE escaping tests

### DIFF
--- a/tests/php/includes/functions/test-acf-option-meta-like-escaping.php
+++ b/tests/php/includes/functions/test-acf-option-meta-like-escaping.php
@@ -119,6 +119,32 @@ class Test_ACF_Option_Meta_Like_Escaping extends BaseTestCase {
 	}
 
 	/**
+	 * A prefix containing a backslash must be escaped.
+	 */
+	public function test_backslash_prefix_is_escaped() {
+		global $wpdb;
+
+		// The prefix is the three characters a \ b.
+		acf_get_option_meta( 'a\\b' );
+
+		$good = $this->expected_like_fragment( 'a\\b_' );
+		$this->assertStringContainsString(
+			$good,
+			$this->captured_sql,
+			'A backslash in the prefix should be escaped via esc_like().'
+		);
+
+		// The previous str_replace() approach escaped only `_`, leaving the
+		// backslash unescaped. That exact fragment must not appear.
+		$bad = $wpdb->prepare( '%s', str_replace( '_', '\_', 'a\\b_%' ) );
+		$this->assertStringNotContainsString(
+			$bad,
+			$this->captured_sql,
+			'The pattern with an unescaped backslash must not be generated.'
+		);
+	}
+
+	/**
 	 * A benign prefix still produces the expected (unchanged) pattern.
 	 */
 	public function test_benign_prefix_unchanged() {

--- a/tests/php/includes/test-like-escaping-parity.php
+++ b/tests/php/includes/test-like-escaping-parity.php
@@ -103,6 +103,31 @@ class Test_Like_Escaping_Parity extends BaseTestCase {
 	}
 
 	/**
+	 * Ensures acf_upgrade_550_taxonomy() also escapes a backslash.
+	 */
+	public function test_upgrade_550_taxonomy_escapes_backslash() {
+		global $wpdb;
+
+		// The taxonomy is the three characters a \ b.
+		acf_upgrade_550_taxonomy( 'a\\b' );
+
+		$query = $this->last_query();
+		$this->assertNotEmpty( $query, 'The upgrade SELECT should have been captured.' );
+		$this->assertStringContainsString(
+			$this->expected_fragment( 'a\\b_' ),
+			$query,
+			'A backslash should be escaped via esc_like().'
+		);
+
+		$bad = $wpdb->prepare( '%s', str_replace( '_', '\_', 'a\\b_%' ) );
+		$this->assertStringNotContainsString(
+			$bad,
+			$query,
+			'The pattern with an unescaped backslash must not be generated.'
+		);
+	}
+
+	/**
 	 * Ensures acf_form_taxonomy::delete_term() escapes the taxonomy and term
 	 * in its legacy (no-termmeta) DELETE.
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Secure Custom Fields (SCF)! Please have a look at the Contributing Guidelines:
https://github.com/WordPress/secure-custom-fields/blob/trunk/docs/contributing/index.md -->

## Summary

Test-only follow-up to #462 / #467 (review feedback).

The `wp_options` `LIKE`-escaping regression tests asserted that `%` and `_` are escaped, and the comments note `esc_like()` also covers the `\` escape character — but no test case exercised `\`. This adds a backslash-prefix case to both:

- `tests/php/includes/functions/test-acf-option-meta-like-escaping.php`
- `tests/php/includes/test-like-escaping-parity.php`

Each new case was confirmed to **fail** against the previous `str_replace( '_', '\_', … )` escaping (which left `\` active) and **pass** with `esc_like()`, so the tests now fully match their stated claim.

No production code changes.

- `composer test:php` (the two classes): OK (7 tests). `phpcs`: clean.

## Use of AI Tools

Authored by Claude Code (Claude Fable 5) under human direction.
