### PR TITLE
Docs: Update WP requirements to 6.2

### DIFF
--- a/docs/welcome/index.md
+++ b/docs/welcome/index.md
@@ -26,6 +26,6 @@ The [Code Reference](../code-reference/) provides detailed technical documentati
 
 ## Prerequisites
 
-- WordPress 6.0 or later
+- WordPress 6.2 or later
 - PHP 7.4 or later
 - Basic understanding of WordPress development

--- a/docs/welcome/installation.md
+++ b/docs/welcome/installation.md
@@ -6,7 +6,7 @@ This guide walks you through installing Secure Custom Fields (SCF) on your WordP
 
 Before installing, ensure your site meets these requirements:
 
-- WordPress 6.0 or later
+- WordPress 6.2 or later
 - PHP 7.4 or later
 - WordPress memory limit of 40MB or greater (64MB recommended)
 


### PR DESCRIPTION
The plugin currently requires WordPress 6.2 or later but the document says 6.0 or later.

I updated the document to match the current requirements.

## Use of AI Tools

None