### PR TITLE
Copy: make strings reported in #479 translatable

### DIFF
--- a/includes/fields/class-acf-field-page_link.php
+++ b/includes/fields/class-acf-field-page_link.php
@@ -483,7 +483,7 @@ if ( ! class_exists( 'acf_field_page_link' ) ) :
 			acf_render_field_setting(
 				$field,
 				array(
-					'label'        => __( 'Allow Archives URLs', 'secure-custom-fields' ),
+					'label'        => __( 'Allow Archive URLs', 'secure-custom-fields' ),
 					'instructions' => '',
 					'name'         => 'allow_archives',
 					'type'         => 'true_false',
@@ -495,7 +495,7 @@ if ( ! class_exists( 'acf_field_page_link' ) ) :
 				$field,
 				array(
 					'label'        => __( 'Select Multiple', 'secure-custom-fields' ),
-					'instructions' => 'Allow content editors to select multiple values',
+					'instructions' => __( 'Allow content editors to select multiple values', 'secure-custom-fields' ),
 					'name'         => 'multiple',
 					'type'         => 'true_false',
 					'ui'           => 1,

--- a/includes/fields/class-acf-field-post_object.php
+++ b/includes/fields/class-acf-field-post_object.php
@@ -409,7 +409,7 @@ if ( ! class_exists( 'acf_field_post_object' ) ) :
 				$field,
 				array(
 					'label'        => __( 'Select Multiple', 'secure-custom-fields' ),
-					'instructions' => 'Allow content editors to select multiple values',
+					'instructions' => __( 'Allow content editors to select multiple values', 'secure-custom-fields' ),
 					'name'         => 'multiple',
 					'type'         => 'true_false',
 					'ui'           => 1,

--- a/includes/fields/class-acf-field-select.php
+++ b/includes/fields/class-acf-field-select.php
@@ -390,7 +390,7 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 				$field,
 				array(
 					'label'        => __( 'Select Multiple', 'secure-custom-fields' ),
-					'instructions' => 'Allow content editors to select multiple values',
+					'instructions' => __( 'Allow content editors to select multiple values', 'secure-custom-fields' ),
 					'name'         => 'multiple',
 					'type'         => 'true_false',
 					'ui'           => 1,

--- a/includes/fields/class-acf-field-user.php
+++ b/includes/fields/class-acf-field-user.php
@@ -114,7 +114,7 @@ if ( ! class_exists( 'ACF_Field_User' ) ) :
 				$field,
 				array(
 					'label'        => __( 'Select Multiple', 'secure-custom-fields' ),
-					'instructions' => 'Allow content editors to select multiple values',
+					'instructions' => __( 'Allow content editors to select multiple values', 'secure-custom-fields' ),
 					'name'         => 'multiple',
 					'type'         => 'true_false',
 					'ui'           => 1,


### PR DESCRIPTION
Fixes #479 by wrapping the untranslated text string in the `__()` translation helper.

Closes #479 