### PR TITLE
Fix lossy float-to-int cast deprecations on PHP 8.5

### DIFF
--- a/bin/generate-field-schema.php
+++ b/bin/generate-field-schema.php
@@ -14,7 +14,7 @@
  * @package SCF
  */
 
-$check_mode = in_array( '--check', $argv, true );
+$check_mode = isset( $argv ) && in_array( '--check', $argv, true );
 
 // Bootstrap minimal SCF environment.
 define( 'ABSPATH', dirname( __DIR__ ) . '/' );

--- a/includes/acf-wp-functions.php
+++ b/includes/acf-wp-functions.php
@@ -126,7 +126,7 @@ function acf_decode_post_id( $post_id = 0 ) {
 	// Interpret numeric value (123).
 	if ( is_numeric( $post_id ) ) {
 		$type = 'post';
-		$id   = $post_id;
+		$id   = scf_numeric_to_int( $post_id );
 
 		// Interpret string value ("user_123" or "option").
 	} elseif ( is_string( $post_id ) ) {

--- a/includes/api/api-helpers.php
+++ b/includes/api/api-helpers.php
@@ -2286,7 +2286,7 @@ function acf_get_post_id_info( $post_id = 0 ) {
 	// if( acf_isset_cache($cache_key) ) return acf_get_cache($cache_key);
 	// numeric
 	if ( is_numeric( $post_id ) ) {
-		$info['id'] = (int) $post_id;
+		$info['id'] = scf_numeric_to_int( $post_id );
 
 		// string
 	} elseif ( is_string( $post_id ) ) {
@@ -2767,6 +2767,23 @@ function acf_current_user_can_admin() {
  */
 function scf_current_user_has_capability() {
 	return current_user_can( acf_get_setting( 'capability' ) );
+}
+
+/**
+ * Casts a numeric value to an integer, returning 0 for floats that cannot
+ * be represented as an integer (NAN or outside the integer range). Casting
+ * such floats directly raises a deprecation notice on PHP 8.5+.
+ *
+ * @since 6.9.1
+ *
+ * @param mixed $value A numeric value (int, float, or numeric string).
+ * @return integer
+ */
+function scf_numeric_to_int( $value ) {
+	if ( is_float( $value ) && ( is_nan( $value ) || $value < (float) PHP_INT_MIN || $value >= (float) PHP_INT_MAX ) ) {
+		return 0;
+	}
+	return (int) $value;
 }
 
 /**


### PR DESCRIPTION
PHP 8.5 raises a deprecation notice when explicitly casting a float that is not representable as an integer (NAN, INF, or outside the integer range). `acf_decode_post_id()` and `acf_get_post_id_info()` cast numeric `$post_id` input directly, so such input triggered deprecation notices on PHP 8.5 — and failures in the post-ID fuzz suite, which promotes deprecations to exceptions.

### Changes
- Adds a `scf_numeric_to_int()` helper that returns `0` for floats that cannot be represented as an integer, and uses it in the numeric branches of both decoders. Behavior for all representable input (ints, numeric strings, in-range floats) is unchanged; string casts never raise this deprecation and are untouched.
- Guards `$argv` in `bin/generate-field-schema.php` for environments where `register_argc_argv` is disabled, fixing a PHPStan `variable.undefined` error.

### Testing
- `Test_Fuzz_Post_ID_Decoding` now passes on PHP 8.5.7 (previously 4 failures)
- Full PHPUnit suite green locally on PHP 8.5 (2841 tests), PHPStan clean
- `phpcs-changed` reports no new violations

Closes N/A — PHP 8.5 compatibility.

## Use of AI Tools

This PR was authored with Claude Code (Claude Fable 5). All changes were reviewed and validated locally with the project's PHPUnit/PHPCS/PHPStan tooling.