### PR TITLE
[codex] Reject remote docs output paths

### DIFF
--- a/docs/bin/generate-parsed-md.php
+++ b/docs/bin/generate-parsed-md.php
@@ -100,9 +100,9 @@ class DocGenerator {
 		$this->parser    = $parser_factory->create( ParserFactory::PREFER_PHP7 );
 		$this->traverser = new NodeTraverser();
 		$this->traverser->addVisitor( new NameResolver() );
-		$this->output_dir = rtrim( $output_dir, '/' );
+		$this->output_dir = $this->validate_output_dir( $output_dir );
 
-		// Clean up existing documentation
+		// Clean up existing documentation.
 		if ( is_dir( $this->output_dir ) ) {
 			$this->cleanup_directory( $this->output_dir );
 		}
@@ -110,6 +110,28 @@ class DocGenerator {
 		if ( ! is_dir( $this->output_dir ) ) {
 			mkdir( $this->output_dir, 0755, true );
 		}
+	}
+
+	/**
+	 * Validate and normalize the output directory path.
+	 *
+	 * @param string $output_dir Directory where documentation will be generated.
+	 * @return string Normalized output directory path.
+	 *
+	 * @throws \InvalidArgumentException If the output path is empty or not local.
+	 */
+	private function validate_output_dir( $output_dir ) {
+		$output_dir = trim( (string) $output_dir );
+
+		if ( '' === $output_dir ) {
+			throw new \InvalidArgumentException( 'Output directory must be a non-empty local filesystem path.' );
+		}
+
+		if ( preg_match( '#^[a-z][a-z0-9+.-]*://#i', $output_dir ) ) {
+			throw new \InvalidArgumentException( 'Output directory must be a local filesystem path.' );
+		}
+
+		return rtrim( $output_dir, '/' );
 	}
 
 	/**
@@ -743,8 +765,18 @@ class DocGenerator {
 	}
 }
 
-// Parse command line arguments
-$options    = getopt( '', array( 'output::' ) );
-$output_dir = isset( $options['output'] ) ? $options['output'] : __DIR__ . '/../code-reference';
-$generator  = new DocGenerator( $output_dir );
-$generator->generate();
+$is_cli_script = PHP_SAPI === 'cli' && isset( $argv[0] ) && __FILE__ === realpath( $argv[0] );
+
+if ( $is_cli_script ) {
+	// Parse command line arguments.
+	$options    = getopt( '', array( 'output::' ) );
+	$output_dir = isset( $options['output'] ) ? $options['output'] : __DIR__ . '/../code-reference';
+
+	try {
+		$generator = new DocGenerator( $output_dir );
+		$generator->generate();
+	} catch ( \InvalidArgumentException $e ) {
+		fwrite( STDERR, $e->getMessage() . PHP_EOL );
+		exit( 1 );
+	}
+}

--- a/tests/php/docs/test-generate-parsed-md.php
+++ b/tests/php/docs/test-generate-parsed-md.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Tests for docs parsed markdown generation.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for the docs parsed markdown generator.
+ */
+class Test_Generate_Parsed_MD extends BaseTestCase {
+	/**
+	 * Temporary output directory created during a test.
+	 *
+	 * @var string
+	 */
+	private $temp_dir;
+
+	/**
+	 * Clean up temporary fixtures.
+	 */
+	public function tear_down() {
+		if ( $this->temp_dir && is_dir( $this->temp_dir ) ) {
+			$this->remove_directory( $this->temp_dir );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Remote stream-wrapper output paths must be rejected before generation.
+	 */
+	public function test_rejects_remote_output_url() {
+		$result = $this->run_generator( 'https://example.com/scf-docs-test' );
+
+		$this->assertSame( 1, $result['status'] );
+		$this->assertStringContainsString( 'Output directory must be a local filesystem path.', $result['output'] );
+	}
+
+	/**
+	 * Local filesystem output directories remain supported.
+	 */
+	public function test_accepts_local_output_directory() {
+		$this->temp_dir = sys_get_temp_dir() . '/scf-docs-output-' . uniqid();
+
+		$result = $this->run_generator( $this->temp_dir );
+
+		$this->assertSame( 0, $result['status'], $result['output'] );
+		$this->assertDirectoryExists( $this->temp_dir );
+		$this->assertFileExists( $this->temp_dir . '/index.md' );
+	}
+
+	/**
+	 * Run the docs generator as a CLI script.
+	 *
+	 * @param string $output_dir Output directory argument.
+	 * @return array{status:int, output:string} Process result.
+	 */
+	private function run_generator( $output_dir ) {
+		$script      = dirname( __DIR__, 3 ) . '/docs/bin/generate-parsed-md.php';
+		$descriptors = array(
+			1 => array( 'pipe', 'w' ),
+			2 => array( 'pipe', 'w' ),
+		);
+
+		$process = proc_open( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_proc_open -- Test intentionally verifies CLI script behavior.
+			array( PHP_BINARY, $script, '--output=' . $output_dir ),
+			$descriptors,
+			$pipes,
+			dirname( __DIR__, 3 )
+		);
+
+		$this->assertIsResource( $process );
+
+		$output = stream_get_contents( $pipes[1] ) . stream_get_contents( $pipes[2] );
+
+		fclose( $pipes[1] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closing test process pipe.
+		fclose( $pipes[2] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closing test process pipe.
+
+		return array(
+			'status' => proc_close( $process ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_proc_close -- Test intentionally verifies CLI script behavior.
+			'output' => $output,
+		);
+	}
+
+	/**
+	 * Recursively remove a temporary directory.
+	 *
+	 * @param string $dir Directory path.
+	 */
+	private function remove_directory( $dir ) {
+		$files = array_diff( scandir( $dir ), array( '.', '..' ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_scandir -- Test fixture cleanup.
+
+		foreach ( $files as $file ) {
+			$path = $dir . '/' . $file;
+
+			if ( is_dir( $path ) ) {
+				$this->remove_directory( $path );
+			} else {
+				unlink( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Test fixture cleanup.
+			}
+		}
+
+		rmdir( $dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Test fixture cleanup.
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Secure Custom Fields (SCF)! Please have a look at the Contributing Guidelines:
https://github.com/WordPress/secure-custom-fields/blob/trunk/docs/contributing/index.md -->

## Summary
Hardens the parsed Markdown documentation generator so the `--output` argument must be a local filesystem path before any cleanup, directory creation, or write operations run.

Previously, URL-style output paths such as `https://example.com/scf-docs-test` were accepted. PHP treated those as stream-wrapper paths, the generator attempted repeated HTTP-wrapper writes, emitted warnings, and still exited successfully. This change rejects remote stream-wrapper output paths with a clear error and non-zero CLI status while preserving local filesystem output support.

The regression test exercises the generator as a CLI script instead of requiring it directly, matching the script's intended use and keeping the test compatible with PHP 7.4's namespace/shebang handling.

## Impact
This is repository/docs tooling hardening. The docs generator is not included in the release zip, but it should still fail safely before performing generated-output or cleanup work against a non-local target.

## Testing
- `npm run wp-env status` - reported the temp worktree environment was uninitialized.
- `npm run wp-env start` - attempted once, but local Docker startup failed because host port `8888` is already allocated.
- `composer test:php -- --filter Test_Generate_Parsed_MD` - passed.
- `composer test:php` - passed locally: `2833 tests, 21586 assertions`.
- `composer test:phpstan` - passed.
- `php docs/bin/generate-parsed-md.php --output=https://example.com/scf-docs-test` - now exits `1` with `Output directory must be a local filesystem path.`
- `vendor/bin/phpcs docs/bin/generate-parsed-md.php tests/php/docs/test-generate-parsed-md.php` - passed.
- `git diff --check` - passed.

No public issue. Follows the internal Low #19 docs tooling hardening item.

## Use of AI Tools
Codex was used to port the fix, run focused validation, address CI feedback, and draft this pull request. The final diff was inspected locally before pushing.