### PR TITLE
Fix block E2E races against newer block editor versions

### DIFF
--- a/tests/e2e/block-testimonial.spec.ts
+++ b/tests/e2e/block-testimonial.spec.ts
@@ -11,6 +11,17 @@ const getVisibleBlockField = ( page, name ) =>
 	page.locator( `.acf-field[data-name="${ name }"]:visible` ).first();
 
 const getEditorCanvas = async ( page, editor ) => {
+	// The editor mounts asynchronously, so right after a navigation the
+	// iframed canvas may not exist yet and a bare count() check would wrongly
+	// fall back to the top document. Wait for either the iframed canvas or
+	// the non-iframed block list to appear before deciding which root to use.
+	await page
+		.locator(
+			'iframe[name="editor-canvas"], .block-editor-block-list__layout'
+		)
+		.first()
+		.waitFor( { timeout: 15000 } );
+
 	if ( await page.locator( 'iframe[name="editor-canvas"]' ).count() ) {
 		return editor.canvas;
 	}
@@ -129,6 +140,11 @@ test.describe( 'SCF Block > Testimonial', () => {
 		// Navigate to edit post page
 		await admin.editPost( post.id );
 
+		// Wait for the editor canvas to mount before inserting. On newer
+		// WordPress versions the editor boots asynchronously and an early
+		// insert can be wiped by editor setup.
+		await getEditorCanvas( page, editor );
+
 		// Add the testimonial block
 		await editor.insertBlock( { name: BLOCK_NAME } );
 
@@ -222,6 +238,11 @@ test.describe( 'SCF Block > Testimonial', () => {
 
 		// Navigate to edit post page
 		await admin.editPost( post.id );
+
+		// Wait for the editor canvas to mount before inserting. On newer
+		// WordPress versions the editor boots asynchronously and an early
+		// insert can be wiped by editor setup.
+		await getEditorCanvas( page, editor );
 
 		// Add the testimonial block
 		await editor.insertBlock( { name: BLOCK_NAME } );

--- a/tests/e2e/block-v3-features.spec.ts
+++ b/tests/e2e/block-v3-features.spec.ts
@@ -16,6 +16,17 @@ const getVisibleBlockField = ( page, name ) =>
 	page.locator( `.acf-field[data-name="${ name }"]:visible` ).first();
 
 const getEditorCanvas = async ( page, editor ) => {
+	// The editor mounts asynchronously, so right after a navigation the
+	// iframed canvas may not exist yet and a bare count() check would wrongly
+	// fall back to the top document. Wait for either the iframed canvas or
+	// the non-iframed block list to appear before deciding which root to use.
+	await page
+		.locator(
+			'iframe[name="editor-canvas"], .block-editor-block-list__layout'
+		)
+		.first()
+		.waitFor( { timeout: 15000 } );
+
 	if ( await page.locator( 'iframe[name="editor-canvas"]' ).count() ) {
 		return editor.canvas;
 	}
@@ -131,6 +142,11 @@ test.describe( 'SCF Block V3 Features', () => {
 		// Navigate to edit post page
 		await admin.editPost( post.id );
 
+		// Wait for the editor canvas to mount before inserting. On newer
+		// WordPress versions the editor boots asynchronously and an early
+		// insert can be wiped by editor setup.
+		await getEditorCanvas( page, editor );
+
 		// Add the v3 block
 		await editor.insertBlock( { name: BLOCK_NAME } );
 
@@ -172,6 +188,11 @@ test.describe( 'SCF Block V3 Features', () => {
 
 		// Navigate to edit post page
 		await admin.editPost( post.id );
+
+		// Wait for the editor canvas to mount before inserting. On newer
+		// WordPress versions the editor boots asynchronously and an early
+		// insert can be wiped by editor setup.
+		await getEditorCanvas( page, editor );
 
 		// Add the v3 block
 		await editor.insertBlock( { name: BLOCK_NAME } );
@@ -256,6 +277,11 @@ test.describe( 'SCF Block V3 Features', () => {
 		// Navigate to edit post page
 		await admin.editPost( post.id );
 
+		// Wait for the editor canvas to mount before inserting. On newer
+		// WordPress versions the editor boots asynchronously and an early
+		// insert can be wiped by editor setup.
+		await getEditorCanvas( page, editor );
+
 		// Add the v3 block
 		await editor.insertBlock( { name: BLOCK_NAME } );
 
@@ -303,6 +329,11 @@ test.describe( 'SCF Block V3 Features', () => {
 
 		// Navigate to edit post page
 		await admin.editPost( post.id );
+
+		// Wait for the editor canvas to mount before inserting. On newer
+		// WordPress versions the editor boots asynchronously and an early
+		// insert can be wiped by editor setup.
+		await getEditorCanvas( page, editor );
 
 		// Add the v3 block
 		await editor.insertBlock( { name: BLOCK_NAME } );


### PR DESCRIPTION
Fixes the `E2E - WP trunk` job failure (`block-v3-features › should save v3 block data correctly`) and the related retry-flakiness in the block specs. See the failing runs referenced from #491/#490 — the same test failed identically on disjoint diffs, pointing at the WordPress trunk editor rather than plugin changes.

### Root causes (two races)
1. **Canvas root sampled too early**: `getEditorCanvas()` checked `iframe[name="editor-canvas"]` count at a single instant. Right after a navigation (e.g. the `page.reload()` in the save test) the editor React app hasn't mounted yet, so the helper wrongly fell back to the top document — and newer WordPress versions now iframe the post editor canvas in situations where older versions didn't (e.g. with meta boxes present), turning this from a latent race into a deterministic failure. The failure screenshot showed the block rendered and saved correctly; the locator was just searching the wrong document root. The helper now waits for either the iframed canvas or the non-iframed block list to mount before deciding.
2. **Insert before editor ready**: the specs dispatched `editor.insertBlock()` immediately after `admin.editPost()` resolved. On WordPress trunk the editor store finishes initializing after that point and wipes the early-inserted block, leaving an empty canvas (confirmed via a diagnostic run: insertion succeeds when the canvas is mounted first). The specs now wait for the canvas before inserting.

### Verification
- Reproduced the failures locally against WordPress trunk (7.1-alpha, `WP_ENV_CORE=WordPress/WordPress`): 3–4 of 4 `block-v3-features` tests failed before the fix.
- After the fix: all 6 tests across `block-v3-features` and `block-testimonial` pass in 3 consecutive local runs on 7.1-alpha.
- The readiness wait also matches WP 6.2 (non-iframed canvas), covered by the CI matrix.

## Use of AI Tools

This PR was authored with Claude Code (Claude Fable 5), including the failure triage (CI artifacts/trace analysis), root-cause diagnosis, fix, and local verification against WordPress trunk.