### PR TITLE
Harden user-contributed choice saving and WooCommerce order saves

### DIFF
--- a/includes/fields/class-acf-field-checkbox.php
+++ b/includes/fields/class-acf-field-checkbox.php
@@ -477,20 +477,18 @@ if ( ! class_exists( 'acf_field_checkbox' ) ) :
 
 
 		/**
-		 * This filter is applied to the $value before it is updated in the db
+		 * Filters the $value before it is updated in the db.
 		 *
-		 * @type    filter
 		 * @since   ACF 3.6
 		 * @date    23/01/13
 		 *
-		 * @param   $value - the value which will be saved in the database
-		 * @param   $post_id - the post_id of which the value will be saved
-		 * @param   $field - the field array holding all the field options
+		 * @param mixed          $value   The value which will be saved in the database.
+		 * @param integer|string $post_id The post_id of which the value will be saved.
+		 * @param array          $field   The field array holding all the field options.
 		 *
-		 * @return  $value - the modified value
+		 * @return mixed
 		 */
 		function update_value( $value, $post_id, $field ) {
-
 			// bail early if is empty
 			if ( empty( $value ) ) {
 				return $value;
@@ -499,7 +497,7 @@ if ( ! class_exists( 'acf_field_checkbox' ) ) :
 			// select -> update_value()
 			$value = acf_get_field_type( 'select' )->update_value( $value, $post_id, $field );
 
-			// save_other_choice
+			// save_custom
 			if ( $field['save_custom'] && scf_current_user_has_capability() ) {
 
 				// get raw $field (may have been changed via repeater field)
@@ -515,26 +513,7 @@ if ( ! class_exists( 'acf_field_checkbox' ) ) :
 					return $value;
 				}
 
-				// loop
-				foreach ( $value as $v ) {
-
-					// ignore if already exists
-					if ( isset( $field['choices'][ $v ] ) ) {
-						continue;
-					}
-
-					// unslash (fixes serialize single quote issue)
-					$v = wp_unslash( $v );
-
-					// sanitize (remove tags)
-					$v = sanitize_text_field( $v );
-
-					// append
-					$field['choices'][ $v ] = $v;
-				}
-
-				// save
-				acf_update_field( $field );
+				acf_get_field_type( 'select' )->append_user_choices_to_field( $value, $post_id, $field );
 			}
 
 			// return

--- a/includes/fields/class-acf-field-radio.php
+++ b/includes/fields/class-acf-field-radio.php
@@ -358,6 +358,14 @@ if ( ! class_exists( 'acf_field_radio' ) ) :
 					// sanitize (remove tags)
 					$value = sanitize_text_field( $value );
 
+					/** This filter is documented in includes/fields/class-acf-field-select.php */
+					$max = (int) apply_filters( 'acf/fields/max_appended_choices', 1000, $field, $post_id );
+
+					// bail if the cap is reached; the normalized value still saves
+					if ( count( $field['choices'] ) >= $max ) {
+						return $value;
+					}
+
 					// update $field
 					$field['choices'][ $value ] = $value;
 

--- a/includes/fields/class-acf-field-select.php
+++ b/includes/fields/class-acf-field-select.php
@@ -596,23 +596,77 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 					return $value;
 				}
 
-				foreach ( $value as $v ) {
-					// Ignore if the option already exists.
-					if ( isset( $field['choices'][ $v ] ) ) {
-						continue;
-					}
-
-					// Unslash (fixes serialize single quote issue) and sanitize.
-					$v = wp_unslash( $v );
-					$v = sanitize_text_field( $v );
-
-					// Append to the field choices.
-					$field['choices'][ $v ] = $v;
-				}
-
-				acf_update_field( $field );
+				$this->append_user_choices_to_field( $value, $post_id, $field );
 			}
 			return $value;
