### PR TITLE
Prepare 6.8.9 Release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,17 @@ This plugin builds upon and is a fork of the previous work done by the contribut
 
 
 == Changelog ==
+= 6.8.9 =
+*Release Date 15th June 2026*
+
+*Security*
+
+- Hardened the escaping of wp_options LIKE queries used when loading option-page meta and during taxonomy term cleanup, switching to esc_like() so option-name prefixes are always matched as literals rather than as patterns.
+
+*Fixes*
+
+- The URL, text, textarea, and select-style fields no longer raise PHP errors when a non-scalar value (such as an array) is submitted; such input is now treated as invalid.
+
 = 6.8.8 =
 *Release Date 11th June 2026*
 

--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -6,7 +6,7 @@
  * Plugin Name:       Secure Custom Fields
  * Plugin URI:        https://developer.wordpress.org/secure-custom-fields/
  * Description:       Secure Custom Fields (SCF) offers an intuitive way for developers to enhance WordPress content management by adding extra fields and options without coding requirements.
- * Version:           6.8.8
+ * Version:           6.8.9
  * Author:            WordPress.org
  * Author URI:        https://wordpress.org/
  * Text Domain:       secure-custom-fields
@@ -33,7 +33,7 @@ if ( ! class_exists( 'ACF' ) ) {
 		 *
 		 * @var string
 		 */
-		public $version = '6.8.8';
+		public $version = '6.8.9';
 
 		/**
 		 * The plugin settings array.


### PR DESCRIPTION
<!-- Thanks for contributing to Secure Custom Fields (SCF)! -->

Prepares the **6.8.9** patch release. Version bumped to 6.8.9; the `Stable tag` in `readme.txt` is intentionally left at 6.8.8 and will be flipped after the wp.org build is smoke-tested (per the release process).

## Changelog (6.8.9)

**Security**
- Hardened the escaping of `wp_options` `LIKE` queries used when loading option-page meta and during taxonomy term cleanup, switching to `esc_like()` so option-name prefixes are always matched as literals rather than as patterns.

**Fixes**
- The URL, text, textarea, and select-style fields no longer raise PHP errors when a non-scalar value (such as an array) is submitted; such input is now treated as invalid.

## Contents (already merged to `trunk`)

- #462 — `esc_like()` in `acf_get_option_meta()`
- #467 — `esc_like()` parity for the taxonomy-form DELETE and the 5.5.0 upgrade SELECT
- #463 / #464 / #465 — URL / text+textarea / select non-scalar input guards
- #468, #450 — supporting tests (not shipped to wp.org)

## Notes

- Generated by `composer prepare-release`; only the version bump and changelog are in this PR (build artifacts are gitignored; docs/translations were already current).
- Stable tag flip and the wp.org SVN deploy are handled separately after merge + smoke test.
