### PR TITLE
[codex] Fix flaky PHPUnit test isolation

### DIFF
--- a/tests/php/includes/abilities/test-scf-internal-post-type-abilities.php
+++ b/tests/php/includes/abilities/test-scf-internal-post-type-abilities.php
@@ -62,7 +62,46 @@ class Test_SCF_Internal_Post_Type_Abilities extends BaseTestCase {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+
+		$this->ensure_taxonomy_instance_registered();
 		$this->abilities = acf_get_instance( 'SCF_Taxonomy_Abilities' );
+		$this->reset_cached_instance();
+	}
+
+	/**
+	 * Clean up singleton state changed by mocked callback tests.
+	 */
+	public function tearDown(): void {
+		$this->ensure_taxonomy_instance_registered();
+		$this->reset_cached_instance();
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Ensures the taxonomy internal post type can be resolved after tests that
+	 * temporarily remove it from the global store.
+	 */
+	private function ensure_taxonomy_instance_registered() {
+		$store = acf_get_store( 'internal-post-types' );
+
+		if ( ! $store ) {
+			$store = acf_register_store( 'internal-post-types' );
+		}
+
+		$store->set( 'acf-taxonomy', ACF_Taxonomy::class );
+	}
+
+	/**
+	 * Resets the cached internal post type instance on the singleton abilities
+	 * object so one test's mock cannot leak into another test.
+	 */
+	private function reset_cached_instance() {
+		$reflection = new ReflectionClass( SCF_Internal_Post_Type_Abilities::class );
+		$property   = $reflection->getProperty( 'instance' );
+		$property->setAccessible( true );
+		$property->setValue( $this->abilities, null );
 	}
 
 	/**
@@ -72,8 +111,9 @@ class Test_SCF_Internal_Post_Type_Abilities extends BaseTestCase {
 	 * @return \PHPUnit\Framework\MockObject\MockObject The mock instance.
 	 */
 	private function inject_mock_instance( array $method_returns ) {
-		$mock_instance            = $this->createMock( ACF_Taxonomy::class );
-		$mock_instance->hook_name = 'acf_taxonomy';
+		$mock_instance                   = $this->createMock( ACF_Taxonomy::class );
+		$mock_instance->hook_name        = 'taxonomy';
+		$mock_instance->hook_name_plural = 'taxonomies';
 
 		foreach ( $method_returns as $method => $return_value ) {
 			$mock_instance->method( $method )->willReturn( $return_value );
@@ -166,7 +206,8 @@ class Test_SCF_Internal_Post_Type_Abilities extends BaseTestCase {
 		global $acf_instances;
 
 		// Store original validator.
-		$original_validator = $acf_instances['SCF_JSON_Schema_Validator'] ?? null;
+		$has_original_validator = array_key_exists( 'SCF_JSON_Schema_Validator', $acf_instances );
+		$original_validator     = $has_original_validator ? $acf_instances['SCF_JSON_Schema_Validator'] : null;
 
 		// Create mock validator that returns false.
 		$mock_validator                             = new class() {
@@ -181,18 +222,21 @@ class Test_SCF_Internal_Post_Type_Abilities extends BaseTestCase {
 		};
 		$acf_instances['SCF_JSON_Schema_Validator'] = $mock_validator;
 
-		// Create a fresh instance (bypassing acf_get_instance cache for this class).
-		$test_instance = new SCF_Taxonomy_Abilities();
+		try {
+			// Create a fresh instance (bypassing acf_get_instance cache for this class).
+			$test_instance = new SCF_Taxonomy_Abilities();
 
-		// Verify NO hooks were registered for this instance.
-		$this->assertFalse(
-			has_action( 'wp_abilities_api_categories_init', array( $test_instance, 'register_categories' ) ),
-			'Should NOT register hooks when schema validation fails'
-		);
-
-		// Restore original validator.
-		if ( $original_validator ) {
-			$acf_instances['SCF_JSON_Schema_Validator'] = $original_validator;
+			// Verify NO hooks were registered for this instance.
+			$this->assertFalse(
+				has_action( 'wp_abilities_api_categories_init', array( $test_instance, 'register_categories' ) ),
+				'Should NOT register hooks when schema validation fails'
+			);
+		} finally {
+			if ( $has_original_validator ) {
+				$acf_instances['SCF_JSON_Schema_Validator'] = $original_validator;
+			} else {
+				unset( $acf_instances['SCF_JSON_Schema_Validator'] );
+			}
 		}
 	}
 
@@ -844,9 +888,10 @@ class Test_SCF_Internal_Post_Type_Abilities extends BaseTestCase {
 				'Unavailable instances should not be cached so later registration attempts can retry'
 			);
 		} finally {
-			if ( $store && $original_instance ) {
-				$store->set( 'acf-taxonomy', $original_instance );
+			if ( $store ) {
+				$store->set( 'acf-taxonomy', $original_instance ? $original_instance : ACF_Taxonomy::class );
 			}
+			$property->setValue( $this->abilities, null );
 		}
 	}
 

--- a/tests/php/includes/forms/test-form-attachment.php
+++ b/tests/php/includes/forms/test-form-attachment.php
@@ -16,6 +16,41 @@ acf_include( 'includes/forms/form-attachment.php' );
 class Test_Form_Attachment extends BaseTestCase {
 
 	/**
+	 * The removable field groups filter used by tests.
+	 *
+	 * @var callable|null
+	 */
+	private $field_groups_filter = null;
+
+	/**
+	 * Clean up global state changed by attachment form tests.
+	 */
+	public function tearDown(): void {
+		if ( $this->field_groups_filter ) {
+			remove_filter( 'acf/load_field_groups', $this->field_groups_filter );
+			$this->field_groups_filter = null;
+		}
+
+		global $current_screen, $typenow, $taxnow;
+		$current_screen = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Resetting globals in test tearDown.
+		$typenow        = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Resetting globals in test tearDown.
+		$taxnow         = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Resetting globals in test tearDown.
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Adds a field group filter that can be removed in tearDown().
+	 */
+	private function add_empty_field_groups_filter() {
+		$this->field_groups_filter = function () {
+			return array();
+		};
+
+		add_filter( 'acf/load_field_groups', $this->field_groups_filter );
+	}
+
+	/**
 	 * Test if the acf_form_attachment class exists.
 	 */
 	public function test_form_attachment_class_exists() {
@@ -73,12 +108,7 @@ class Test_Form_Attachment extends BaseTestCase {
 		);
 
 		// Ensure no field groups match.
-		add_filter(
-			'acf/get_field_groups',
-			function () {
-				return array();
-			}
-		);
+		$this->add_empty_field_groups_filter();
 
 		$result = $form_attachment->edit_attachment( $form_fields, $post );
 

--- a/tests/php/includes/forms/test-form-comment.php
+++ b/tests/php/includes/forms/test-form-comment.php
@@ -9,6 +9,7 @@ use WorDBless\BaseTestCase;
 
 // Load the acf_form_comment class.
 acf_include( 'includes/forms/form-comment.php' );
+acf_include( 'includes/locations/class-acf-location-comment.php' );
 
 /**
  * Class Test_Form_Comment
@@ -16,10 +17,31 @@ acf_include( 'includes/forms/form-comment.php' );
 class Test_Form_Comment extends BaseTestCase {
 
 	/**
+	 * The removable field groups filter used by tests.
+	 *
+	 * @var callable|null
+	 */
+	private $field_groups_filter = null;
+
+	/**
+	 * Set up each test with a clean form store.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		acf_get_store( 'form' )->reset();
+	}
+
+	/**
 	 * Clean up after each test to prevent global state pollution.
 	 */
 	public function tearDown(): void {
-		parent::tearDown();
+		if ( $this->field_groups_filter ) {
+			remove_filter( 'acf/load_field_groups', $this->field_groups_filter );
+			$this->field_groups_filter = null;
+		}
+
+		acf_get_store( 'form' )->reset();
 
 		// Reset globals to prevent polluting other tests.
 		global $pagenow, $post;
@@ -27,6 +49,19 @@ class Test_Form_Comment extends BaseTestCase {
 		$pagenow = null;
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Resetting globals in test tearDown.
 		$post = null;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Adds a field group filter that can be removed in tearDown().
+	 */
+	private function add_empty_field_groups_filter() {
+		$this->field_groups_filter = function () {
+			return array();
+		};
+
+		add_filter( 'acf/load_field_groups', $this->field_groups_filter );
 	}
 
 	/**
@@ -167,12 +202,7 @@ class Test_Form_Comment extends BaseTestCase {
 		$html = '<textarea name="comment">Original comment field</textarea>';
 
 		// Ensure no field groups match.
-		add_filter(
-			'acf/get_field_groups',
-			function () {
-				return array();
-			}
-		);
+		$this->add_empty_field_groups_filter();
 
 		$result = $form_comment->comment_form_field_comment( $html );
 
@@ -256,12 +286,7 @@ class Test_Form_Comment extends BaseTestCase {
 		$comment->comment_post_ID = 1;
 
 		// Ensure no field groups match to avoid rendering.
-		add_filter(
-			'acf/get_field_groups',
-			function () {
-				return array();
-			}
-		);
+		$this->add_empty_field_groups_filter();
 
 		ob_start();
 		$form_comment->edit_comment( $comment );
@@ -278,42 +303,56 @@ class Test_Form_Comment extends BaseTestCase {
 	 * post_id formatted as "comment_{comment_ID}".
 	 */
 	public function test_edit_comment_uses_correct_post_id_format() {
-		$form_comment = new acf_form_comment();
+		$form_comment   = new acf_form_comment();
+		$parent_post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Comment parent',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			)
+		);
 
 		// Create a mock comment object.
 		$comment                  = new stdClass();
 		$comment->comment_ID      = 456;
-		$comment->comment_post_ID = 1;
+		$comment->comment_post_ID = $parent_post_id;
 
-		// Register a real field group to trigger the rendering path.
-		$field_group = acf_update_field_group(
-			array(
-				'key'                   => 'group_comment_test',
-				'title'                 => 'Comment Test Group',
-				'location'              => array(
+		// Return a field group directly to trigger the rendering path without
+		// relying on field group persistence or location-rule state.
+		$field_group               = array(
+			'ID'                    => 0,
+			'key'                   => 'group_comment_test_' . uniqid(),
+			'title'                 => 'Comment Test Group',
+			'active'                => true,
+			'location'              => array(
+				array(
 					array(
-						array(
-							'param'    => 'comment',
-							'operator' => '==',
-							'value'    => 'all',
-						),
+						'param'    => 'comment',
+						'operator' => '==',
+						'value'    => 'all',
 					),
 				),
-				'instruction_placement' => 'label',
-			)
+			),
+			'label_placement'       => 'top',
+			'instruction_placement' => 'label',
 		);
+		$this->field_groups_filter = function () use ( $field_group ) {
+			return array( $field_group );
+		};
+		add_filter( 'acf/load_field_groups', $this->field_groups_filter );
 
-		// Capture output to prevent it from polluting test output.
-		ob_start();
-		$form_comment->edit_comment( $comment );
-		ob_get_clean();
+		try {
+			// Capture output to prevent it from polluting test output.
+			ob_start();
+			$form_comment->edit_comment( $comment );
+			ob_get_clean();
 
-		// Verify form data was stored with correct post_id format.
-		$form_data = acf_get_form_data( 'post_id' );
-		$this->assertEquals( 'comment_456', $form_data, 'post_id should be formatted as comment_{id}' );
-
-		// Cleanup: delete the field group.
-		acf_delete_field_group( $field_group['ID'] );
+			// Verify form data was stored with correct post_id format.
+			$form_data = acf_get_form_data( 'post_id' );
+			$this->assertEquals( 'comment_456', $form_data, 'post_id should be formatted as comment_{id}' );
+		} finally {
+			wp_delete_post( $parent_post_id, true );
+		}
 	}
 
 	/**

--- a/tests/php/includes/forms/test-form-wc-order.php
+++ b/tests/php/includes/forms/test-form-wc-order.php
@@ -20,11 +20,13 @@ class Test_Form_WC_Order extends BaseTestCase {
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
-		parent::tear_down();
+		acf_get_store( 'form' )->reset();
 
 		// Clean up any filters/actions we added.
 		remove_all_filters( 'acf/input/meta_box_priority' );
 		remove_all_actions( 'acf/add_meta_boxes' );
+
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/php/includes/functions/test-acf-post-functions.php
+++ b/tests/php/includes/functions/test-acf-post-functions.php
@@ -26,6 +26,7 @@ class Test_ACF_Post_Functions extends BaseTestCase {
 
 		// Reset the post_templates cache between tests.
 		acf_set_data( 'post_templates', null );
+		$this->reset_current_screen();
 	}
 
 	/**
@@ -33,8 +34,21 @@ class Test_ACF_Post_Functions extends BaseTestCase {
 	 */
 	public function tear_down(): void {
 		acf_set_data( 'post_templates', null );
+		$this->reset_current_screen();
 
 		parent::tear_down();
+	}
+
+	/**
+	 * Reset WordPress' current screen so title formatting is tested outside
+	 * admin context unless a test explicitly sets a screen.
+	 */
+	private function reset_current_screen() {
+		global $current_screen, $typenow, $taxnow;
+
+		$current_screen = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Resetting globals in tests.
+		$typenow        = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Resetting globals in tests.
+		$taxnow         = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Resetting globals in tests.
 	}
 
 	// =========================================================================

--- a/tests/php/includes/test-revisions.php
+++ b/tests/php/includes/test-revisions.php
@@ -41,6 +41,34 @@ class Test_ACF_Revisions extends BaseTestCase {
 	private $field;
 
 	/**
+	 * Local field key for the current test.
+	 *
+	 * @var string
+	 */
+	private $field_key;
+
+	/**
+	 * Local field name for the current test.
+	 *
+	 * @var string
+	 */
+	private $field_name;
+
+	/**
+	 * Removable post meta shim callback.
+	 *
+	 * @var callable|null
+	 */
+	private $post_metadata_filter = null;
+
+	/**
+	 * Removable revision query shim callback.
+	 *
+	 * @var callable|null
+	 */
+	private $posts_pre_query_filter = null;
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function setUp(): void {
@@ -48,30 +76,20 @@ class Test_ACF_Revisions extends BaseTestCase {
 
 		$this->install_wordbless_shims();
 
-		acf_add_local_field_group(
+		$this->field_key  = 'field_revision_text_' . uniqid();
+		$this->field_name = 'revision_text_' . uniqid();
+		acf_get_store( 'fields' )->reset();
+
+		acf_add_local_field(
 			array(
-				'key'      => 'group_revision_test',
-				'title'    => 'Revision Test Group',
-				'fields'   => array(
-					array(
-						'key'   => 'field_revision_text',
-						'label' => 'Revision Text',
-						'name'  => 'revision_text',
-						'type'  => 'text',
-					),
-				),
-				'location' => array(
-					array(
-						array(
-							'param'    => 'post_type',
-							'operator' => '==',
-							'value'    => 'post',
-						),
-					),
-				),
+				'key'    => $this->field_key,
+				'label'  => 'Revision Text',
+				'name'   => $this->field_name,
+				'type'   => 'text',
+				'parent' => 0,
 			)
 		);
-		$this->field = acf_get_field( 'field_revision_text' );
+		$this->field = acf_get_field( $this->field_key );
 
 		$this->post_id = wp_insert_post(
 			array(
@@ -90,7 +108,27 @@ class Test_ACF_Revisions extends BaseTestCase {
 	 */
 	public function tearDown(): void {
 		unset( $_POST['_acf_changed'], $_POST['action'], $_GET['preview'], $_GET['preview_id'] );
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+		if ( $this->field_name ) {
+			remove_filter( "_wp_post_revision_field_{$this->field_name}", array( acf()->revisions, 'wp_post_revision_field' ), 10 );
+		}
+
+		if ( $this->post_metadata_filter ) {
+			remove_filter( 'get_post_metadata', $this->post_metadata_filter, 20 );
+			$this->post_metadata_filter = null;
+		}
+
+		if ( $this->posts_pre_query_filter ) {
+			remove_filter( 'posts_pre_query', $this->posts_pre_query_filter, 10 );
+			$this->posts_pre_query_filter = null;
+		}
+
+		if ( $this->field_key ) {
+			acf_remove_local_field( $this->field_key );
+		}
+
 		acf_get_store( 'values' )->reset();
+		acf_get_store( 'fields' )->reset();
 		acf()->revisions->cache = array();
 		unregister_meta_key( 'post', '_acf' );
 		parent::tearDown();
@@ -103,40 +141,35 @@ class Test_ACF_Revisions extends BaseTestCase {
 	 * @return void
 	 */
 	private function install_wordbless_shims() {
-		add_filter(
-			'get_post_metadata',
-			function ( $check, $object_id, $meta_key ) {
-				if ( '' !== $meta_key ) {
-					return $check;
-				}
+		$this->post_metadata_filter = function ( $check, $object_id, $meta_key ) {
+			if ( '' !== $meta_key ) {
+				return $check;
+			}
 
 				$store = \WorDBless\PostMeta::init();
 				$all   = array();
-				if ( isset( $store->meta[ $object_id ] ) ) {
-					foreach ( $store->meta[ $object_id ] as $row ) {
-						$all[ $row['meta_key'] ][] = $row['meta_value'];
-					}
+			if ( isset( $store->meta[ $object_id ] ) ) {
+				foreach ( $store->meta[ $object_id ] as $row ) {
+					$all[ $row['meta_key'] ][] = $row['meta_value'];
 				}
+			}
 				return $all;
-			},
-			20,
-			3
-		);
+		};
 
-		add_filter(
-			'posts_pre_query',
-			function ( $posts, $query ) {
-				if ( 'revision' !== $query->get( 'post_type' ) ) {
-					return $posts;
-				}
+		add_filter( 'get_post_metadata', $this->post_metadata_filter, 20, 3 );
+
+		$this->posts_pre_query_filter = function ( $posts, $query ) {
+			if ( 'revision' !== $query->get( 'post_type' ) ) {
+				return $posts;
+			}
 
 				$parent = (int) $query->get( 'post_parent' );
 				$found  = array();
-				foreach ( \WorDBless\Posts::init()->posts as $post ) {
-					if ( 'revision' === $post->post_type && (int) $post->post_parent === $parent && 'inherit' === $post->post_status ) {
-						$found[] = new WP_Post( $post );
-					}
+			foreach ( \WorDBless\Posts::init()->posts as $post ) {
+				if ( 'revision' === $post->post_type && (int) $post->post_parent === $parent && 'inherit' === $post->post_status ) {
+					$found[] = new WP_Post( $post );
 				}
+			}
 				usort(
 					$found,
 					function ( $a, $b ) {
@@ -144,10 +177,9 @@ class Test_ACF_Revisions extends BaseTestCase {
 					}
 				);
 				return $found;
-			},
-			10,
-			2
-		);
+		};
+
+		add_filter( 'posts_pre_query', $this->posts_pre_query_filter, 10, 2 );
 	}
 
 	/**
@@ -204,12 +236,12 @@ class Test_ACF_Revisions extends BaseTestCase {
 		$this->assertIsInt( $rev_id );
 
 		// The freshly created revision has no SCF meta yet.
-		$this->assertSame( '', get_post_meta( $rev_id, 'revision_text', true ) );
+		$this->assertSame( '', get_post_meta( $rev_id, $this->field_name, true ) );
 
 		acf_save_post_revision( $this->post_id );
 
-		$this->assertSame( 'first value', get_post_meta( $rev_id, 'revision_text', true ) );
-		$this->assertSame( 'field_revision_text', get_post_meta( $rev_id, '_revision_text', true ) );
+		$this->assertSame( 'first value', get_post_meta( $rev_id, $this->field_name, true ) );
+		$this->assertSame( $this->field_key, get_post_meta( $rev_id, '_' . $this->field_name, true ) );
 	}
 
 	/**
@@ -241,7 +273,7 @@ class Test_ACF_Revisions extends BaseTestCase {
 		// Now change the value and corrupt the reference on the parent post.
 		acf_get_store( 'values' )->reset();
 		acf_update_value( 'second value', $this->post_id, $this->field );
-		update_post_meta( $this->post_id, '_revision_text', 'field_something_else' );
+		update_post_meta( $this->post_id, '_' . $this->field_name, 'field_something_else' );
 
 		// Restore the original revision through the real WP API. This fires
 		// the wp_restore_post_revision action handled by acf_revisions.
@@ -249,8 +281,8 @@ class Test_ACF_Revisions extends BaseTestCase {
 		$this->assertEquals( $this->post_id, $restored );
 
 		// Raw meta restored.
-		$this->assertSame( 'first value', get_post_meta( $this->post_id, 'revision_text', true ) );
-		$this->assertSame( 'field_revision_text', get_post_meta( $this->post_id, '_revision_text', true ) );
+		$this->assertSame( 'first value', get_post_meta( $this->post_id, $this->field_name, true ) );
+		$this->assertSame( $this->field_key, get_post_meta( $this->post_id, '_' . $this->field_name, true ) );
 
 		// And the value loads through the SCF API.
 		acf_get_store( 'values' )->reset();
@@ -279,16 +311,16 @@ class Test_ACF_Revisions extends BaseTestCase {
 
 		$latest = acf_get_post_latest_revision( $this->post_id );
 		$this->assertNotEquals( $rev1, $latest->ID );
-		$this->assertSame( 'second value', get_post_meta( $latest->ID, 'revision_text', true ) );
+		$this->assertSame( 'second value', get_post_meta( $latest->ID, $this->field_name, true ) );
 
 		// Restore revision 1 directly via the SCF handler.
 		acf()->revisions->wp_restore_post_revision( $this->post_id, $rev1 );
 
 		// Parent post and the latest revision both carry the restored value.
-		$this->assertSame( 'first value', get_post_meta( $this->post_id, 'revision_text', true ) );
+		$this->assertSame( 'first value', get_post_meta( $this->post_id, $this->field_name, true ) );
 		$latest = acf_get_post_latest_revision( $this->post_id );
-		$this->assertSame( 'first value', get_post_meta( $latest->ID, 'revision_text', true ) );
-		$this->assertSame( 'field_revision_text', get_post_meta( $latest->ID, '_revision_text', true ) );
+		$this->assertSame( 'first value', get_post_meta( $latest->ID, $this->field_name, true ) );
+		$this->assertSame( $this->field_key, get_post_meta( $latest->ID, '_' . $this->field_name, true ) );
 	}
 
 	// =========================================================================
@@ -359,8 +391,8 @@ class Test_ACF_Revisions extends BaseTestCase {
 
 		acf()->revisions->maybe_save_revision( $rev_id, $this->post_id );
 
-		$this->assertSame( 'saved value', get_post_meta( $rev_id, 'revision_text', true ) );
-		$this->assertSame( 'field_revision_text', get_post_meta( $rev_id, '_revision_text', true ) );
+		$this->assertSame( 'saved value', get_post_meta( $rev_id, $this->field_name, true ) );
+		$this->assertSame( $this->field_key, get_post_meta( $rev_id, '_' . $this->field_name, true ) );
 	}
 
 	// =========================================================================
@@ -381,11 +413,11 @@ class Test_ACF_Revisions extends BaseTestCase {
 		);
 
 		$this->assertArrayHasKey( 'post_title', $fields );
-		$this->assertArrayHasKey( 'revision_text', $fields );
-		$this->assertSame( 'Revision Text (revision_text)', $fields['revision_text'] );
+		$this->assertArrayHasKey( $this->field_name, $fields );
+		$this->assertSame( "Revision Text ({$this->field_name})", $fields[ $this->field_name ] );
 
 		// A render filter is attached for the field.
-		$this->assertNotFalse( has_filter( '_wp_post_revision_field_revision_text' ) );
+		$this->assertNotFalse( has_filter( "_wp_post_revision_field_{$this->field_name}" ) );
 	}
 
 	/**
@@ -422,14 +454,14 @@ class Test_ACF_Revisions extends BaseTestCase {
 		$post = get_post( $this->post_id );
 
 		// Empty values render as an empty string.
-		$this->assertSame( '', acf()->revisions->wp_post_revision_field( '', 'revision_text', $post ) );
+		$this->assertSame( '', acf()->revisions->wp_post_revision_field( '', $this->field_name, $post ) );
 
 		// Plain strings pass through.
-		$this->assertSame( 'hello', acf()->revisions->wp_post_revision_field( 'hello', 'revision_text', $post ) );
+		$this->assertSame( 'hello', acf()->revisions->wp_post_revision_field( 'hello', $this->field_name, $post ) );
 
 		// Serialized arrays are unserialized and imploded for display.
 		$serialized = serialize( array( 'one', 'two' ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- raw meta is stored serialized.
-		$this->assertSame( 'one, two', acf()->revisions->wp_post_revision_field( $serialized, 'revision_text', $post ) );
+		$this->assertSame( 'one, two', acf()->revisions->wp_post_revision_field( $serialized, $this->field_name, $post ) );
 	}
 
 	// =========================================================================

--- a/tests/php/includes/test-upgrades.php
+++ b/tests/php/includes/test-upgrades.php
@@ -32,11 +32,60 @@ class Test_ACF_Upgrades extends BaseTestCase {
 	private $captured_termmeta = array();
 
 	/**
+	 * Removable query result filters registered by tests.
+	 *
+	 * @var array
+	 */
+	private $query_results_filters = array();
+
+	/**
+	 * Removable insert filters registered by tests.
+	 *
+	 * @var array
+	 */
+	private $insert_filters = array();
+
+	/**
+	 * Removable posts_pre_query filters registered by tests.
+	 *
+	 * @var array
+	 */
+	private $posts_pre_query_filters = array();
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function setUp(): void {
 		parent::setUp();
 		$this->captured_termmeta = array();
+		delete_option( 'acf_version' );
+		delete_option( 'db_version' );
+	}
+
+	/**
+	 * Remove filters installed by tests so random ordering cannot leak closures
+	 * bound to prior PHPUnit instances.
+	 */
+	public function tearDown(): void {
+		foreach ( $this->query_results_filters as $filter ) {
+			remove_filter( 'wordbless_wpdb_query_results', $filter, 10 );
+		}
+
+		foreach ( $this->insert_filters as $filter ) {
+			remove_filter( 'wordbless_wpdb_insert', $filter, 10 );
+		}
+
+		foreach ( $this->posts_pre_query_filters as $filter ) {
+			remove_filter( 'posts_pre_query', $filter, 10 );
+		}
+
+		$this->query_results_filters   = array();
+		$this->insert_filters          = array();
+		$this->posts_pre_query_filters = array();
+		delete_option( 'acf_version' );
+		delete_option( 'db_version' );
+
+		parent::tearDown();
 	}
 
 	/**
@@ -104,32 +153,30 @@ class Test_ACF_Upgrades extends BaseTestCase {
 	 * @return void
 	 */
 	private function seed_legacy_fields( $ofg_id, $fields ) {
-		add_filter(
-			'wordbless_wpdb_query_results',
-			function ( $results, $query ) use ( $ofg_id, $fields ) {
+		$filter = function ( $results, $query ) use ( $ofg_id, $fields ) {
 				global $wpdb;
 
-				if ( false === strpos( $query, $wpdb->postmeta ) || false === strpos( $query, "post_id = {$ofg_id}" ) ) {
-					return $results;
-				}
+			if ( false === strpos( $query, $wpdb->postmeta ) || false === strpos( $query, "post_id = {$ofg_id}" ) ) {
+				return $results;
+			}
 
 				$rows    = array();
 				$meta_id = 9000;
-				foreach ( $fields as $meta_key => $field ) {
-					// phpcs:disable WordPress.DB.SlowDBQuery -- mimicking raw postmeta rows, not building a query.
-					$rows[] = (object) array(
-						'meta_id'    => $meta_id++, // phpcs:ignore Squiz.Operators.IncrementDecrementUsage.Found -- simple counter.
-						'post_id'    => $ofg_id,
-						'meta_key'   => $meta_key,
-						'meta_value' => serialize( $field ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- seeding legacy ACF4 data format.
-					);
-					// phpcs:enable WordPress.DB.SlowDBQuery
-				}
+			foreach ( $fields as $meta_key => $field ) {
+				// phpcs:disable WordPress.DB.SlowDBQuery -- mimicking raw postmeta rows, not building a query.
+				$rows[] = (object) array(
+					'meta_id'    => $meta_id++, // phpcs:ignore Squiz.Operators.IncrementDecrementUsage.Found -- simple counter.
+					'post_id'    => $ofg_id,
+					'meta_key'   => $meta_key,
+					'meta_value' => serialize( $field ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- seeding legacy ACF4 data format.
+				);
+				// phpcs:enable WordPress.DB.SlowDBQuery
+			}
 				return $rows;
-			},
-			10,
-			2
-		);
+		};
+
+		$this->query_results_filters[] = $filter;
+		add_filter( 'wordbless_wpdb_query_results', $filter, 10, 2 );
 	}
 
 	/**
@@ -142,44 +189,40 @@ class Test_ACF_Upgrades extends BaseTestCase {
 	 * @return void
 	 */
 	private function seed_legacy_termmeta( $option_rows ) {
-		add_filter(
-			'wordbless_wpdb_query_results',
-			function ( $results, $query ) use ( $option_rows ) {
+		$query_filter = function ( $results, $query ) use ( $option_rows ) {
 				global $wpdb;
 
 				// Only intercept the options query for the 'category' taxonomy.
-				if ( false === strpos( $query, $wpdb->options ) || false === strpos( $query, 'category' ) ) {
-					return $results;
-				}
+			if ( false === strpos( $query, $wpdb->options ) || false === strpos( $query, 'category' ) ) {
+				return $results;
+			}
 
 				$rows      = array();
 				$option_id = 1;
-				foreach ( $option_rows as $name => $value ) {
-					$rows[] = (object) array(
-						'option_id'    => $option_id++, // phpcs:ignore Squiz.Operators.IncrementDecrementUsage.Found -- simple counter.
-						'option_name'  => $name,
-						'option_value' => $value,
-					);
-				}
+			foreach ( $option_rows as $name => $value ) {
+				$rows[] = (object) array(
+					'option_id'    => $option_id++, // phpcs:ignore Squiz.Operators.IncrementDecrementUsage.Found -- simple counter.
+					'option_name'  => $name,
+					'option_value' => $value,
+				);
+			}
 				return $rows;
-			},
-			10,
-			2
-		);
+		};
 
-		add_filter(
-			'wordbless_wpdb_insert',
-			function ( $result, $table, $data ) {
+		$this->query_results_filters[] = $query_filter;
+		add_filter( 'wordbless_wpdb_query_results', $query_filter, 10, 2 );
+
+		$insert_filter = function ( $result, $table, $data ) {
 				global $wpdb;
 
-				if ( $table === $wpdb->termmeta ) {
-					$this->captured_termmeta[] = $data;
-				}
+			if ( $table === $wpdb->termmeta ) {
+				$this->captured_termmeta[] = $data;
+			}
 				return $result;
-			},
-			10,
-			3
-		);
+		};
+
+		$this->insert_filters[] = $insert_filter;
+		add_filter( 'wordbless_wpdb_insert', $insert_filter, 10, 3 );
 	}
 
 	// =========================================================================
@@ -665,24 +708,22 @@ class Test_ACF_Upgrades extends BaseTestCase {
 	 * @return void
 	 */
 	private function shim_legacy_field_group_query() {
-		add_filter(
-			'posts_pre_query',
-			function ( $posts, $query ) {
-				if ( 'acf' !== $query->get( 'post_type' ) ) {
-					return $posts;
-				}
+		$filter = function ( $posts, $query ) {
+			if ( 'acf' !== $query->get( 'post_type' ) ) {
+				return $posts;
+			}
 
 				$found = array();
-				foreach ( \WorDBless\Posts::init()->posts as $post ) {
-					if ( 'acf' === $post->post_type ) {
-						$found[] = new WP_Post( $post );
-					}
+			foreach ( \WorDBless\Posts::init()->posts as $post ) {
+				if ( 'acf' === $post->post_type ) {
+					$found[] = new WP_Post( $post );
 				}
+			}
 				return $found;
-			},
-			10,
-			2
-		);
+		};
+
+		$this->posts_pre_query_filters[] = $filter;
+		add_filter( 'posts_pre_query', $filter, 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Secure Custom Fields (SCF)! Please have a look at the Contributing Guidelines:
https://github.com/WordPress/secure-custom-fields/blob/trunk/docs/contributing/index.md -->

Fixes several order-dependent PHPUnit flakes by tightening test isolation around shared ACF state.

- Reset mocked internal post type singletons and schema validators between ability tests.
- Clear ACF form, field, and value stores plus leaked admin screen globals in form/post/revision tests.
- Scope revision test field keys and names per test to avoid local-field cache collisions.
- Remove WorDBless upgrade filters and reset version options after upgrade tests.

Validated with:

- `vendor/bin/phpcs tests/php/includes/test-upgrades.php tests/php/includes/abilities/test-scf-internal-post-type-abilities.php tests/php/includes/forms/test-form-attachment.php tests/php/includes/forms/test-form-comment.php tests/php/includes/forms/test-form-wc-order.php tests/php/includes/functions/test-acf-post-functions.php tests/php/includes/test-revisions.php`
- `composer test:php`
- `composer test:php -- --order-by=random --random-order-seed=172930`
- `npm run build`

<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes N/A

## Use of AI Tools

This PR was authored with assistance from OpenAI Codex. Codex was used to investigate random-order PHPUnit failures, implement the test-isolation changes, run local validation, and prepare this pull request.