### PR TITLE
Bump Tested up to 7.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg
 Tags: fields, custom fields, meta, scf
 Requires at least: 6.2
-Tested up to: 6.9.1
+Tested up to: 7.0
 Requires PHP: 7.4
 Stable tag: 6.8.9
 License: GPLv2 or later


### PR DESCRIPTION
Updates the `Tested up to` header in `readme.txt` to 7.0 for the next release. SCF runs against WordPress 7.0 (current wp-env core) and the full suite is green there.

## Use of AI Tools

Written with Claude Code (Claude Opus 4.8) under human direction.