### PR TITLE
Explain reserved core menu slots in Menu Position help text

### DIFF
--- a/includes/admin/views/acf-post-type/advanced-settings.php
+++ b/includes/admin/views/acf-post-type/advanced-settings.php
@@ -793,7 +793,7 @@ foreach ( acf_get_combined_post_type_settings_tabs() as $tab_key => $tab_label )
 					'prefix'       => 'acf_post_type',
 					'value'        => $acf_post_type['menu_position'],
 					'label'        => __( 'Menu Position', 'secure-custom-fields' ),
-					'instructions' => __( 'The position in the sidebar menu in the admin dashboard.', 'secure-custom-fields' ),
+					'instructions' => __( 'The position in the admin sidebar menu. WordPress reserves several positions (e.g. 2 Dashboard, 4 separator, 5 Posts, 10 Media, 20 Pages, 25 Comments); if the chosen position is already taken, the item is moved down to the next free slot. To keep multiple post types grouped and in order, use spaced values that avoid those slots, such as 21–24 or 26 and above.', 'secure-custom-fields' ),
 					'conditions'   => array(
 						'field'    => 'show_in_menu',
 						'operator' => '==',


### PR DESCRIPTION
Expands the Menu Position help text in the post type editor to explain WordPress's reserved menu slots, after a user hit confusing ordering in #360.

A custom post type whose `menu_position` collides with a core slot (Dashboard 2, separator 4, Posts 5, Media 10, Pages 20, Comments 25, …) is pushed by WordPress core to the next free slot — so e.g. position 4 lands below Posts. The field previously gave no hint of this.

See #360.

## Screenshot

<!-- TODO: drag the screenshot here in the GitHub UI -->

## Use of AI Tools

Written with Claude Code (Claude Opus 4.8) under human direction.