+		}
+
+		/**
+		 * Appends submitter-contributed values to a persisted field's `choices`
+		 * array, subject to the `acf/fields/max_appended_choices` cap. Used by
+		 * checkbox `save_custom` and select `save_options`. Callers must have
+		 * already verified that the setting is enabled and that the field has
+		 * an ID (i.e. it's not local/JSON-only).
+		 *
+		 * @internal Helper for SCF's choice field types; not intended for
+		 *           external callers. Signature may change without notice.
+		 *
+		 * @since ACF 6.8.5
+		 *
+		 * @param array          $value   Submitted values.
+		 * @param integer|string $post_id The post_id of which the value will be saved.
+		 * @param array          $field   The persisted field array. Must have an ID.
+		 * @return void
+		 */
+		public function append_user_choices_to_field( $value, $post_id, $field ) {
+			/**
+			 * Filters the maximum number of choices that may be stored on a field
+			 * via the checkbox `save_custom`, radio `save_other_choice`, and select
+			 * `save_options` settings. Once reached, additional submitter-contributed
+			 * values are not appended to the field definition. The submitter's own
+			 * field value still saves to their post.
+			 *
+			 * @since ACF 6.8.5
+			 *
+			 * @param int            $max     Maximum number of choices. Default 1000.
+			 * @param array          $field   The field array holding all the field options.
+			 * @param integer|string $post_id The post_id of which the value will be saved.
+			 */
+			$max = (int) apply_filters( 'acf/fields/max_appended_choices', 1000, $field, $post_id );
+
+			$appended = false;
+
+			foreach ( $value as $v ) {
+				// Skip if the raw submitted value matches an existing key,
+				// preserving back-compat for fields whose choices contain
+				// un-normalized keys (e.g. developer-registered with HTML).
+				if ( isset( $field['choices'][ $v ] ) ) {
+					continue;
+				}
+
+				// Unslash (fixes serialize single quote issue) and sanitize.
+				$v = wp_unslash( $v );
+				$v = sanitize_text_field( $v );
+
+				// Skip if the normalized value is empty or already exists.
+				if ( $v === '' || isset( $field['choices'][ $v ] ) ) {
+					continue;
+				}
+
+				// Stop appending once the cap is reached.
+				if ( count( $field['choices'] ) >= $max ) {
+					break;
+				}
+
+				// Append to the field choices.
+				$field['choices'][ $v ] = $v;
+				$appended               = true;
+			}
+
+			// Save only if we actually appended a new choice.
+			if ( $appended ) {
+				acf_update_field( $field );
+			}
 		}
 
 

--- a/includes/forms/WC_Order.php
+++ b/includes/forms/WC_Order.php
@@ -22,7 +22,6 @@ class WC_Order {
 	 */
 	public function __construct() {
 		add_action( 'load-woocommerce_page_wc-orders', array( $this, 'initialize' ) );
-		add_action( 'woocommerce_update_order', array( $this, 'save_order' ), 10, 1 );
 		// Defer registering other order type hooks to after all order types are registered
 		add_action( 'wp_loaded', array( $this, 'register_order_type_hooks' ) );
 	}
@@ -38,6 +37,8 @@ class WC_Order {
 	public function initialize() {
 		acf_enqueue_scripts( array( 'uploader' => true ) );
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 10, 2 );
+		// Only attach the save handler on order edit screens.
+		add_action( 'woocommerce_update_order', array( $this, 'save_order' ), 10, 1 );
 	}
 
 	/**

--- a/tests/php/includes/fields/test-class-acf-field-select.php
+++ b/tests/php/includes/fields/test-class-acf-field-select.php
@@ -296,4 +296,113 @@ class Test_ACF_Field_Select extends Abstract_ACF_Field_Test {
 
 		$this->assertSame( '', $result );
 	}
+
+	/**
+	 * Get a persisted select field for append_user_choices_to_field tests.
+	 *
+	 * @param array $overrides Optional field configuration overrides.
+	 * @return array The field array with a real acf-field post ID.
+	 */
+	protected function get_persisted_field( $overrides = array() ) {
+		$field       = $this->get_field( $overrides );
+		$field['ID'] = wp_insert_post(
+			array(
+				'post_title'  => $field['label'],
+				'post_name'   => $field['key'],
+				'post_type'   => 'acf-field',
+				'post_status' => 'publish',
+			)
+		);
+
+		return $field;
+	}
+
+	/**
+	 * Capture the field passed to acf_update_field via the acf/update_field filter.
+	 *
+	 * @param array|null $captured Set by reference to the saved field array.
+	 * @return void
+	 */
+	protected function capture_updated_field( &$captured ) {
+		add_filter(
+			'acf/update_field',
+			function ( $field ) use ( &$captured ) {
+				$captured = $field;
+				return $field;
+			}
+		);
+	}
+
+	/**
+	 * Test append_user_choices_to_field appends new sanitized choices and saves the field.
+	 */
+	public function test_append_user_choices_appends_and_saves() {
+		$field    = $this->get_persisted_field();
+		$captured = null;
+		$this->capture_updated_field( $captured );
+
+		$this->field_instance->append_user_choices_to_field( array( 'purple', '<script>alert(1)</script>orange' ), $this->post_id, $field );
+
+		$this->assertIsArray( $captured, 'acf_update_field should be called when a choice is appended' );
+		$this->assertArrayHasKey( 'purple', $captured['choices'] );
+		$this->assertArrayHasKey( 'orange', $captured['choices'], 'Appended choices should be sanitized with sanitize_text_field' );
+		$this->assertArrayNotHasKey( '<script>alert(1)</script>orange', $captured['choices'] );
+	}
+
+	/**
+	 * Test append_user_choices_to_field does not save when all values are duplicates or empty.
+	 */
+	public function test_append_user_choices_skips_duplicates_and_empty() {
+		$field    = $this->get_persisted_field();
+		$captured = null;
+		$this->capture_updated_field( $captured );
+
+		$this->field_instance->append_user_choices_to_field( array( 'red', '', '<b></b>' ), $this->post_id, $field );
+
+		$this->assertNull( $captured, 'acf_update_field should not be called when nothing new is appended' );
+	}
+
+	/**
+	 * Test the acf/fields/max_appended_choices cap stops appending new choices.
+	 */
+	public function test_append_user_choices_respects_max_appended_choices() {
+		// The base field already has 3 choices; cap at 4 so only one more fits.
+		add_filter(
+			'acf/fields/max_appended_choices',
+			function () {
+				return 4;
+			}
+		);
+
+		$field    = $this->get_persisted_field();
+		$captured = null;
+		$this->capture_updated_field( $captured );
+
+		$this->field_instance->append_user_choices_to_field( array( 'purple', 'orange' ), $this->post_id, $field );
+
+		$this->assertIsArray( $captured );
+		$this->assertArrayHasKey( 'purple', $captured['choices'] );
+		$this->assertArrayNotHasKey( 'orange', $captured['choices'], 'Choices beyond the max_appended_choices cap should not be appended' );
+		$this->assertCount( 4, $captured['choices'] );
+	}
+
+	/**
+	 * Test no choices are appended when the field is already at the cap.
+	 */
+	public function test_append_user_choices_at_cap_does_not_save() {
+		add_filter(
+			'acf/fields/max_appended_choices',
+			function () {
+				return 3;
+			}
+		);
+
+		$field    = $this->get_persisted_field();
+		$captured = null;
+		$this->capture_updated_field( $captured );
+
+		$this->field_instance->append_user_choices_to_field( array( 'purple' ), $this->post_id, $field );
+
+		$this->assertNull( $captured, 'acf_update_field should not be called when the cap is already reached' );
+	}
 }

