### PR TITLE
Fix #479 — Make 'Allow content editors to select multiple values' translatable

### DIFF
--- a/includes/fields/class-acf-field-select.php
+++ b/includes/fields/class-acf-field-select.php
@@ -1,8 +1,9 @@
 <?php
 
-if ( ! class_exists( 'acf_field_select' ) ) :
+if (!class_exists('acf_field_select')):
 
-	class acf_field_select extends acf_field {
+	class acf_field_select extends acf_field
+	{
 
 
 
@@ -16,32 +17,33 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 * @param   n/a
 		 * @return  n/a
 		 */
-		function initialize() {
+		function initialize()
+		{
 
 			// vars
-			$this->name          = 'select';
-			$this->label         = _x( 'Select', 'noun', 'secure-custom-fields' );
-			$this->category      = 'choice';
-			$this->description   = __( 'A dropdown list with a selection of choices that you specify.', 'secure-custom-fields' );
+			$this->name = 'select';
+			$this->label = _x('Select', 'noun', 'secure-custom-fields');
+			$this->category = 'choice';
+			$this->description = __('A dropdown list with a selection of choices that you specify.', 'secure-custom-fields');
 			$this->preview_image = acf_get_url() . '/assets/images/field-type-previews/field-preview-select.png';
-			$this->doc_url       = 'https://developer.wordpress.org/secure-custom-fields/features/fields/select/';
-			$this->tutorial_url  = 'https://developer.wordpress.org/secure-custom-fields/features/fields/select/select-tutorial/';
-			$this->defaults      = array(
-				'multiple'       => 0,
-				'allow_null'     => 0,
-				'choices'        => array(),
-				'default_value'  => '',
-				'ui'             => 0,
-				'ajax'           => 0,
-				'placeholder'    => '',
-				'return_format'  => 'value',
+			$this->doc_url = 'https://developer.wordpress.org/secure-custom-fields/features/fields/select/';
+			$this->tutorial_url = 'https://developer.wordpress.org/secure-custom-fields/features/fields/select/select-tutorial/';
+			$this->defaults = array(
+				'multiple' => 0,
+				'allow_null' => 0,
+				'choices' => array(),
+				'default_value' => '',
+				'ui' => 0,
+				'ajax' => 0,
+				'placeholder' => '',
+				'return_format' => 'value',
 				'create_options' => 0,
-				'save_options'   => 0,
+				'save_options' => 0,
 			);
 
 			// ajax
-			add_action( 'wp_ajax_acf/fields/select/query', array( $this, 'ajax_query' ) );
-			add_action( 'wp_ajax_nopriv_acf/fields/select/query', array( $this, 'ajax_query' ) );
+			add_action('wp_ajax_acf/fields/select/query', array($this, 'ajax_query'));
+			add_action('wp_ajax_nopriv_acf/fields/select/query', array($this, 'ajax_query'));
 		}
 
 
@@ -52,57 +54,58 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 *
 		 * @return void
 		 */
-		public function input_admin_enqueue_scripts() {
+		public function input_admin_enqueue_scripts()
+		{
 			// Bail early if not enqueuing select2.
-			if ( ! acf_get_setting( 'enqueue_select2' ) ) {
+			if (!acf_get_setting('enqueue_select2')) {
 				return;
 			}
 
 			global $wp_scripts;
 
-			$min   = defined( 'SCF_DEVELOPMENT_MODE' ) && SCF_DEVELOPMENT_MODE ? '' : '.min';
-			$major = acf_get_setting( 'select2_version' );
+			$min = defined('SCF_DEVELOPMENT_MODE') && SCF_DEVELOPMENT_MODE ? '' : '.min';
+			$major = acf_get_setting('select2_version');
 
 			// attempt to find 3rd party Select2 version
 			// - avoid including v3 CSS when v4 JS is already enqueued.
-			if ( isset( $wp_scripts->registered['select2'] ) ) {
+			if (isset($wp_scripts->registered['select2'])) {
 				$major = (int) $wp_scripts->registered['select2']->ver;
 			}
 
-			if ( $major === 3 ) {
+			if ($major === 3) {
 				// Use v3 if necessary.
 				$version = '3.5.2';
-				$script  = acf_get_url( "assets/inc/select2/3/select2{$min}.js" );
-				$style   = acf_get_url( 'assets/inc/select2/3/select2.css' );
+				$script = acf_get_url("assets/inc/select2/3/select2{$min}.js");
+				$style = acf_get_url('assets/inc/select2/3/select2.css');
 			} else {
 				// Default to v4.
 				$version = '4.0.13';
-				$script  = acf_get_url( "assets/inc/select2/4/select2.full{$min}.js" );
-				$style   = acf_get_url( "assets/inc/select2/4/select2{$min}.css" );
+				$script = acf_get_url("assets/inc/select2/4/select2.full{$min}.js");
+				$style = acf_get_url("assets/inc/select2/4/select2{$min}.css");
 			}
 
-			wp_enqueue_script( 'select2', $script, array( 'jquery' ), $version );
-			wp_enqueue_style( 'select2', $style, '', $version );
+			wp_enqueue_script('select2', $script, array('jquery'), $version);
+			wp_enqueue_style('select2', $style, '', $version);
 
 			acf_localize_data(
 				array(
 					'select2L10n' => array(
-						'matches_1'            => _x( 'One result is available, press enter to select it.', 'Select2 JS matches_1', 'secure-custom-fields' ),
+						'matches_1' => _x('One result is available, press enter to select it.', 'Select2 JS matches_1', 'secure-custom-fields'),
 						/* translators: %d - number of results available in select field */
-						'matches_n'            => _x( '%d results are available, use up and down arrow keys to navigate.', 'Select2 JS matches_n', 'secure-custom-fields' ),
-						'matches_0'            => _x( 'No matches found', 'Select2 JS matches_0', 'secure-custom-fields' ),
-						'input_too_short_1'    => _x( 'Please enter 1 or more characters', 'Select2 JS input_too_short_1', 'secure-custom-fields' ),
+						'matches_n' => _x('%d results are available, use up and down arrow keys to navigate.', 'Select2 JS matches_n', 'secure-custom-fields'),
+						'matches_0' => _x('No matches found', 'Select2 JS matches_0', 'secure-custom-fields'),
+						'input_too_short_1' => _x('Please enter 1 or more characters', 'Select2 JS input_too_short_1', 'secure-custom-fields'),
 						/* translators: %d - number of characters to enter into select field input */
-						'input_too_short_n'    => _x( 'Please enter %d or more characters', 'Select2 JS input_too_short_n', 'secure-custom-fields' ),
-						'input_too_long_1'     => _x( 'Please delete 1 character', 'Select2 JS input_too_long_1', 'secure-custom-fields' ),
+						'input_too_short_n' => _x('Please enter %d or more characters', 'Select2 JS input_too_short_n', 'secure-custom-fields'),
+						'input_too_long_1' => _x('Please delete 1 character', 'Select2 JS input_too_long_1', 'secure-custom-fields'),
 						/* translators: %d - number of characters that should be removed from select field */
-						'input_too_long_n'     => _x( 'Please delete %d characters', 'Select2 JS input_too_long_n', 'secure-custom-fields' ),
-						'selection_too_long_1' => _x( 'You can only select 1 item', 'Select2 JS selection_too_long_1', 'secure-custom-fields' ),
+						'input_too_long_n' => _x('Please delete %d characters', 'Select2 JS input_too_long_n', 'secure-custom-fields'),
+						'selection_too_long_1' => _x('You can only select 1 item', 'Select2 JS selection_too_long_1', 'secure-custom-fields'),
 						/* translators: %d - maximum number of items that can be selected in the select field */
-						'selection_too_long_n' => _x( 'You can only select %d items', 'Select2 JS selection_too_long_n', 'secure-custom-fields' ),
-						'load_more'            => _x( 'Loading more results&hellip;', 'Select2 JS load_more', 'secure-custom-fields' ),
-						'searching'            => _x( 'Searching&hellip;', 'Select2 JS searching', 'secure-custom-fields' ),
-						'load_fail'            => _x( 'Loading failed', 'Select2 JS load_fail', 'secure-custom-fields' ),
+						'selection_too_long_n' => _x('You can only select %d items', 'Select2 JS selection_too_long_n', 'secure-custom-fields'),
+						'load_more' => _x('Loading more results&hellip;', 'Select2 JS load_more', 'secure-custom-fields'),
+						'searching' => _x('Searching&hellip;', 'Select2 JS searching', 'secure-custom-fields'),
+						'load_fail' => _x('Loading failed', 'Select2 JS load_fail', 'secure-custom-fields'),
 					),
 				)
 			);
@@ -115,27 +118,28 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 *
 		 * @return void
 		 */
-		public function ajax_query() {
-			$nonce = acf_request_arg( 'nonce', '' );
-			$key   = acf_request_arg( 'field_key', '' );
+		public function ajax_query()
+		{
+			$nonce = acf_request_arg('nonce', '');
+			$key = acf_request_arg('field_key', '');
 
-			$is_field_key = acf_is_field_key( $key );
+			$is_field_key = acf_is_field_key($key);
 
 			// Back-compat for field settings.
-			if ( ! $is_field_key ) {
-				if ( ! acf_current_user_can_admin() ) {
+			if (!$is_field_key) {
+				if (!acf_current_user_can_admin()) {
 					die();
 				}
 
 				$nonce = '';
-				$key   = '';
+				$key = '';
 			}
 
-			if ( ! acf_verify_ajax( $nonce, $key, $is_field_key, 'select' ) ) {
+			if (!acf_verify_ajax($nonce, $key, $is_field_key, 'select')) {
 				die();
 			}
 
-			acf_send_ajax_results( $this->get_ajax_query( $_POST ) );
+			acf_send_ajax_results($this->get_ajax_query($_POST));
 		}
 
 		/**
@@ -146,59 +150,60 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 * @param array $options An array of options.
 		 * @return array A select2 compatible array of options.
 		 */
-		public function get_ajax_query( $options = array() ) {
+		public function get_ajax_query($options = array())
+		{
 			$options = acf_parse_args(
 				$options,
 				array(
-					'post_id'   => 0,
-					's'         => '',
+					'post_id' => 0,
+					's' => '',
 					'field_key' => '',
-					'paged'     => 1,
+					'paged' => 1,
 				)
 			);
 
-			$shortcut = apply_filters( 'acf/fields/select/query', array(), $options );
-			$shortcut = apply_filters( 'acf/fields/select/query/key=' . $options['field_key'], $shortcut, $options );
-			if ( ! empty( $shortcut ) ) {
+			$shortcut = apply_filters('acf/fields/select/query', array(), $options);
+			$shortcut = apply_filters('acf/fields/select/query/key=' . $options['field_key'], $shortcut, $options);
+			if (!empty($shortcut)) {
 				return $shortcut;
 			}
 
 			// load field.
-			$field = acf_get_field( $options['field_key'] );
-			if ( ! $field ) {
+			$field = acf_get_field($options['field_key']);
+			if (!$field) {
 				return false;
 			}
 
 			// get choices.
-			$choices = acf_get_array( $field['choices'] );
-			if ( empty( $field['choices'] ) ) {
+			$choices = acf_get_array($field['choices']);
+			if (empty($field['choices'])) {
 				return false;
 			}
 
 			$results = array();
-			$s       = null;
+			$s = null;
 
 			// search.
-			if ( isset( $options['s'] ) && '' !== $options['s'] ) {
+			if (isset($options['s']) && '' !== $options['s']) {
 
 				// strip slashes (search may be integer)
-				$s = strval( $options['s'] );
-				$s = wp_unslash( $s );
+				$s = strval($options['s']);
+				$s = wp_unslash($s);
 			}
 
-			foreach ( $field['choices'] as $k => $v ) {
+			foreach ($field['choices'] as $k => $v) {
 
 				// ensure $v is a string.
-				$v = strval( $v );
+				$v = strval($v);
 
 				// if searching, but doesn't exist.
-				if ( is_string( $s ) && stripos( $v, $s ) === false ) {
+				if (is_string($s) && stripos($v, $s) === false) {
 					continue;
 				}
 
 				// append results.
 				$results[] = array(
-					'id'   => $k,
+					'id' => $k,
 					'text' => $v,
 				);
 			}
@@ -219,117 +224,118 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 *
 		 * @since   ACF 3.6
 		 */
-		function render_field( $field ) {
+		function render_field($field)
+		{
 
-			$value   = acf_get_array( $field['value'] );
-			$choices = acf_get_array( $field['choices'] );
+			$value = acf_get_array($field['value']);
+			$choices = acf_get_array($field['choices']);
 
-			if ( empty( $field['placeholder'] ) ) {
-				$field['placeholder'] = _x( 'Select', 'verb', 'secure-custom-fields' );
+			if (empty($field['placeholder'])) {
+				$field['placeholder'] = _x('Select', 'verb', 'secure-custom-fields');
 			}
 
 			// Add empty value (allows '' to be selected).
-			if ( empty( $value ) ) {
-				$value = array( '' );
+			if (empty($value)) {
+				$value = array('');
 			}
 
 			// Prepend empty choice
 			// - only for single selects
 			// - have tried array_merge but this causes keys to re-index if is numeric (post ID's)
-			if ( isset( $field['allow_null'] ) && $field['allow_null'] && isset( $field['multiple'] ) && ! $field['multiple'] ) {
-				$choices = array( '' => "- {$field['placeholder']} -" ) + $choices;
+			if (isset($field['allow_null']) && $field['allow_null'] && isset($field['multiple']) && !$field['multiple']) {
+				$choices = array('' => "- {$field['placeholder']} -") + $choices;
 			}
 
 			// Clean up choices if using ajax.
-			if ( isset( $field['ui'] ) && $field['ui'] && isset( $field['ajax'] ) && $field['ajax'] ) {
+			if (isset($field['ui']) && $field['ui'] && isset($field['ajax']) && $field['ajax']) {
 				$minimal = array();
-				foreach ( $value as $key ) {
-					if ( isset( $choices[ $key ] ) ) {
-						$minimal[ $key ] = $choices[ $key ];
+				foreach ($value as $key) {
+					if (isset($choices[$key])) {
+						$minimal[$key] = $choices[$key];
 					}
 				}
 				$choices = $minimal;
 			}
 
 			$select = array(
-				'id'               => acf_maybe_get( $field, 'id', '' ),
-				'class'            => acf_maybe_get( $field, 'class', '' ),
-				'name'             => acf_maybe_get( $field, 'name', '' ),
-				'data-ui'          => acf_maybe_get( $field, 'ui', '' ),
-				'data-ajax'        => acf_maybe_get( $field, 'ajax', '' ),
-				'data-multiple'    => acf_maybe_get( $field, 'multiple', '' ),
-				'data-placeholder' => acf_maybe_get( $field, 'placeholder', '' ),
-				'data-allow_null'  => acf_maybe_get( $field, 'allow_null', '' ),
+				'id' => acf_maybe_get($field, 'id', ''),
+				'class' => acf_maybe_get($field, 'class', ''),
+				'name' => acf_maybe_get($field, 'name', ''),
+				'data-ui' => acf_maybe_get($field, 'ui', ''),
+				'data-ajax' => acf_maybe_get($field, 'ajax', ''),
+				'data-multiple' => acf_maybe_get($field, 'multiple', ''),
+				'data-placeholder' => acf_maybe_get($field, 'placeholder', ''),
+				'data-allow_null' => acf_maybe_get($field, 'allow_null', ''),
 			);
 
-			if ( ! empty( $field['aria-label'] ) ) {
+			if (!empty($field['aria-label'])) {
 				$select['aria-label'] = $field['aria-label'];
 			}
 
-			if ( isset( $field['multiple'] ) && $field['multiple'] ) {
+			if (isset($field['multiple']) && $field['multiple']) {
 				$select['multiple'] = 'multiple';
-				$select['size']     = 5;
-				$select['name']    .= '[]';
+				$select['size'] = 5;
+				$select['name'] .= '[]';
 
 				// Reduce size to single line if UI.
-				if ( isset( $field['ui'] ) && $field['ui'] ) {
+				if (isset($field['ui']) && $field['ui']) {
 					$select['size'] = 1;
 				}
 			}
 
-			if ( ! empty( $field['create_options'] ) && $field['ui'] ) {
+			if (!empty($field['create_options']) && $field['ui']) {
 				$select['data-create_options'] = true;
 			}
 
 			// special atts
-			if ( ! empty( $field['readonly'] ) ) {
+			if (!empty($field['readonly'])) {
 				$select['readonly'] = 'readonly';
 			}
-			if ( ! empty( $field['disabled'] ) ) {
+			if (!empty($field['disabled'])) {
 				$select['disabled'] = 'disabled';
 			}
-			if ( ! empty( $field['ajax_action'] ) ) {
+			if (!empty($field['ajax_action'])) {
 				$select['data-ajax_action'] = $field['ajax_action'];
 			}
-			if ( ! empty( $field['nonce'] ) ) {
+			if (!empty($field['nonce'])) {
 				$select['data-nonce'] = $field['nonce'];
 			}
-			if ( isset( $field['ajax'] ) && $field['ajax'] && empty( $field['nonce'] ) && isset( $field['key'] ) && acf_is_field_key( $field['key'] ) ) {
-				$select['data-nonce'] = wp_create_nonce( 'acf_field_' . $this->name . '_' . $field['key'] );
+			if (isset($field['ajax']) && $field['ajax'] && empty($field['nonce']) && isset($field['key']) && acf_is_field_key($field['key'])) {
+				$select['data-nonce'] = wp_create_nonce('acf_field_' . $this->name . '_' . $field['key']);
 			}
-			if ( ! empty( $field['hide_search'] ) ) {
+			if (!empty($field['hide_search'])) {
 				$select['data-minimum-results-for-search'] = '-1';
 			}
 
 			// hidden input is needed to allow validation to see <select> element with no selected value
-			if ( ( isset( $field['multiple'] ) && $field['multiple'] ) || ( isset( $field['ui'] ) && $field['ui'] ) ) {
+			if ((isset($field['multiple']) && $field['multiple']) || (isset($field['ui']) && $field['ui'])) {
 				acf_hidden_input(
 					array(
-						'id'   => $field['id'] . '-input',
+						'id' => $field['id'] . '-input',
 						'name' => $field['name'],
 					)
 				);
 			}
 
 			// append
-			$select['value']   = $value;
+			$select['value'] = $value;
 			$select['choices'] = $choices;
 
-			if ( ! empty( $field['create_options'] ) && $field['ui'] && is_array( $field['value'] ) ) {
-				foreach ( $field['value'] as $value ) {
+			if (!empty($field['create_options']) && $field['ui'] && is_array($field['value'])) {
+				foreach ($field['value'] as $value) {
 					// Already exists in choices.
-					if ( isset( $field['choices'][ $value ] ) ) {
+					if (isset($field['choices'][$value])) {
 						continue;
 					}
 
-					$option = esc_attr( $value );
+					$option = esc_attr($value);
 
-					$select['choices'][ $option ] = $option;
+					$select['choices'][$option] = $option;
 				}
 			}
 
 			// render
-			acf_select_input( $select );
+			acf_select_input($select);
 		}
 
 
@@ -341,20 +347,21 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 * @param array $field An array holding all the field's data.
 		 * @return void
 		 */
-		public function render_field_settings( $field ) {
+		public function render_field_settings($field)
+		{
 
 			// encode choices (convert from array)
-			$field['choices']       = acf_encode_choices( $field['choices'] );
-			$field['default_value'] = acf_encode_choices( $field['default_value'], false );
+			$field['choices'] = acf_encode_choices($field['choices']);
+			$field['default_value'] = acf_encode_choices($field['default_value'], false);
 
 			// choices
 			acf_render_field_setting(
 				$field,
 				array(
-					'label'        => __( 'Choices', 'secure-custom-fields' ),
-					'instructions' => __( 'Enter each choice on a new line.', 'secure-custom-fields' ) . '<br />' . __( 'For more control, you may specify both a value and label like this:', 'secure-custom-fields' ) . '<br /><span class="acf-field-setting-example">' . __( 'red : Red', 'secure-custom-fields' ) . '</span>',
-					'name'         => 'choices',
-					'type'         => 'textarea',
+					'label' => __('Choices', 'secure-custom-fields'),
+					'instructions' => __('Enter each choice on a new line.', 'secure-custom-fields') . '<br />' . __('For more control, you may specify both a value and label like this:', 'secure-custom-fields') . '<br /><span class="acf-field-setting-example">' . __('red : Red', 'secure-custom-fields') . '</span>',
+					'name' => 'choices',
+					'type' => 'textarea',
 				)
 			);
 
@@ -362,10 +369,10 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 			acf_render_field_setting(
 				$field,
 				array(
-					'label'        => __( 'Default Value', 'secure-custom-fields' ),
-					'instructions' => __( 'Enter each default value on a new line', 'secure-custom-fields' ),
-					'name'         => 'default_value',
-					'type'         => 'textarea',
+					'label' => __('Default Value', 'secure-custom-fields'),
+					'instructions' => __('Enter each default value on a new line', 'secure-custom-fields'),
+					'name' => 'default_value',
+					'type' => 'textarea',
 				)
 			);
 
@@ -373,15 +380,15 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 			acf_render_field_setting(
 				$field,
 				array(
-					'label'        => __( 'Return Format', 'secure-custom-fields' ),
-					'instructions' => __( 'Specify the value returned', 'secure-custom-fields' ),
-					'type'         => 'radio',
-					'name'         => 'return_format',
-					'layout'       => 'horizontal',
-					'choices'      => array(
-						'value' => __( 'Value', 'secure-custom-fields' ),
-						'label' => __( 'Label', 'secure-custom-fields' ),
-						'array' => __( 'Both (Array)', 'secure-custom-fields' ),
+					'label' => __('Return Format', 'secure-custom-fields'),
+					'instructions' => __('Specify the value returned', 'secure-custom-fields'),
+					'type' => 'radio',
+					'name' => 'return_format',
+					'layout' => 'horizontal',
+					'choices' => array(
+						'value' => __('Value', 'secure-custom-fields'),
+						'label' => __('Label', 'secure-custom-fields'),
+						'array' => __('Both (Array)', 'secure-custom-fields'),
 					),
 				)
 			);
@@ -389,11 +396,11 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 			acf_render_field_setting(
 				$field,
 				array(
-					'label'        => __( 'Select Multiple', 'secure-custom-fields' ),
-					'instructions' => 'Allow content editors to select multiple values',
-					'name'         => 'multiple',
-					'type'         => 'true_false',
-					'ui'           => 1,
+					'label' => __('Select Multiple', 'secure-custom-fields'),
+					'instructions' => __('Allow content editors to select multiple values', 'secure-custom-fields'),
+					'name' => 'multiple',
+					'type' => 'true_false',
+					'ui' => 1,
 				)
 			);
 		}
@@ -406,15 +413,16 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 * @param array $field The field settings array.
 		 * @return void
 		 */
-		public function render_field_validation_settings( $field ) {
+		public function render_field_validation_settings($field)
+		{
 			acf_render_field_setting(
 				$field,
 				array(
-					'label'        => __( 'Allow Null', 'secure-custom-fields' ),
+					'label' => __('Allow Null', 'secure-custom-fields'),
 					'instructions' => '',
-					'name'         => 'allow_null',
-					'type'         => 'true_false',
-					'ui'           => 1,
+					'name' => 'allow_null',
+					'type' => 'true_false',
+					'ui' => 1,
 				)
 			);
 		}
@@ -427,30 +435,31 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 * @param array $field The field settings array.
 		 * @return void
 		 */
-		public function render_field_presentation_settings( $field ) {
+		public function render_field_presentation_settings($field)
+		{
 			acf_render_field_setting(
 				$field,
 				array(
-					'label'        => __( 'Stylized UI', 'secure-custom-fields' ),
-					'instructions' => __( 'Use a stylized checkbox using select2', 'secure-custom-fields' ),
-					'name'         => 'ui',
-					'type'         => 'true_false',
-					'ui'           => 1,
+					'label' => __('Stylized UI', 'secure-custom-fields'),
+					'instructions' => __('Use a stylized checkbox using select2', 'secure-custom-fields'),
+					'name' => 'ui',
+					'type' => 'true_false',
+					'ui' => 1,
 				)
 			);
 
 			acf_render_field_setting(
 				$field,
 				array(
-					'label'        => __( 'Use AJAX to lazy load choices?', 'secure-custom-fields' ),
+					'label' => __('Use AJAX to lazy load choices?', 'secure-custom-fields'),
 					'instructions' => '',
-					'name'         => 'ajax',
-					'type'         => 'true_false',
-					'ui'           => 1,
-					'conditions'   => array(
-						'field'    => 'ui',
+					'name' => 'ajax',
+					'type' => 'true_false',
+					'ui' => 1,
+					'conditions' => array(
+						'field' => 'ui',
 						'operator' => '==',
-						'value'    => 1,
+						'value' => 1,
 					),
 				)
 			);
@@ -458,21 +467,21 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 			acf_render_field_setting(
 				$field,
 				array(
-					'label'        => __( 'Create Options', 'secure-custom-fields' ),
-					'instructions' => __( 'Allow content editors to create new options by typing in the Select input. Multiple options can be created from a comma separated string.', 'secure-custom-fields' ),
-					'name'         => 'create_options',
-					'type'         => 'true_false',
-					'ui'           => 1,
-					'conditions'   => array(
+					'label' => __('Create Options', 'secure-custom-fields'),
+					'instructions' => __('Allow content editors to create new options by typing in the Select input. Multiple options can be created from a comma separated string.', 'secure-custom-fields'),
+					'name' => 'create_options',
+					'type' => 'true_false',
+					'ui' => 1,
+					'conditions' => array(
 						array(
-							'field'    => 'ui',
+							'field' => 'ui',
 							'operator' => '==',
-							'value'    => 1,
+							'value' => 1,
 						),
 						array(
-							'field'    => 'multiple',
+							'field' => 'multiple',
 							'operator' => '==',
-							'value'    => 1,
+							'value' => 1,
 						),
 					),
 				)
@@ -481,26 +490,26 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 			acf_render_field_setting(
 				$field,
 				array(
-					'label'        => __( 'Save Options', 'secure-custom-fields' ),
-					'instructions' => __( 'Save created options back to the "Choices" setting in the field definition.', 'secure-custom-fields' ),
-					'name'         => 'save_options',
-					'type'         => 'true_false',
-					'ui'           => 1,
-					'conditions'   => array(
+					'label' => __('Save Options', 'secure-custom-fields'),
+					'instructions' => __('Save created options back to the "Choices" setting in the field definition.', 'secure-custom-fields'),
+					'name' => 'save_options',
+					'type' => 'true_false',
+					'ui' => 1,
+					'conditions' => array(
 						array(
-							'field'    => 'ui',
+							'field' => 'ui',
 							'operator' => '==',
-							'value'    => 1,
+							'value' => 1,
 						),
 						array(
-							'field'    => 'multiple',
+							'field' => 'multiple',
 							'operator' => '==',
-							'value'    => 1,
+							'value' => 1,
 						),
 						array(
-							'field'    => 'create_options',
+							'field' => 'create_options',
 							'operator' => '==',
-							'value'    => 1,
+							'value' => 1,
 						),
 					),
 				)
@@ -517,18 +526,19 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 * @param array          $field   The field array holding all the field options.
 		 * @return mixed
 		 */
-		public function load_value( $value, $post_id, $field ) {
+		public function load_value($value, $post_id, $field)
+		{
 
 			// Return an array when field is set for multiple.
-			if ( $field['multiple'] ) {
-				if ( acf_is_empty( $value ) ) {
+			if ($field['multiple']) {
+				if (acf_is_empty($value)) {
 					return array();
 				}
-				return acf_array( $value );
+				return acf_array($value);
 			}
 
 			// Otherwise, return a single value.
-			return acf_unarray( $value );
+			return acf_unarray($value);
 		}
 
 
@@ -540,15 +550,16 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 * @param array $field The field array holding all the field options.
 		 * @return array
 		 */
-		public function update_field( $field ) {
+		public function update_field($field)
+		{
 
 			// Decode choices (convert to array).
-			$field['choices']       = acf_decode_choices( $field['choices'] );
-			$field['default_value'] = acf_decode_choices( $field['default_value'], true );
+			$field['choices'] = acf_decode_choices($field['choices']);
+			$field['default_value'] = acf_decode_choices($field['default_value'], true);
 
 			// Convert back to string for single selects.
-			if ( ! $field['multiple'] ) {
-				$field['default_value'] = acf_unarray( $field['default_value'] );
+			if (!$field['multiple']) {
+				$field['default_value'] = acf_unarray($field['default_value']);
 			}
 
 			return $field;
@@ -566,37 +577,38 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 *
 		 * @return mixed
 		 */
-		public function update_value( $value, $post_id, $field ) {
+		public function update_value($value, $post_id, $field)
+		{
 
 			// Bail early if no value.
-			if ( empty( $value ) ) {
+			if (empty($value)) {
 				return $value;
 			}
 
 			// Format array of values.
 			// - Parse each value as string for SQL LIKE queries.
 			// - Guard against nested arrays (e.g. crafted POST input) by stringifying scalars only.
-			if ( is_array( $value ) ) {
+			if (is_array($value)) {
 				$value = array_map(
-					static function ( $v ) {
-						return is_scalar( $v ) ? strval( $v ) : '';
+					static function ($v) {
+						return is_scalar($v) ? strval($v) : '';
 					},
 					$value
 				);
 			}
 
 			// Save custom options back to the field definition if configured.
-			if ( ! empty( $field['save_options'] ) && is_array( $value ) && scf_current_user_has_capability() ) {
+			if (!empty($field['save_options']) && is_array($value) && scf_current_user_has_capability()) {
 				// Get the raw field, using the ID if present or the key otherwise (i.e. when using JSON).
 				$selector = $field['ID'] ? $field['ID'] : $field['key'];
-				$field    = acf_get_field( $selector );
+				$field = acf_get_field($selector);
 
 				// Bail if we don't have a valid field or field ID (JSON only).
-				if ( empty( $field['ID'] ) ) {
+				if (empty($field['ID'])) {
 					return $value;
 				}
 
-				$this->append_user_choices_to_field( $value, $post_id, $field );
+				$this->append_user_choices_to_field($value, $post_id, $field);
 			}
 			return $value;
 		}
@@ -618,7 +630,8 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 * @param array          $field   The persisted field array. Must have an ID.
 		 * @return void
 		 */
-		public function append_user_choices_to_field( $value, $post_id, $field ) {
+		public function append_user_choices_to_field($value, $post_id, $field)
+		{
 			/**
 			 * Filters the maximum number of choices that may be stored on a field
 			 * via the checkbox `save_custom`, radio `save_other_choice`, and select
@@ -632,40 +645,40 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 			 * @param array          $field   The field array holding all the field options.
 			 * @param integer|string $post_id The post_id of which the value will be saved.
 			 */
-			$max = (int) apply_filters( 'acf/fields/max_appended_choices', 1000, $field, $post_id );
+			$max = (int) apply_filters('acf/fields/max_appended_choices', 1000, $field, $post_id);
 
 			$appended = false;
 
-			foreach ( $value as $v ) {
+			foreach ($value as $v) {
 				// Skip if the raw submitted value matches an existing key,
 				// preserving back-compat for fields whose choices contain
 				// un-normalized keys (e.g. developer-registered with HTML).
-				if ( isset( $field['choices'][ $v ] ) ) {
+				if (isset($field['choices'][$v])) {
 					continue;
 				}
 
 				// Unslash (fixes serialize single quote issue) and sanitize.
-				$v = wp_unslash( $v );
-				$v = sanitize_text_field( $v );
+				$v = wp_unslash($v);
+				$v = sanitize_text_field($v);
 
 				// Skip if the normalized value is empty or already exists.
-				if ( '' === $v || isset( $field['choices'][ $v ] ) ) {
+				if ('' === $v || isset($field['choices'][$v])) {
 					continue;
 				}
 
 				// Stop appending once the cap is reached.
-				if ( count( $field['choices'] ) >= $max ) {
+				if (count($field['choices']) >= $max) {
 					break;
 				}
 
 				// Append to the field choices.
-				$field['choices'][ $v ] = $v;
-				$appended               = true;
+				$field['choices'][$v] = $v;
+				$appended = true;
 			}
 
 			// Save only if we actually appended a new choice.
-			if ( $appended ) {
-				acf_update_field( $field );
+			if ($appended) {
+				acf_update_field($field);
 			}
 		}
 
@@ -678,9 +691,10 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 * @param array $field The main field array.
 		 * @return array
 		 */
-		public function translate_field( $field ) {
+		public function translate_field($field)
+		{
 
-			$field['choices'] = acf_translate( $field['choices'] );
+			$field['choices'] = acf_translate($field['choices']);
 			return $field;
 		}
 
@@ -696,13 +710,14 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 *
 		 * @return mixed
 		 */
-		public function format_value( $value, $post_id, $field ) {
-			if ( is_array( $value ) ) {
-				foreach ( $value as $i => $val ) {
-					$value[ $i ] = $this->format_value_single( $val, $post_id, $field );
+		public function format_value($value, $post_id, $field)
+		{
+			if (is_array($value)) {
+				foreach ($value as $i => $val) {
+					$value[$i] = $this->format_value_single($val, $post_id, $field);
 				}
 			} else {
-				$value = $this->format_value_single( $value, $post_id, $field );
+				$value = $this->format_value_single($value, $post_id, $field);
 			}
 			return $value;
 		}
@@ -717,17 +732,18 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 * @param array          $field   The field array holding all the field options.
 		 * @return mixed
 		 */
-		public function format_value_single( $value, $post_id, $field ) {
+		public function format_value_single($value, $post_id, $field)
+		{
 			// Bail early if is empty.
-			if ( acf_is_empty( $value ) ) {
+			if (acf_is_empty($value)) {
 				return $value;
 			}
 
-			$label = acf_maybe_get( $field['choices'], $value, $value );
+			$label = acf_maybe_get($field['choices'], $value, $value);
 
-			if ( 'label' === $field['return_format'] ) {
+			if ('label' === $field['return_format']) {
 				$value = $label;
-			} elseif ( 'array' === $field['return_format'] ) {
+			} elseif ('array' === $field['return_format']) {
 				$value = array(
 					'value' => $value,
 					'label' => $label,
@@ -745,39 +761,40 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 * @param  array   $field The field array.
 		 * @return boolean|WP_Error
 		 */
-		public function validate_rest_value( $valid, $value, $field ) {
+		public function validate_rest_value($valid, $value, $field)
+		{
 			// rest_validate_request_arg() handles the other types, we just worry about strings.
-			if ( is_null( $value ) || is_array( $value ) ) {
+			if (is_null($value) || is_array($value)) {
 				return $valid;
 			}
 
-			if ( ! acf_maybe_get( $field, 'choices' ) ) {
+			if (!acf_maybe_get($field, 'choices')) {
 				return $valid;
 			}
 
 			$option_keys = array_diff(
-				array_keys( $field['choices'] ),
-				array_values( $field['choices'] )
+				array_keys($field['choices']),
+				array_values($field['choices'])
 			);
 
-			$allowed = empty( $option_keys ) ? $field['choices'] : $option_keys;
+			$allowed = empty($option_keys) ? $field['choices'] : $option_keys;
 
-			if ( ! in_array( $value, $allowed ) ) {
-				$prefix = isset( $field['prefix'] ) ? $field['prefix'] : '';
-				$name   = isset( $field['name'] ) ? $field['name'] : '';
-				$param  = sprintf( '%s[%s]', $prefix, $name );
-				$data   = array(
+			if (!in_array($value, $allowed)) {
+				$prefix = isset($field['prefix']) ? $field['prefix'] : '';
+				$name = isset($field['name']) ? $field['name'] : '';
+				$param = sprintf('%s[%s]', $prefix, $name);
+				$data = array(
 					'param' => $param,
 					'value' => $value,
 				);
-				$error  = sprintf(
+				$error = sprintf(
 					/* translators: 1: parameter, 2: allowed values */
-					__( '%1$s is not one of %2$s', 'secure-custom-fields' ),
+					__('%1$s is not one of %2$s', 'secure-custom-fields'),
 					$param,
-					implode( ', ', $allowed )
+					implode(', ', $allowed)
 				);
 
-				return new WP_Error( 'rest_invalid_param', $error, $data );
+				return new WP_Error('rest_invalid_param', $error, $data);
 			}
 
 			return $valid;
@@ -791,12 +808,13 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 * @param array $choices The choices for the field.
 		 * @return array
 		 */
-		public function format_rest_choices( $choices ) {
-			$keys        = array_keys( $choices );
-			$values      = array_values( $choices );
+		public function format_rest_choices($choices)
+		{
+			$keys = array_keys($choices);
+			$values = array_values($choices);
 			$int_choices = array();
 
-			if ( array_diff( $keys, $values ) ) {
+			if (array_diff($keys, $values)) {
 				// User has specified custom keys.
 				$choices = $keys;
 			} else {
@@ -805,16 +823,16 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 			}
 
 			// Assume everything is a string by default.
-			$choices = array_map( 'strval', $choices );
+			$choices = array_map('strval', $choices);
 
 			// Also allow integers if is_numeric().
-			foreach ( $choices as $choice ) {
-				if ( is_numeric( $choice ) ) {
+			foreach ($choices as $choice) {
+				if (is_numeric($choice)) {
 					$int_choices[] = (int) $choice;
 				}
 			}
 
-			return array_merge( $choices, $int_choices );
+			return array_merge($choices, $int_choices);
 		}
 
 		/**
@@ -823,25 +841,26 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 * @param array $field The main field array.
 		 * @return array
 		 */
-		public function get_rest_schema( array $field ) {
+		public function get_rest_schema(array $field)
+		{
 			$schema = array(
-				'type'     => array( 'string', 'array', 'int', 'null' ),
-				'required' => ! empty( $field['required'] ),
-				'items'    => array(
-					'type' => array( 'string', 'int' ),
-					'enum' => $this->format_rest_choices( $field['choices'] ),
+				'type' => array('string', 'array', 'int', 'null'),
+				'required' => !empty($field['required']),
+				'items' => array(
+					'type' => array('string', 'int'),
+					'enum' => $this->format_rest_choices($field['choices']),
 				),
 			);
 
-			if ( empty( $field['allow_null'] ) ) {
+			if (empty($field['allow_null'])) {
 				$schema['minItems'] = 1;
 			}
 
-			if ( empty( $field['multiple'] ) ) {
+			if (empty($field['multiple'])) {
 				$schema['maxItems'] = 1;
 			}
 
-			if ( isset( $field['default_value'] ) && '' !== $field['default_value'] ) {
+			if (isset($field['default_value']) && '' !== $field['default_value']) {
 				$schema['default'] = $field['default_value'];
 			}
 
@@ -855,12 +874,13 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 		 *
 		 * @return string[]
 		 */
-		public function get_jsonld_output_types(): array {
-			return array( 'Text' );
+		public function get_jsonld_output_types(): array
+		{
+			return array('Text');
 		}
 	}
 
 
 	// initialize
-	acf_register_field_type( 'acf_field_select' );
+	acf_register_field_type('acf_field_select');
 endif; // class_exists check

--- a/includes/fields/class-acf-field-user.php
+++ b/includes/fields/class-acf-field-user.php
@@ -1,11 +1,12 @@
 <?php
 
-if ( ! class_exists( 'ACF_Field_User' ) ) :
+if (!class_exists('ACF_Field_User')):
 
 	/**
 	 * ACF_Field_User Class
 	 */
-	class ACF_Field_User extends acf_field {
+	class ACF_Field_User extends acf_field
+	{
 
 
 		/**
@@ -14,31 +15,32 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @date    5/03/2014
 		 * @since   ACF 5.0.0
 		 */
-		function initialize() {
-			$this->name          = 'user';
-			$this->label         = __( 'User', 'secure-custom-fields' );
-			$this->category      = 'relational';
-			$this->description   = __( 'Allows the selection of one or more users which can be used to create relationships between data objects.', 'secure-custom-fields' );
+		function initialize()
+		{
+			$this->name = 'user';
+			$this->label = __('User', 'secure-custom-fields');
+			$this->category = 'relational';
+			$this->description = __('Allows the selection of one or more users which can be used to create relationships between data objects.', 'secure-custom-fields');
 			$this->preview_image = acf_get_url() . '/assets/images/field-type-previews/field-preview-user.png';
-			$this->doc_url       = 'https://developer.wordpress.org/secure-custom-fields/features/fields/user/';
-			$this->tutorial_url  = 'https://developer.wordpress.org/secure-custom-fields/features/fields/user/user-tutorial/';
-			$this->defaults      = array(
-				'role'                 => '',
-				'multiple'             => 0,
-				'allow_null'           => 0,
-				'return_format'        => 'array',
+			$this->doc_url = 'https://developer.wordpress.org/secure-custom-fields/features/fields/user/';
+			$this->tutorial_url = 'https://developer.wordpress.org/secure-custom-fields/features/fields/user/user-tutorial/';
+			$this->defaults = array(
+				'role' => '',
+				'multiple' => 0,
+				'allow_null' => 0,
+				'return_format' => 'array',
 				'bidirectional_target' => array(),
 			);
 
 			// Register filter variations.
-			acf_add_filter_variations( 'acf/fields/user/query', array( 'name', 'key' ), 1 );
-			acf_add_filter_variations( 'acf/fields/user/result', array( 'name', 'key' ), 2 );
-			acf_add_filter_variations( 'acf/fields/user/search_columns', array( 'name', 'key' ), 3 );
-			add_filter( 'acf/conditional_logic/choices', array( $this, 'render_field_user_conditional_choices' ), 10, 3 );
+			acf_add_filter_variations('acf/fields/user/query', array('name', 'key'), 1);
+			acf_add_filter_variations('acf/fields/user/result', array('name', 'key'), 2);
+			acf_add_filter_variations('acf/fields/user/search_columns', array('name', 'key'), 3);
+			add_filter('acf/conditional_logic/choices', array($this, 'render_field_user_conditional_choices'), 10, 3);
 
 			// Add AJAX query.
-			add_action( 'wp_ajax_acf/fields/user/query', array( $this, 'ajax_query' ) );
-			add_action( 'wp_ajax_nopriv_acf/fields/user/query', array( $this, 'ajax_query' ) );
+			add_action('wp_ajax_acf/fields/user/query', array($this, 'ajax_query'));
+			add_action('wp_ajax_nopriv_acf/fields/user/query', array($this, 'ajax_query'));
 		}
 
 		/**
@@ -51,19 +53,20 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param string $rule_value        The rule value.
 		 * @return array
 		 */
-		public function render_field_user_conditional_choices( $choices, $conditional_field, $rule_value ) {
-			if ( ! is_array( $conditional_field ) || $conditional_field['type'] !== 'user' ) {
+		public function render_field_user_conditional_choices($choices, $conditional_field, $rule_value)
+		{
+			if (!is_array($conditional_field) || $conditional_field['type'] !== 'user') {
 				return $choices;
 			}
-			if ( ! empty( $rule_value ) ) {
+			if (!empty($rule_value)) {
 				$user = acf_get_users(
 					array(
-						'include' => array( $rule_value ),
+						'include' => array($rule_value),
 					)
 				);
 
-				$user_result = acf_get_user_result( $user[0] );
-				$choices     = array( $user_result['id'] => $user_result['text'] );
+				$user_result = acf_get_user_result($user[0]);
+				$choices = array($user_result['id'] => $user_result['text']);
 			}
 
 			return $choices;
@@ -78,46 +81,47 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param   array $field The ACF field.
 		 * @return  void
 		 */
-		function render_field_settings( $field ) {
+		function render_field_settings($field)
+		{
 			acf_render_field_setting(
 				$field,
 				array(
-					'label'        => __( 'Filter by Role', 'secure-custom-fields' ),
+					'label' => __('Filter by Role', 'secure-custom-fields'),
 					'instructions' => '',
-					'type'         => 'select',
-					'name'         => 'role',
-					'choices'      => acf_get_user_role_labels(),
-					'multiple'     => 1,
-					'ui'           => 1,
-					'allow_null'   => 1,
-					'placeholder'  => __( 'All user roles', 'secure-custom-fields' ),
+					'type' => 'select',
+					'name' => 'role',
+					'choices' => acf_get_user_role_labels(),
+					'multiple' => 1,
+					'ui' => 1,
+					'allow_null' => 1,
+					'placeholder' => __('All user roles', 'secure-custom-fields'),
 				)
 			);
 
 			acf_render_field_setting(
 				$field,
 				array(
-					'label'        => __( 'Return Format', 'secure-custom-fields' ),
+					'label' => __('Return Format', 'secure-custom-fields'),
 					'instructions' => '',
-					'type'         => 'radio',
-					'name'         => 'return_format',
-					'choices'      => array(
-						'array'  => __( 'User Array', 'secure-custom-fields' ),
-						'object' => __( 'User Object', 'secure-custom-fields' ),
-						'id'     => __( 'User ID', 'secure-custom-fields' ),
+					'type' => 'radio',
+					'name' => 'return_format',
+					'choices' => array(
+						'array' => __('User Array', 'secure-custom-fields'),
+						'object' => __('User Object', 'secure-custom-fields'),
+						'id' => __('User ID', 'secure-custom-fields'),
 					),
-					'layout'       => 'horizontal',
+					'layout' => 'horizontal',
 				)
 			);
 
 			acf_render_field_setting(
 				$field,
 				array(
-					'label'        => __( 'Select Multiple', 'secure-custom-fields' ),
-					'instructions' => 'Allow content editors to select multiple values',
-					'name'         => 'multiple',
-					'type'         => 'true_false',
-					'ui'           => 1,
+					'label' => __('Select Multiple', 'secure-custom-fields'),
+					'instructions' => __('Allow content editors to select multiple values', 'secure-custom-fields'),
+					'name' => 'multiple',
+					'type' => 'true_false',
+					'ui' => 1,
 				)
 			);
 		}
@@ -130,15 +134,16 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param array $field The field settings array.
 		 * @return void
 		 */
-		function render_field_validation_settings( $field ) {
+		function render_field_validation_settings($field)
+		{
 			acf_render_field_setting(
 				$field,
 				array(
-					'label'        => __( 'Allow Null', 'secure-custom-fields' ),
+					'label' => __('Allow Null', 'secure-custom-fields'),
 					'instructions' => '',
-					'name'         => 'allow_null',
-					'type'         => 'true_false',
-					'ui'           => 1,
+					'name' => 'allow_null',
+					'type' => 'true_false',
+					'ui' => 1,
 				)
 			);
 		}
@@ -151,8 +156,9 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param array $field The field settings array.
 		 * @return void
 		 */
-		public function render_field_advanced_settings( $field ) {
-			acf_render_bidirectional_field_settings( $field );
+		public function render_field_advanced_settings($field)
+		{
+			acf_render_bidirectional_field_settings($field);
 		}
 
 		/**
@@ -163,19 +169,20 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param   array $field The ACF field.
 		 * @return  void
 		 */
-		public function render_field( $field ) {
+		public function render_field($field)
+		{
 			// Change Field into a select.
-			$field['type']    = 'select';
-			$field['ui']      = 1;
-			$field['ajax']    = 1;
+			$field['type'] = 'select';
+			$field['ui'] = 1;
+			$field['ajax'] = 1;
 			$field['choices'] = array();
-			$field['nonce']   = wp_create_nonce( 'acf_field_' . $this->name . '_' . $field['key'] );
+			$field['nonce'] = wp_create_nonce('acf_field_' . $this->name . '_' . $field['key']);
 
 			// Populate choices.
-			if ( $field['value'] ) {
+			if ($field['value']) {
 
 				// Clean value into an array of IDs.
-				$user_ids = array_map( 'intval', acf_array( $field['value'] ) );
+				$user_ids = array_map('intval', acf_array($field['value']));
 
 				// Find users in database (ensures all results are real).
 				$users = acf_get_users(
@@ -185,15 +192,15 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 				);
 
 				// Append.
-				if ( $users ) {
-					foreach ( $users as $user ) {
-						$field['choices'][ $user->ID ] = $this->get_result( $user, $field );
+				if ($users) {
+					foreach ($users as $user) {
+						$field['choices'][$user->ID] = $this->get_result($user, $field);
 					}
 				}
 			}
 
 			// Render.
-			acf_render_field( $field );
+			acf_render_field($field);
 		}
 
 		/**
@@ -207,13 +214,14 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param   (int|string) $post_id The post_id being edited.
 		 * @return  string
 		 */
-		function get_result( $user, $field, $post_id = 0 ) {
+		function get_result($user, $field, $post_id = 0)
+		{
 
 			// Get user result item.
-			$item = acf_get_user_result( $user );
+			$item = acf_get_user_result($user);
 
 			// Default $post_id to current post being edited.
-			$post_id = $post_id ? $post_id : acf_get_form_data( 'post_id' );
+			$post_id = $post_id ? $post_id : acf_get_form_data('post_id');
 
 			/**
 			 * Filters the result text.
@@ -226,7 +234,7 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 			 * @param   array $field The ACF field related to this query.
 			 * @param   (int|string) $post_id The post_id being edited.
 			 */
-			return apply_filters( 'acf/fields/user/result', $item['text'], $user, $field, $post_id );
+			return apply_filters('acf/fields/user/result', $item['text'], $user, $field, $post_id);
 		}
 
 		/**
@@ -240,10 +248,11 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param   array $field   The field array containing all settings.
 		 * @return  mixed
 		 */
-		function load_value( $value, $post_id, $field ) {
+		function load_value($value, $post_id, $field)
+		{
 
 			// Add compatibility for version 4.
-			if ( $value === 'null' ) {
+			if ($value === 'null') {
 				return false;
 			}
 			return $value;
@@ -260,15 +269,16 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param   array $field   The field array containing all settings.
 		 * @return  mixed
 		 */
-		function format_value( $value, $post_id, $field ) {
+		function format_value($value, $post_id, $field)
+		{
 
 			// Bail early if no value.
-			if ( ! $value ) {
+			if (!$value) {
 				return false;
 			}
 
 			// Clean value into an array of IDs.
-			$user_ids = array_map( 'intval', acf_array( $value ) );
+			$user_ids = array_map('intval', acf_array($value));
 
 			// Find users in database (ensures all results are real).
 			$users = acf_get_users(
@@ -278,32 +288,32 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 			);
 
 			// Bail early if no users found.
-			if ( ! $users ) {
+			if (!$users) {
 				return false;
 			}
 
 			// Format values using field settings.
 			$value = array();
-			foreach ( $users as $user ) {
+			foreach ($users as $user) {
 
 				// Return object.
-				if ( $field['return_format'] == 'object' ) {
+				if ($field['return_format'] == 'object') {
 					$item = $user;
 
 					// Return array.
-				} elseif ( $field['return_format'] == 'array' ) {
+				} elseif ($field['return_format'] == 'array') {
 					$item = array(
-						'ID'               => $user->ID,
-						'user_firstname'   => $user->user_firstname,
-						'user_lastname'    => $user->user_lastname,
-						'nickname'         => $user->nickname,
-						'user_nicename'    => $user->user_nicename,
-						'display_name'     => $user->display_name,
-						'user_email'       => $user->user_email,
-						'user_url'         => $user->user_url,
-						'user_registered'  => $user->user_registered,
+						'ID' => $user->ID,
+						'user_firstname' => $user->user_firstname,
+						'user_lastname' => $user->user_lastname,
+						'nickname' => $user->nickname,
+						'user_nicename' => $user->user_nicename,
+						'display_name' => $user->display_name,
+						'user_email' => $user->user_email,
+						'user_url' => $user->user_url,
+						'user_registered' => $user->user_registered,
 						'user_description' => $user->user_description,
-						'user_avatar'      => get_avatar( $user->ID ),
+						'user_avatar' => get_avatar($user->ID),
 					);
 
 					// Return ID.
@@ -316,8 +326,8 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 			}
 
 			// Convert to single.
-			if ( ! $field['multiple'] ) {
-				$value = array_shift( $value );
+			if (!$field['multiple']) {
+				$value = array_shift($value);
 			}
 
 			// Return.
@@ -334,27 +344,28 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param  array $field   The field array containing all settings.
 		 * @return mixed $value   The modified value.
 		 */
-		public function update_value( $value, $post_id, $field ) {
+		public function update_value($value, $post_id, $field)
+		{
 
 			// Bail early if no value.
-			if ( empty( $value ) ) {
-				acf_update_bidirectional_values( array(), $post_id, $field, 'user' );
+			if (empty($value)) {
+				acf_update_bidirectional_values(array(), $post_id, $field, 'user');
 				return $value;
 			}
 
 			// Format array of values.
 			// - ensure each value is an id.
 			// - Parse each id as string for SQL LIKE queries.
-			if ( acf_is_sequential_array( $value ) ) {
-				$value = array_map( 'acf_idval', $value );
-				$value = array_map( 'strval', $value );
+			if (acf_is_sequential_array($value)) {
+				$value = array_map('acf_idval', $value);
+				$value = array_map('strval', $value);
 
 				// Parse single value for id.
 			} else {
-				$value = acf_idval( $value );
+				$value = acf_idval($value);
 			}
 
-			acf_update_bidirectional_values( acf_get_array( $value ), $post_id, $field, 'user' );
+			acf_update_bidirectional_values(acf_get_array($value), $post_id, $field, 'user');
 
 			// Return value.
 			return $value;
@@ -368,25 +379,26 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 *
 		 * @return  void
 		 */
-		function ajax_query() {
+		function ajax_query()
+		{
 
 			// phpcs:disable WordPress.Security.NonceVerification.Recommended
 			// Modify Request args.
-			if ( isset( $_REQUEST['s'] ) ) {
-				$_REQUEST['search'] = sanitize_text_field( $_REQUEST['s'] );
+			if (isset($_REQUEST['s'])) {
+				$_REQUEST['search'] = sanitize_text_field($_REQUEST['s']);
 			}
-			if ( isset( $_REQUEST['paged'] ) ) {
-				$_REQUEST['page'] = absint( $_REQUEST['paged'] );
+			if (isset($_REQUEST['paged'])) {
+				$_REQUEST['page'] = absint($_REQUEST['paged']);
 			}
 			// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 			// Add query hooks.
-			add_action( 'acf/ajax/query_users/init', array( $this, 'ajax_query_init' ), 10, 2 );
-			add_filter( 'acf/ajax/query_users/args', array( $this, 'ajax_query_args' ), 10, 3 );
-			add_filter( 'acf/ajax/query_users/result', array( $this, 'ajax_query_result' ), 10, 3 );
-			add_filter( 'acf/ajax/query_users/search_columns', array( $this, 'ajax_query_search_columns' ), 10, 4 );
+			add_action('acf/ajax/query_users/init', array($this, 'ajax_query_init'), 10, 2);
+			add_filter('acf/ajax/query_users/args', array($this, 'ajax_query_args'), 10, 3);
+			add_filter('acf/ajax/query_users/result', array($this, 'ajax_query_result'), 10, 3);
+			add_filter('acf/ajax/query_users/search_columns', array($this, 'ajax_query_search_columns'), 10, 4);
 			// Simulate AJAX request.
-			acf_get_instance( 'ACF_Ajax_Query_Users' )->request();
+			acf_get_instance('ACF_Ajax_Query_Users')->request();
 		}
 
 		/**
@@ -399,18 +411,19 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param   ACF_Ajax_Query $query   The query object.
 		 * @return  void
 		 */
-		function ajax_query_init( $request, $query ) {
+		function ajax_query_init($request, $query)
+		{
 			// Require field and make sure it's a user field.
-			if ( ! $query->field || $query->field['type'] !== $this->name ) {
-				$query->send( new WP_Error( 'acf_missing_field', __( 'Error loading field.', 'secure-custom-fields' ), array( 'status' => 404 ) ) );
+			if (!$query->field || $query->field['type'] !== $this->name) {
+				$query->send(new WP_Error('acf_missing_field', __('Error loading field.', 'secure-custom-fields'), array('status' => 404)));
 			}
 
 			// Verify that this is a legitimate request using a separate nonce from the main AJAX nonce.
-			$nonce = acf_request_arg( 'nonce', '' );
-			$key   = acf_request_arg( 'field_key', '' );
+			$nonce = acf_request_arg('nonce', '');
+			$key = acf_request_arg('field_key', '');
 
-			if ( ! acf_verify_ajax( $nonce, $key, true, 'user' ) ) {
-				$query->send( new WP_Error( 'acf_invalid_request', __( 'Invalid request.', 'secure-custom-fields' ), array( 'status' => 404 ) ) );
+			if (!acf_verify_ajax($nonce, $key, true, 'user')) {
+				$query->send(new WP_Error('acf_invalid_request', __('Invalid request.', 'secure-custom-fields'), array('status' => 404)));
 			}
 		}
 
@@ -425,11 +438,12 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param   ACF_Ajax_Query $query   The query object.
 		 * @return  array
 		 */
-		function ajax_query_args( $args, $request, $query ) {
+		function ajax_query_args($args, $request, $query)
+		{
 
 			// Add specific roles.
-			if ( $query->field['role'] ) {
-				$args['role__in'] = acf_array( $query->field['role'] );
+			if ($query->field['role']) {
+				$args['role__in'] = acf_array($query->field['role']);
 			}
 
 			/**
@@ -442,7 +456,7 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 			 * @param   array $field The ACF field related to this query.
 			 * @param   (int|string) $post_id The post_id being edited.
 			 */
-			return apply_filters( 'acf/fields/user/query', $args, $query->field, $query->post_id );
+			return apply_filters('acf/fields/user/query', $args, $query->field, $query->post_id);
 		}
 
 		/**
@@ -456,7 +470,8 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param   WP_User_Query $WP_User_Query The WP_User_Query instance.
 		 * @return  array
 		 */
-		function ajax_query_search_columns( $columns, $search, $WP_User_Query, $query ) {
+		function ajax_query_search_columns($columns, $search, $WP_User_Query, $query)
+		{
 
 			/**
 			 * Filters the column names to be searched.
@@ -469,7 +484,7 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 			 * @param   WP_User_Query $WP_User_Query The WP_User_Query instance.
 			 * @param   array $field The ACF field related to this query.
 			 */
-			return apply_filters( 'acf/fields/user/search_columns', $columns, $search, $WP_User_Query, $query->field );
+			return apply_filters('acf/fields/user/search_columns', $columns, $search, $WP_User_Query, $query->field);
 		}
 
 		/**
@@ -483,7 +498,8 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param   ACF_Ajax_Query $query The query object.
 		 * @return  array
 		 */
-		function ajax_query_result( $item, $user, $query ) {
+		function ajax_query_result($item, $user, $query)
+		{
 
 			/**
 			 * Filters the result text.
@@ -496,7 +512,7 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 			 * @param   array $field The ACF field related to this query.
 			 * @param   (int|string) $post_id The post_id being edited.
 			 */
-			$item['text'] = apply_filters( 'acf/fields/user/result', $item['text'], $user, $query->field, $query->post_id );
+			$item['text'] = apply_filters('acf/fields/user/result', $item['text'], $user, $query->field, $query->post_id);
 			return $item;
 		}
 
@@ -510,8 +526,9 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param   array $args An array of query args.
 		 * @return  array
 		 */
-		function get_ajax_query( $options = array() ) {
-			_deprecated_function( __FUNCTION__, '5.8.9' );
+		function get_ajax_query($options = array())
+		{
+			_deprecated_function(__FUNCTION__, '5.8.9');
 			return array();
 		}
 
@@ -527,8 +544,9 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param   WP_User_Query $WP_User_Query The WP_User_Query instance.
 		 * @return  array
 		 */
-		function user_search_columns( $columns, $search, $WP_User_Query ) {
-			_deprecated_function( __FUNCTION__, '5.8.9' );
+		function user_search_columns($columns, $search, $WP_User_Query)
+		{
+			_deprecated_function(__FUNCTION__, '5.8.9');
 			return $columns;
 		}
 
@@ -540,59 +558,60 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param  array   $field The field array.
 		 * @return boolean|WP_Error
 		 */
-		public function validate_rest_value( $valid, $value, $field ) {
-			if ( is_null( $value ) ) {
+		public function validate_rest_value($valid, $value, $field)
+		{
+			if (is_null($value)) {
 				return $valid;
 			}
 
-			$param = sprintf( '%s[%s]', $field['prefix'], $field['name'] );
-			$data  = array( 'param' => $param );
-			$value = is_array( $value ) ? $value : array( $value );
+			$param = sprintf('%s[%s]', $field['prefix'], $field['name']);
+			$data = array('param' => $param);
+			$value = is_array($value) ? $value : array($value);
 
-			$invalid_users      = array();
+			$invalid_users = array();
 			$insufficient_roles = array();
 
-			foreach ( $value as $user_id ) {
-				$user_data = get_userdata( $user_id );
-				if ( ! $user_data ) {
+			foreach ($value as $user_id) {
+				$user_data = get_userdata($user_id);
+				if (!$user_data) {
 					$invalid_users[] = $user_id;
 					continue;
 				}
 
-				if ( empty( $field['role'] ) ) {
+				if (empty($field['role'])) {
 					continue;
 				}
 
-				$has_roles = count( array_intersect( $field['role'], $user_data->roles ) );
-				if ( ! $has_roles ) {
+				$has_roles = count(array_intersect($field['role'], $user_data->roles));
+				if (!$has_roles) {
 					$insufficient_roles[] = $user_id;
 				}
 			}
 
-			if ( count( $invalid_users ) ) {
+			if (count($invalid_users)) {
 				$error = sprintf(
 					/* translators: %s: field value */
-					__( '%1$s must have a valid user ID.', 'secure-custom-fields' ),
+					__('%1$s must have a valid user ID.', 'secure-custom-fields'),
 					$param
 				);
 				$data['value'] = $invalid_users;
-				return new WP_Error( 'rest_invalid_param', $error, $data );
+				return new WP_Error('rest_invalid_param', $error, $data);
 			}
 
-			if ( count( $insufficient_roles ) ) {
+			if (count($insufficient_roles)) {
 				$error = sprintf(
 					/* translators: 1: field name, 2: role name */
 					_n(
 						'%1$s must have a user with the %2$s role.',
 						'%1$s must have a user with one of the following roles: %2$s',
-						count( $field['role'] ),
+						count($field['role']),
 						'secure-custom-fields'
 					),
 					$param,
-					count( $field['role'] ) > 1 ? implode( ', ', $field['role'] ) : $field['role'][0]
+					count($field['role']) > 1 ? implode(', ', $field['role']) : $field['role'][0]
 				);
 				$data['value'] = $insufficient_roles;
-				return new WP_Error( 'rest_invalid_param', $error, $data );
+				return new WP_Error('rest_invalid_param', $error, $data);
 			}
 
 			return $valid;
@@ -604,20 +623,21 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param array $field
 		 * @return array
 		 */
-		public function get_rest_schema( array $field ) {
+		public function get_rest_schema(array $field)
+		{
 			$schema = array(
-				'type'     => array( 'integer', 'array', 'null' ),
-				'required' => ! empty( $field['required'] ),
-				'items'    => array(
+				'type' => array('integer', 'array', 'null'),
+				'required' => !empty($field['required']),
+				'items' => array(
 					'type' => 'integer',
 				),
 			);
 
-			if ( empty( $field['allow_null'] ) ) {
+			if (empty($field['allow_null'])) {
 				$schema['minItems'] = 1;
 			}
 
-			if ( empty( $field['multiple'] ) ) {
+			if (empty($field['multiple'])) {
 				$schema['maxItems'] = 1;
 			}
 
@@ -631,17 +651,18 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param array          $field
 		 * @return array
 		 */
-		public function get_rest_links( $value, $post_id, array $field ) {
+		public function get_rest_links($value, $post_id, array $field)
+		{
 			$links = array();
 
-			if ( empty( $value ) ) {
+			if (empty($value)) {
 				return $links;
 			}
 
-			foreach ( (array) $value as $object_id ) {
+			foreach ((array) $value as $object_id) {
 				$links[] = array(
-					'rel'        => 'acf:user',
-					'href'       => rest_url( '/wp/v2/users/' . $object_id ),
+					'rel' => 'acf:user',
+					'href' => rest_url('/wp/v2/users/' . $object_id),
 					'embeddable' => true,
 				);
 			}
@@ -657,8 +678,9 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param array          $field
 		 * @return mixed
 		 */
-		public function format_value_for_rest( $value, $post_id, array $field ) {
-			return acf_format_numerics( $value );
+		public function format_value_for_rest($value, $post_id, array $field)
+		{
+			return acf_format_numerics($value);
 		}
 
 		/**
@@ -671,41 +693,42 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param array          $field   The field array.
 		 * @return mixed
 		 */
-		public function format_value_for_jsonld( $value, $post_id, $field ) {
-			if ( empty( $value ) ) {
+		public function format_value_for_jsonld($value, $post_id, $field)
+		{
+			if (empty($value)) {
 				return null;
 			}
 
 			// Get output format with fallback.
 			$output_format = $field['schema_output_format'] ?? '';
-			if ( empty( $output_format ) ) {
-				$property      = $field['schema_property'] ?? '';
-				$output_format = \SCF\AI\GEO\Schema::get_default_output_format( $this->name, $property );
+			if (empty($output_format)) {
+				$property = $field['schema_property'] ?? '';
+				$output_format = \SCF\AI\GEO\Schema::get_default_output_format($this->name, $property);
 			}
 
 			// Default to Person if still empty.
-			if ( empty( $output_format ) ) {
+			if (empty($output_format)) {
 				$output_format = 'Person';
 			}
 
 			$field['return_format'] = 'object';
-			$users                  = $this->format_value( $value, $post_id, $field );
+			$users = $this->format_value($value, $post_id, $field);
 
-			if ( ! $users ) {
+			if (!$users) {
 				return null;
 			}
 
 			// Handle single user.
-			if ( $users instanceof \WP_User ) {
-				return $this->format_user_for_jsonld( $users, $output_format );
+			if ($users instanceof \WP_User) {
+				return $this->format_user_for_jsonld($users, $output_format);
 			}
 
 			// Handle multiple users.
 			$formatted = array();
-			if ( is_array( $users ) ) {
-				foreach ( $users as $user ) {
-					if ( $user instanceof \WP_User ) {
-						$formatted[] = $this->format_user_for_jsonld( $user, $output_format );
+			if (is_array($users)) {
+				foreach ($users as $user) {
+					if ($user instanceof \WP_User) {
+						$formatted[] = $this->format_user_for_jsonld($user, $output_format);
 					}
 				}
 			}
@@ -722,15 +745,16 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 * @param string   $output_format The output format (Person or Organization).
 		 * @return array The formatted user data.
 		 */
-		private function format_user_for_jsonld( $user, $output_format ) {
+		private function format_user_for_jsonld($user, $output_format)
+		{
 			$data = array(
 				'@type' => $output_format,
-				'name'  => $user->get( 'display_name' ),
+				'name' => $user->get('display_name'),
 			);
 
 			// Add URL if available.
-			$url = $user->get( 'user_url' );
-			if ( $url ) {
+			$url = $user->get('user_url');
+			if ($url) {
 				$data['url'] = $url;
 			}
 
@@ -744,12 +768,13 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 		 *
 		 * @return string[]
 		 */
-		public function get_jsonld_output_types(): array {
-			return array( 'Person', 'Organization' );
+		public function get_jsonld_output_types(): array
+		{
+			return array('Person', 'Organization');
 		}
 	}
 
 
 	// initialize
-	acf_register_field_type( 'ACF_Field_User' );
+	acf_register_field_type('ACF_Field_User');
 endif; // class_exists check


### PR DESCRIPTION
The  instructions  string in both Select and User field settings wasn't wrapped in  __()  so it couldn't be translated

Closes #479 
