### PR TITLE
GitHub Actions: Update E2E matrix to WordPress 6.9

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
             matrix:
                 event: ['${{ github.event_name }}']
                 shard: [1, 2, 3, 4]
-                wp: ['6.2', '6.8', 'latest', 'trunk']
+                wp: ['6.2', '6.9', 'latest', 'trunk']
                 exclude:
                     # On PRs: Skip minimum supported WP version for faster feedback
                     - event: 'pull_request'


### PR DESCRIPTION
## What

Updates the E2E matrix from WordPress 6.8 to 6.9.