--- a/tests/php/includes/forms/test-form-wc-order.php
+++ b/tests/php/includes/forms/test-form-wc-order.php
@@ -73,9 +73,9 @@ class Test_Form_WC_Order extends BaseTestCase {
 			'Should register initialize action for base WC orders page'
 		);
 
-		$this->assertNotFalse(
+		$this->assertFalse(
 			has_action( 'woocommerce_update_order', array( $wc_order, 'save_order' ) ),
-			'Should register save_order action'
+			'Should not register save_order until an order edit screen loads'
 		);
 
 		$this->assertNotFalse(
@@ -262,7 +262,7 @@ class Test_Form_WC_Order extends BaseTestCase {
 	}
 
 	/**
-	 * Test initialize method adds correct action.
+	 * Test initialize method adds correct actions.
 	 */
 	public function test_initialize_adds_meta_boxes_action() {
 		$wc_order = new WC_Order();
@@ -278,6 +278,14 @@ class Test_Form_WC_Order extends BaseTestCase {
 			has_action( 'add_meta_boxes', array( $wc_order, 'add_meta_boxes' ) ),
 			'initialize should add add_meta_boxes action'
 		);
+
+		// Check that the save handler is attached on the order edit screen.
+		$this->assertNotFalse(
+			has_action( 'woocommerce_update_order', array( $wc_order, 'save_order' ) ),
+			'initialize should add save_order action'
+		);
+
+		remove_action( 'woocommerce_update_order', array( $wc_order, 'save_order' ), 10 );
 	}
 
 	/**


### PR DESCRIPTION
Security hardening for choice-type fields and the WooCommerce order save flow.

### Changes
- **Choice-append cap**: adds an `acf/fields/max_appended_choices` filter (default 1000) limiting the number of user-contributed choices that can be persisted to checkbox (`save_custom`), radio (`save_other_choice`), and select (`save_options`) field definitions. A malicious or misbehaving submitter can no longer grow a field definition without bound; the submitter's own field value still saves normally once the cap is reached.
- **Shared helper**: the append/sanitize loops previously duplicated in the checkbox and select field types are consolidated into a single `append_user_choices_to_field()` helper on the select field type, with the checkbox field delegating to it. The existing `scf_current_user_has_capability()` guards are preserved, values are sanitized with `sanitize_text_field()`, and the field is only re-saved when a new choice was actually appended.
- **WooCommerce order saves**: the `woocommerce_update_order` save handler is now attached from `initialize()` (order edit screens only) rather than the class constructor, so it is not registered on unrelated requests.

### Testing
- New PHPUnit tests cover the helper: append + sanitization, duplicate/empty skipping, cap enforcement via the filter, and no-save when already at the cap
- WC_Order tests updated for the new hook registration point
- `phpcs-changed` (as run in CI) reports no new violations; PHPStan unchanged

Closes N/A — proactive security hardening.

## Use of AI Tools

This PR was authored with Claude Code (Claude Fable 5), including the implementation and tests. All changes were reviewed and validated locally with the project's PHPUnit/PHPCS/PHPStan tooling.