### PR TITLE
Security: Instruction does not escape html

### DIFF
--- a/includes/acf-field-functions.php
+++ b/includes/acf-field-functions.php
@@ -907,11 +907,11 @@ function acf_render_field_instructions( $field, $tooltip = false ) {
 		if ( $tooltip ) {
 			printf( '<div class="acf-tip"><i tabindex="0" class="acf-icon acf-icon-help acf-js-tooltip" title="%s">?</i></div>', esc_attr( $instructions ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped earlier in function.
 		} else {
-			printf( '<p class="description">%s</p>', $instructions ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped earlier in function.
+			printf( '<p class="description">%s</p>', esc_html( $instructions ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped earlier in function.
 		}
 	} elseif ( ! empty( $field['hint'] ) ) {
 		$instructions = acf_esc_html( $field['hint'] );
-		printf( '<p class="description">%s</p>', $instructions ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped earlier in function.
+		printf( '<p class="description">%s</p>', esc_html( $instructions ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped earlier in function.
 	}
 }
 


### PR DESCRIPTION
Add Escaping for Instruction Field as its breaking tab when the field group created in theme/plugin file by scf action hooks like 'acf/include_fields'.
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #502