### PR TITLE
Hardening and code-quality improvements across fields, REST, and abilities

### DIFF
--- a/assets/src/js/pro/_acf-field-flexible-content.js
+++ b/assets/src/js/pro/_acf-field-flexible-content.js
@@ -1033,9 +1033,7 @@
 					) }</label>
                 </div>
                 <div class="acf-input">
-                  <input id="acf-new-layout-label" type="text" name="acf_new_layout_label" value="${ this.get(
-						'currentName'
-					) }">
+                  <input id="acf-new-layout-label" type="text" name="acf_new_layout_label" value="">
                 </div>
               </div>
               <div class="acf-actions">
@@ -1057,6 +1055,7 @@
 			acf.models.PopupConfirm.prototype.render.apply( this, arguments );
 			setTimeout( () => {
 				const $input = this.$el.find( 'input#acf-new-layout-label' );
+				$input.val( this.get( 'currentName' ) );
 				const textLength = $input.val().length;
 				$input.trigger( 'focus' );
 				$input[ 0 ].setSelectionRange( textLength, textLength );

--- a/includes/Blocks/Bindings.php
+++ b/includes/Blocks/Bindings.php
@@ -79,27 +79,38 @@ class Bindings {
 				}
 			}
 
+			$field_value = $field['value'];
+
 			switch ( $attribute_name ) {
 				case 'id':
 				case 'alt':
 				case 'title':
 					// The value is in the field of the same name.
-					$value = $field['value'][ $attribute_name ] ?? '';
+					$value = is_array( $field_value ) ? $field_value[ $attribute_name ] ?? '' : '';
 					break;
 				case 'url':
-					// The URL is the field value.
-					$value = $field['value']['url'] ?? $field['value'] ?? '';
+					if ( is_array( $field_value ) ) {
+						// The URL is in the array returned by media-like fields.
+						$value = $field_value['url'] ?? '';
+					} elseif ( is_scalar( $field_value ) || null === $field_value ) {
+						// Scalar URL-like fields use the field value directly.
+						$value = $field_value ?? '';
+					} else {
+						$value = '';
+					}
 					break;
 				case 'rel':
 					// Handle checkbox field for rel attribute by joining array values.
-					if ( is_array( $field['value'] ) ) {
-						$value = implode( ' ', $field['value'] );
+					if ( is_array( $field_value ) ) {
+						$value = implode( ' ', $field_value );
+					} elseif ( is_scalar( $field_value ) || null === $field_value ) {
+						$value = $field_value ?? '';
 					} else {
-						$value = $field['value'] ?? '';
+						$value = '';
 					}
 					break;
 				default:
-					$value = $field['value'];
+					$value = $field_value;
 
 					if ( is_array( $value ) ) {
 						$value = wp_json_encode( $value );

--- a/includes/abilities/class-scf-field-abilities.php
+++ b/includes/abilities/class-scf-field-abilities.php
@@ -128,6 +128,106 @@ if ( ! class_exists( 'SCF_Field_Abilities' ) ) :
 		}
 
 		/**
+		 * Gets all known field schema properties.
+		 *
+		 * The field schema may be either a direct object schema or a oneOf of
+		 * field type variants. Update inputs are partial, so they need the union
+		 * of known properties without requiring a complete field object.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @return array
+		 */
+		private function get_field_schema_properties() {
+			$field_schema = $this->get_field_schema();
+
+			if ( isset( $field_schema['definitions']['field'] ) ) {
+				$field_schema = $field_schema['definitions']['field'];
+			}
+
+			if ( isset( $field_schema['properties'] ) && is_array( $field_schema['properties'] ) ) {
+				return $field_schema['properties'];
+			}
+
+			$field_properties = array();
+			foreach ( $field_schema['oneOf'] ?? array() as $variant ) {
+				if ( isset( $variant['properties'] ) && is_array( $variant['properties'] ) ) {
+					$field_properties = $this->merge_field_schema_properties( $field_properties, $variant['properties'] );
+				}
+			}
+
+			return $field_properties;
+		}
+
+		/**
+		 * Merges field property schema maps while preserving enum/type variants.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param array $properties Existing property schema map.
+		 * @param array $next_properties Property schema map to merge in.
+		 * @return array
+		 */
+		private function merge_field_schema_properties( array $properties, array $next_properties ) {
+			foreach ( $next_properties as $property_name => $property_schema ) {
+				if ( ! isset( $properties[ $property_name ] ) || ! is_array( $properties[ $property_name ] ) || ! is_array( $property_schema ) ) {
+					$properties[ $property_name ] = $property_schema;
+					continue;
+				}
+
+				$properties[ $property_name ] = $this->merge_field_schema_property(
+					$properties[ $property_name ],
+					$property_schema
+				);
+			}
+
+			return $properties;
+		}
+
+		/**
+		 * Merges two schemas for the same field property.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param array $property_schema Existing property schema.
+		 * @param array $next_property_schema Property schema to merge in.
+		 * @return array
+		 */
+		private function merge_field_schema_property( array $property_schema, array $next_property_schema ) {
+			$merged = array_merge( $property_schema, $next_property_schema );
+
+			if ( isset( $property_schema['type'], $next_property_schema['type'] ) ) {
+				$merged['type'] = array_values(
+					array_unique(
+						array_merge(
+							(array) $property_schema['type'],
+							(array) $next_property_schema['type']
+						),
+						SORT_REGULAR
+					)
+				);
+			}
+
+			if ( isset( $property_schema['enum'], $next_property_schema['enum'] ) && is_array( $property_schema['enum'] ) && is_array( $next_property_schema['enum'] ) ) {
+				$merged['enum'] = array_values(
+					array_unique(
+						array_merge( $property_schema['enum'], $next_property_schema['enum'] ),
+						SORT_REGULAR
+					)
+				);
+			}
+
+			if ( isset( $property_schema['properties'], $next_property_schema['properties'] ) && is_array( $property_schema['properties'] ) && is_array( $next_property_schema['properties'] ) ) {
+				$merged['properties'] = $this->merge_field_schema_properties(
+					$property_schema['properties'],
+					$next_property_schema['properties']
+				);
+			}
+
+			return $merged;
+		}
+
+		/**
 		 * Gets the SCF identifier schema.
 		 *
 		 * @since 6.8.0
@@ -352,12 +452,7 @@ if ( ! class_exists( 'SCF_Field_Abilities' ) ) :
 		 * @since 6.8.0
 		 */
 		private function register_update_ability() {
-			// Get field properties from field schema.
-			$field_schema     = $this->get_field_schema();
-			$field_properties = array();
-			if ( isset( $field_schema['definitions']['field']['properties'] ) ) {
-				$field_properties = $field_schema['definitions']['field']['properties'];
-			}
+			$field_properties = $this->get_field_schema_properties();
 
 			wp_register_ability(
 				$this->ability_name( 'update' ),
@@ -377,9 +472,9 @@ if ( ! class_exists( 'SCF_Field_Abilities' ) ) :
 						),
 					),
 					'input_schema'        => array(
-						'type'       => 'object',
-						'required'   => array( 'ID' ),
-						'properties' => array_merge(
+						'type'                 => 'object',
+						'required'             => array( 'ID' ),
+						'properties'           => array_merge(
 							array(
 								'ID' => array(
 									'type'        => 'integer',
@@ -388,6 +483,7 @@ if ( ! class_exists( 'SCF_Field_Abilities' ) ) :
 							),
 							$field_properties
 						),
+						'additionalProperties' => false,
 					),
 					'output_schema'       => $this->get_field_with_internal_fields_schema(),
 				)

--- a/includes/abilities/class-scf-internal-post-type-abilities.php
+++ b/includes/abilities/class-scf-internal-post-type-abilities.php
@@ -735,19 +735,54 @@ if ( ! class_exists( 'SCF_Internal_Post_Type_Abilities' ) ) :
 				return $this->not_found_error();
 			}
 
-			$new_post_id = isset( $input['new_post_id'] ) ? $input['new_post_id'] : 0;
+			$new_post_id = isset( $input['new_post_id'] ) ? (int) $input['new_post_id'] : 0;
 
-			// Validate that new_post_id references an existing WordPress post.
-			if ( $new_post_id && ! get_post( $new_post_id ) ) {
-				return new WP_Error(
-					'invalid_new_post_id',
-					sprintf(
-						/* translators: %d: Invalid post ID */
-						__( 'Invalid new_post_id: %d does not exist.', 'secure-custom-fields' ),
-						$new_post_id
-					),
-					array( 'status' => 400 )
-				);
+			if ( $new_post_id ) {
+				if ( 0 > $new_post_id ) {
+					return new WP_Error(
+						'invalid_new_post_id',
+						__( 'Invalid new_post_id: ID must be a positive integer.', 'secure-custom-fields' ),
+						array( 'status' => 400 )
+					);
+				}
+
+				$target = get_post( $new_post_id );
+
+				if ( ! $target ) {
+					return new WP_Error(
+						'invalid_new_post_id',
+						sprintf(
+							/* translators: %d: Invalid post ID */
+							__( 'Invalid new_post_id: %d does not exist.', 'secure-custom-fields' ),
+							$new_post_id
+						),
+						array( 'status' => 400 )
+					);
+				}
+
+				if ( $target->post_type !== $this->internal_post_type ) {
+					return new WP_Error(
+						'invalid_new_post_id',
+						sprintf(
+							/* translators: %s: Entity type */
+							__( 'Invalid new_post_id: target must be an existing SCF %s.', 'secure-custom-fields' ),
+							$this->entity_name()
+						),
+						array( 'status' => 400 )
+					);
+				}
+
+				if ( ! current_user_can( 'edit_post', $new_post_id ) ) {
+					return new WP_Error(
+						'forbidden',
+						sprintf(
+							/* translators: %s: Entity type */
+							__( 'Insufficient permissions to overwrite this SCF %s.', 'secure-custom-fields' ),
+							$this->entity_name()
+						),
+						array( 'status' => 403 )
+					);
+				}
 			}
 
 			$duplicated = $this->instance()->duplicate_post( $input['identifier'], $new_post_id );

--- a/includes/api/api-helpers.php
+++ b/includes/api/api-helpers.php
@@ -3182,6 +3182,10 @@ function acf_translate( $string ) {
 		return $string;
 	}
 
+	if ( acf_get_setting( 'l10n_var_export' ) ) {
+		return "!!__(!!'{$string}!!', !!'{$textdomain}!!')!!";
+	}
+
 	// translate
 	return __( $string, $textdomain );
 }

--- a/includes/class-acf-internal-post-type.php
+++ b/includes/class-acf-internal-post-type.php
@@ -1,10 +1,18 @@
 <?php
+/**
+ * ACF internal post type base class.
+ *
+ * @package wordpress/secure-custom-fields
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
 if ( ! class_exists( 'ACF_Internal_Post_Type' ) ) {
+	/**
+	 * Base class for ACF-backed internal post types.
+	 */
 	abstract class ACF_Internal_Post_Type {
 
 
@@ -155,7 +163,7 @@ if ( ! class_exists( 'ACF_Internal_Post_Type' ) ) {
 			$raw_post['title']      = $post->post_title;
 			$raw_post['key']        = $post->post_name;
 			$raw_post['menu_order'] = $post->menu_order;
-			$raw_post['active']     = in_array( $post->post_status, array( 'publish', 'auto-draft' ) );
+			$raw_post['active']     = in_array( $post->post_status, array( 'publish', 'auto-draft' ), true );
 
 			return $raw_post;
 		}
@@ -184,7 +192,7 @@ if ( ! class_exists( 'ACF_Internal_Post_Type' ) ) {
 				$cache_key = $this->cache_key . $id;
 				$post_id   = wp_cache_get( $cache_key, 'secure-custom-fields' );
 
-				if ( $post_id === false ) {
+				if ( false === $post_id ) {
 					$query_key = 'acf_' . $this->post_key_prefix . 'key';
 
 					// Query posts.
@@ -394,7 +402,7 @@ if ( ! class_exists( 'ACF_Internal_Post_Type' ) ) {
 			$cache_key = acf_cache_key( $this->cache_key_plural );
 			$post_ids  = wp_cache_get( $cache_key, 'secure-custom-fields' ); // TODO: Do we need to change the group at all?
 
-			if ( $post_ids === false ) {
+			if ( false === $post_ids ) {
 
 				// Query posts.
 				$posts = get_posts(
@@ -718,6 +726,20 @@ if ( ! class_exists( 'ACF_Internal_Post_Type' ) ) {
 			// Disable filters to ensure ACF loads data from DB.
 			acf_disable_filters();
 
+			$new_post_id = (int) $new_post_id;
+
+			if ( 0 > $new_post_id ) {
+				return false;
+			}
+
+			if ( $new_post_id ) {
+				$target = get_post( $new_post_id );
+
+				if ( ! $target || $target->post_type !== $this->post_type ) {
+					return false;
+				}
+			}
+
 			$post = $this->get_post( $id );
 			if ( ! $post || ! $post['ID'] ) {
 				return false;
@@ -843,6 +865,8 @@ if ( ! class_exists( 'ACF_Internal_Post_Type' ) ) {
 		 * @return string
 		 */
 		public function export_post_as_php( $post = array() ) {
+			unset( $post );
+
 			return '';
 		}
 

--- a/includes/fields/class-acf-field-checkbox.php
+++ b/includes/fields/class-acf-field-checkbox.php
@@ -500,7 +500,7 @@ if ( ! class_exists( 'acf_field_checkbox' ) ) :
 			$value = acf_get_field_type( 'select' )->update_value( $value, $post_id, $field );
 
 			// save_other_choice
-			if ( $field['save_custom'] ) {
+			if ( $field['save_custom'] && scf_current_user_has_capability() ) {
 
 				// get raw $field (may have been changed via repeater field)
 				// if field is local, it won't have an ID

--- a/includes/fields/class-acf-field-flexible-content.php
+++ b/includes/fields/class-acf-field-flexible-content.php
@@ -993,6 +993,41 @@ if ( ! class_exists( 'acf_field_flexible_content' ) ) :
 		}
 
 		/**
+		 * Deletes any ACF row meta that belongs to the provided flexible content row.
+		 *
+		 * @since ACF 6.5
+		 *
+		 * @param integer $i       The index of the row to delete.
+		 * @param array   $field   The field array containing all settings.
+		 * @param mixed   $post_id The post ID where the value is saved.
+		 * @return boolean
+		 */
+		private function delete_row_meta_by_prefix( $i, $field, $post_id ) {
+			if ( empty( $field['name'] ) ) {
+				return false;
+			}
+
+			$meta = acf_get_meta( $post_id );
+			if ( empty( $meta ) || ! is_array( $meta ) ) {
+				return false;
+			}
+
+			$deleted = false;
+			$prefix  = "{$field['name']}_{$i}_";
+
+			foreach ( array_keys( $meta ) as $meta_name ) {
+				if ( 0 !== strpos( $meta_name, $prefix ) ) {
+					continue;
+				}
+
+				acf_delete_value( $post_id, array( 'name' => $meta_name ) );
+				$deleted = true;
+			}
+
+			return $deleted;
+		}
+
+		/**
 		 * This function will delete a value row
 		 *
 		 * @since   ACF 5.5.8
@@ -1017,7 +1052,7 @@ if ( ! class_exists( 'acf_field_flexible_content' ) ) :
 
 			// bail early if no layout
 			if ( ! $layout || empty( $layout['sub_fields'] ) ) {
-				return false;
+				return $this->delete_row_meta_by_prefix( $i, $field, $post_id );
 			}
 
 			// loop
@@ -1029,6 +1064,8 @@ if ( ! class_exists( 'acf_field_flexible_content' ) ) :
 				// delete value
 				acf_delete_value( $post_id, $sub_field );
 			}
+
+			$this->delete_row_meta_by_prefix( $i, $field, $post_id );
 
 			// return
 			return true;
@@ -1134,7 +1171,7 @@ if ( ! class_exists( 'acf_field_flexible_content' ) ) :
 					unset( $row['acf_fc_layout_disabled'] );
 
 					if ( ! empty( $row['acf_fc_layout_custom_label'] ) ) {
-						$renamed_layouts[ $i ] = $row['acf_fc_layout_custom_label'];
+						$renamed_layouts[ $i ] = sanitize_text_field( $row['acf_fc_layout_custom_label'] );
 					}
 					unset( $row['acf_fc_layout_custom_label'] );
 

--- a/includes/fields/class-acf-field-nav-menu.php
+++ b/includes/fields/class-acf-field-nav-menu.php
@@ -151,7 +151,7 @@ if ( ! class_exists( 'Acf_Field_Nav_Menu' ) ) :
 			}
 
 			?>
-				<select id="<?php esc_attr( $field['id'] ); ?>" class="<?php echo esc_attr( $field['class'] ); ?>" name="<?php echo esc_attr( $field['name'] ); ?>">
+				<select id="<?php echo esc_attr( $field['id'] ); ?>" class="<?php echo esc_attr( $field['class'] ); ?>" name="<?php echo esc_attr( $field['name'] ); ?>">
 					<?php
 					if ( $allow_null ) {
 						?>

--- a/includes/fields/class-acf-field-radio.php
+++ b/includes/fields/class-acf-field-radio.php
@@ -337,7 +337,7 @@ if ( ! class_exists( 'acf_field_radio' ) ) :
 			}
 
 			// save_other_choice
-			if ( $field['save_other_choice'] ) {
+			if ( $field['save_other_choice'] && scf_current_user_has_capability() ) {
 
 				// value isn't in choices yet
 				if ( ! isset( $field['choices'][ $value ] ) ) {

--- a/includes/fields/class-acf-field-select.php
+++ b/includes/fields/class-acf-field-select.php
@@ -586,7 +586,7 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 			}
 
 			// Save custom options back to the field definition if configured.
-			if ( ! empty( $field['save_options'] ) && is_array( $value ) ) {
+			if ( ! empty( $field['save_options'] ) && is_array( $value ) && scf_current_user_has_capability() ) {
 				// Get the raw field, using the ID if present or the key otherwise (i.e. when using JSON).
 				$selector = $field['ID'] ? $field['ID'] : $field['key'];
 				$field    = acf_get_field( $selector );

--- a/includes/forms/WC_Order.php
+++ b/includes/forms/WC_Order.php
@@ -255,6 +255,21 @@ class WC_Order {
 		if ( ! $this->is_hpos_enabled() ) {
 			return;
 		}
+
+		if (
+			! is_admin()
+			|| ! current_user_can( 'edit_shop_orders' ) // phpcs:ignore WordPress.WP.Capabilities.Unknown -- WooCommerce capability.
+			|| ! acf_verify_nonce( 'post' )
+		) {
+			return;
+		}
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Verified above with acf_verify_nonce().
+		if ( empty( $_POST['acf'] ) ) {
+			return;
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
 		// Remove the action to prevent an infinite loop via $order->save().
 		remove_action( 'woocommerce_update_order', array( $this, 'save_order' ), 10 );
 		acf_save_post( 'woo_order_' . $order_id );

--- a/includes/rest-api/class-acf-rest-api.php
+++ b/includes/rest-api/class-acf-rest-api.php
@@ -231,15 +231,18 @@ class ACF_Rest_Api {
 				}
 
 				// Format the field value according to the request params.
-				$format     = $request->get_param( 'acf_format' ) ? $request->get_param( 'acf_format' ) : acf_get_setting( 'rest_api_format' );
-				$rest_value = acf_format_value_for_rest( $value, $post_id, $field, $format );
+				$format                 = $request->get_param( 'acf_format' ) ? $request->get_param( 'acf_format' ) : acf_get_setting( 'rest_api_format' );
+				$rest_value             = acf_format_value_for_rest( $value, $post_id, $field, $format );
+				$source_formatted_value = ( 'oembed' === $field['type'] && 'standard' !== $format )
+					? $rest_value
+					: acf_format_value( $value, $post_id, $field );
 
 				// We keep this one for backward compatibility with existing code that expects the field value to be.
 				$fields[ $field['name'] ]             = $rest_value;
 				$fields[ $field['name'] . '_source' ] = array(
 					'label'           => $field['label'],
 					'type'            => $field['type'],
-					'formatted_value' => acf_format_value( $value, $post_id, $field ),
+					'formatted_value' => $source_formatted_value,
 				);
 			}
 		}

--- a/includes/rest-api/class-acf-rest-types-endpoint.php
+++ b/includes/rest-api/class-acf-rest-types-endpoint.php
@@ -55,6 +55,25 @@ class SCF_Rest_Types_Endpoint {
 	}
 
 	/**
+	 * Checks whether the matched REST route permits the request.
+	 *
+	 * @since SCF 6.8.0
+	 *
+	 * @param array           $handler The matched REST route handler.
+	 * @param WP_REST_Request $request The request object.
+	 * @return bool True when the route permission callback allows the request.
+	 */
+	private function request_has_permission( $handler, $request ) {
+		if ( empty( $handler['permission_callback'] ) || ! is_callable( $handler['permission_callback'] ) ) {
+			return true;
+		}
+
+		$permission = call_user_func( $handler['permission_callback'], $request );
+
+		return ! is_wp_error( $permission ) && false !== $permission && null !== $permission;
+	}
+
+	/**
 	 * Filter post types requests for individual post type requests.
 	 *
 	 * @since SCF 6.5.0
@@ -76,6 +95,10 @@ class SCF_Rest_Types_Endpoint {
 
 		// Only proceed if source parameter is provided and valid
 		if ( ! $source || ! $this->is_valid_source( $source ) ) {
+			return $response;
+		}
+
+		if ( ! $this->request_has_permission( $handler, $request ) ) {
 			return $response;
 		}
 
@@ -175,6 +198,10 @@ class SCF_Rest_Types_Endpoint {
 	 * @return void
 	 */
 	public function register_extra_fields() {
+		if ( ! acf_get_setting( 'rest_api_enabled' ) ) {
+			return;
+		}
+
 		register_rest_field(
 			'type',
 			'scf_field_groups',
@@ -208,6 +235,10 @@ class SCF_Rest_Types_Endpoint {
 	 * @return array Array of field data.
 	 */
 	public function get_scf_fields( $post_type_object ) {
+		if ( ! scf_current_user_has_capability() ) {
+			return array();
+		}
+
 		$post_type         = $post_type_object['slug'];
 		$field_groups      = acf_get_field_groups( array( 'post_type' => $post_type ) );
 		$field_groups_data = array();
@@ -311,7 +342,7 @@ class SCF_Rest_Types_Endpoint {
 					),
 				),
 			),
-			'context'     => array( 'view', 'edit', 'embed' ),
+			'context'     => array( 'edit' ),
 		);
 	}
 

--- a/tests/php/includes/forms/test-form-wc-order.php
+++ b/tests/php/includes/forms/test-form-wc-order.php
@@ -15,6 +15,12 @@ require_once __DIR__ . '/wc-order-test-functions.php';
  * Class Test_Form_WC_Order
  */
 class Test_Form_WC_Order extends BaseTestCase {
+	/**
+	 * User IDs created during a test.
+	 *
+	 * @var int[]
+	 */
+	private $user_ids = array();
 
 	/**
 	 * Tear down after each test.
@@ -25,6 +31,18 @@ class Test_Form_WC_Order extends BaseTestCase {
 		// Clean up any filters/actions we added.
 		remove_all_filters( 'acf/input/meta_box_priority' );
 		remove_all_actions( 'acf/add_meta_boxes' );
+
+		foreach ( $this->user_ids as $user_id ) {
+			wp_delete_user( $user_id );
+		}
+		$this->user_ids = array();
+
+		unset( $_POST['acf'], $_POST['_acf_nonce'] );
+		wp_set_current_user( 0 );
+
+		global $current_screen;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Resetting globals in test teardown.
+		$current_screen = null;
 
 		parent::tear_down();
 	}
@@ -388,15 +406,101 @@ class Test_Form_WC_Order extends BaseTestCase {
 	}
 
 	/**
+	 * Test save_order does not save outside the admin order screen.
+	 */
+	public function test_save_order_requires_admin_context() {
+		$wc_order = $this->get_hpos_enabled_order_form();
+		$this->set_order_manager_user();
+		$this->set_valid_acf_order_payload();
+
+		$saved_post_id = null;
+		$save_hook     = function ( $post_id ) use ( &$saved_post_id ) {
+			$saved_post_id = $post_id;
+		};
+		add_action( 'acf/save_post', $save_hook );
+
+		$wc_order->save_order( 123 );
+
+		remove_action( 'acf/save_post', $save_hook );
+
+		$this->assertNull( $saved_post_id, 'ACF order fields should not save outside admin context.' );
+	}
+
+	/**
+	 * Test save_order requires the shop order editing capability.
+	 */
+	public function test_save_order_requires_shop_order_capability() {
+		$wc_order = $this->get_hpos_enabled_order_form();
+		set_current_screen( 'woocommerce_page_wc-orders' );
+		$this->set_order_manager_user( false );
+		$this->set_valid_acf_order_payload();
+
+		$saved_post_id = null;
+		$save_hook     = function ( $post_id ) use ( &$saved_post_id ) {
+			$saved_post_id = $post_id;
+		};
+		add_action( 'acf/save_post', $save_hook );
+
+		$wc_order->save_order( 123 );
+
+		remove_action( 'acf/save_post', $save_hook );
+
+		$this->assertNull( $saved_post_id, 'Users without edit_shop_orders must not save ACF order fields.' );
+	}
+
+	/**
+	 * Test save_order requires an ACF post nonce.
+	 */
+	public function test_save_order_requires_acf_nonce() {
+		$wc_order = $this->get_hpos_enabled_order_form();
+		set_current_screen( 'woocommerce_page_wc-orders' );
+		$this->set_order_manager_user();
+		$_POST['acf'] = array( 'field_test_wc_order' => 'Injected value' );
+
+		$saved_post_id = null;
+		$save_hook     = function ( $post_id ) use ( &$saved_post_id ) {
+			$saved_post_id = $post_id;
+		};
+		add_action( 'acf/save_post', $save_hook );
+
+		$wc_order->save_order( 123 );
+
+		remove_action( 'acf/save_post', $save_hook );
+
+		$this->assertNull( $saved_post_id, 'ACF order fields should not save without a valid ACF nonce.' );
+	}
+
+	/**
+	 * Test save_order saves ACF fields for authorized admin order edits.
+	 */
+	public function test_save_order_saves_for_authorized_admin_order_edit() {
+		$wc_order = $this->get_hpos_enabled_order_form();
+		set_current_screen( 'woocommerce_page_wc-orders' );
+		$this->set_order_manager_user();
+		$this->set_valid_acf_order_payload();
+
+		$saved_post_id = null;
+		$save_hook     = function ( $post_id ) use ( &$saved_post_id ) {
+			$saved_post_id = $post_id;
+		};
+		add_action( 'acf/save_post', $save_hook );
+
+		$wc_order->save_order( 123 );
+
+		remove_action( 'acf/save_post', $save_hook );
+
+		$this->assertSame( 'woo_order_123', $saved_post_id, 'Authorized admin order edits should save ACF order fields.' );
+	}
+
+	/**
 	 * Test save_order removes action to prevent infinite loop.
 	 */
 	public function test_save_order_removes_action_to_prevent_loop() {
 		// Create a partial mock to control is_hpos_enabled.
-		$wc_order = $this->getMockBuilder( WC_Order::class )
-			->onlyMethods( array( 'is_hpos_enabled' ) )
-			->getMock();
-
-		$wc_order->method( 'is_hpos_enabled' )->willReturn( true );
+		$wc_order = $this->get_hpos_enabled_order_form();
+		set_current_screen( 'woocommerce_page_wc-orders' );
+		$this->set_order_manager_user();
+		$this->set_valid_acf_order_payload();
 
 		// Add the action first.
 		add_action( 'woocommerce_update_order', array( $wc_order, 'save_order' ), 10 );
@@ -412,6 +516,57 @@ class Test_Form_WC_Order extends BaseTestCase {
 			has_action( 'woocommerce_update_order', array( $wc_order, 'save_order' ) ),
 			'save_order should remove itself to prevent infinite loop'
 		);
+	}
+
+	/**
+	 * Get a WC order form mock with HPOS enabled.
+	 *
+	 * @return WC_Order
+	 */
+	private function get_hpos_enabled_order_form() {
+		$wc_order = $this->getMockBuilder( WC_Order::class )
+			->onlyMethods( array( 'is_hpos_enabled' ) )
+			->getMock();
+
+		$wc_order->method( 'is_hpos_enabled' )->willReturn( true );
+
+		return $wc_order;
+	}
+
+	/**
+	 * Set the current user to a test user.
+	 *
+	 * @param bool $can_edit_orders Whether the user should have edit_shop_orders.
+	 * @return int The user ID.
+	 */
+	private function set_order_manager_user( $can_edit_orders = true ) {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'wc_order_user_' . uniqid(),
+				'user_pass'  => 'password',
+				'user_email' => 'wc-order-user-' . uniqid() . '@example.com',
+				'role'       => 'subscriber',
+			)
+		);
+
+		$this->user_ids[] = $user_id;
+		$user             = get_user_by( 'id', $user_id );
+
+		if ( $can_edit_orders ) {
+			$user->add_cap( 'edit_shop_orders' );
+		}
+
+		wp_set_current_user( $user_id );
+
+		return $user_id;
+	}
+
+	/**
+	 * Set a valid ACF order save payload.
+	 */
+	private function set_valid_acf_order_payload() {
+		$_POST['_acf_nonce'] = wp_create_nonce( 'post' );
+		$_POST['acf']        = array( 'field_test_wc_order' => 'Saved value' );
 	}
 
 	/**

--- a/tests/php/includes/test-scf-ui-options-page-functions.php
+++ b/tests/php/includes/test-scf-ui-options-page-functions.php
@@ -645,8 +645,16 @@ class Test_SCF_UI_Options_Page_Functions extends BaseTestCase {
 	public function test_duplicate_ui_options_page_skips_copy_suffix_with_new_post_id() {
 		$original       = acf_get_ui_options_page( $this->options_page_id );
 		$original_title = $original['title'];
+		$target_post_id = wp_insert_post(
+			array(
+				'post_type'   => 'acf-ui-options-page',
+				'post_title'  => 'Target Options Page',
+				'post_status' => 'publish',
+				'post_name'   => 'ui_options_page_target_' . uniqid(),
+			)
+		);
 
-		$result = acf_duplicate_ui_options_page( $this->options_page_id, 999 );
+		$result = acf_duplicate_ui_options_page( $this->options_page_id, $target_post_id );
 
 		$this->assertIsArray( $result, 'Should return an array' );
 		$this->assertEquals(


### PR DESCRIPTION
This PR groups a set of defensive hardening and code-quality refactors across
field types, the REST layer, the Abilities API, and form integrations.

- Validate duplicate target IDs, type, and ownership in internal post-type duplication
- Constrain the field update ability input schema (reject unknown properties, union variant props)
- Normalize non-scalar block-binding attribute values
- Gate custom choice persistence behind capability checks (checkbox/radio/select)
- Sanitize flexible-content layout labels and remove orphaned row meta on layout removal
- Gate REST type field-group metadata by capability and REST setting, honor route
  permissions before source filtering, and restrict context to `edit`
- Guard oEmbed REST source value formatting
- Require authentication and nonce before saving field data on WooCommerce orders
- Render the nav-menu field ID attribute
- Preserve l10n wrappers in PHP exports

## Use of AI Tools

Authored with assistance from Claude Code (Anthropic). All changes were reviewed
by a human contributor, and the full PHPUnit, Jest, and PHPStan suites pass locally.
