### PR TITLE
e2e Tests: Fix user profile field E2E check on WP 6.2

### DIFF
--- a/tests/e2e/user-profile-fields.spec.ts
+++ b/tests/e2e/user-profile-fields.spec.ts
@@ -124,18 +124,18 @@ test.describe( 'User Profile Fields', () => {
 
 		// SECTION 4: Verify the value is readable via get_field() on the
 		// frontend (the test plugin appends the target user's field value
-		// to post content on the author archive). Derive the admin's actual
+		// to single post content). Derive the admin's actual
 		// user ID instead of assuming user 1, and pass it to the plugin via
 		// the scf_test_user_id query arg.
 		const adminUser = await requestUtils.rest( {
 			path: '/wp/v2/users/me',
 		} );
-		await requestUtils.createPost( {
+		const post = await requestUtils.createPost( {
 			title: 'User Field Frontend Check',
 			status: 'publish',
 		} );
 		await page.goto(
-			`/?author=${ adminUser.id }&scf_test_user_id=${ adminUser.id }`
+			`/?p=${ post.id }&scf_test_user_id=${ adminUser.id }`
 		);
 		const frontendValue = page.locator( '#scf-test-user-title' ).first();
 		await expect( frontendValue ).toBeVisible( {


### PR DESCRIPTION
## What

Updates the user profile fields E2E test so the frontend check opens the test post directly instead of using the author archive.

## Why

WP 6.2 renders author archives through an excerpt block. The saved value is still visible, but the excerpt strips the fixture element ID, which makes the selector check fail for the wrong reason.

The single post view keeps the fixture markup intact, so the test can still assert `#scf-test-user-title`.

See: https://github.com/WordPress/secure-custom-fields/actions/runs/27411753282/job/81014463675

## Testing Instructions

Not applicable; test-only change.

## Use of AI Tools

I used AI to review the test change.
