### PR TITLE
#499 UI: Align URL Field Globe Icon Inside the URL Input Box.

### DIFF
--- a/assets/src/sass/acf-input.scss
+++ b/assets/src/sass/acf-input.scss
@@ -709,7 +709,8 @@ html[dir=rtl] input.acf-is-prepended.acf-is-appended {
 *-----------------------------------------------------------------------------*/
 .acf-url i {
   position: absolute;
-  top: 5px;
+  top: 50%;
+  transform: translateY(-50%);
   left: 5px;
   opacity: 0.5;
   color: #7e8993;


### PR DESCRIPTION
<!-- Insert a description of your changes here -->
This PR is to resolve #499 . the issue is the globe icon in url field does not aligned in center. I added css to make it center aligned.
``` css 
   .acf-url i {
      top: 50%;
      transform: translateY(-50%);
} 
``` 

<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #499 