### PR TITLE
Set Stable tag to 6.8.9

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: fields, custom fields, meta, scf
 Requires at least: 6.2
 Tested up to: 6.9.1
 Requires PHP: 7.4
-Stable tag: 6.8.8
+Stable tag: 6.8.9
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Flips the readme Stable tag to 6.8.9 to match the wp.org SVN trunk (Stable tag committed in svn r3570548). Plugin code is 6.8.9 (released via #469); this keeps the git readme in sync.