### PR TITLE
Backport: ACF 6.8.6 changes

### DIFF
--- a/assets/src/js/_acf-validation.js
+++ b/assets/src/js/_acf-validation.js
@@ -746,13 +746,20 @@
 	 *
 	 * @date	20/10/2021
 	 * @since	ACF 5.11.0
+	 *
+	 * @param {jQuery} [$form] - Optional form element to scope the input search to. If omitted, searches the entire document.
 	 */
-	var ensureInvalidFieldVisibility = function () {
-		// Load each ACF input field and check it's browser validation state.
-		var $inputs = $( '.acf-field input' );
+	const ensureInvalidFieldVisibility = function ( $form ) {
+		// Load each ACF input field and check its browser validation state.
+		// Scope to the given form if provided, otherwise search the entire document.
+		const $inputs = $form
+			? $form.find( '.acf-field input' )
+			: $( '.acf-field input' );
 		$inputs.each( function () {
-			if ( ! this.checkValidity() ) {
-				// Field is invalid, so we need to make sure it's metabox is visible.
+			// Use validity.valid (a property) instead of checkValidity() (a method) to avoid
+			// dispatching the native 'invalid' event, which can trigger ACF validation prematurely.
+			if ( ! this.validity.valid ) {
+				// Field is invalid, so we need to make sure its metabox is visible.
 				ensureFieldPostBoxIsVisible( $( this ) );
 			}
 		} );
@@ -924,19 +931,37 @@
 		 *
 		 *  Callback when clicking submit.
 		 *
+		 *  Only acts on submit buttons that are associated with a form containing ACF fields.
+		 *  This prevents submit buttons in unrelated UI (e.g. the WP link inserter modal) from
+		 *  triggering premature validation of ACF fields on the page behind the modal.
+		 *
+		 *  Uses the native HTMLButtonElement.form property to resolve the associated form,
+		 *  which correctly handles both DOM-ancestor forms and the HTML form="id" attribute.
+		 *
 		 *  @date	4/9/18
 		 *  @since	ACF 5.7.5
 		 *
 		 *  @param	object e The event object.
-		 *  @param	jQuery $el The input element.
+		 *  @param	jQuery $el The submit button element.
 		 *  @return	void
 		 */
 		onClickSubmit: function ( e, $el ) {
-			// Some browsers (safari) force their browser validation before our AJAX validation,
-			// so we need to make sure fields are visible earlier than showErrors()
-			ensureInvalidFieldVisibility();
+			const form = $el.length ? $el[ 0 ].form : null;
 
-			// store the "click event" for later use in this.onSubmit()
+			if ( ! form ) {
+				return;
+			}
+
+			const $form = $( form );
+
+			if ( ! $form.find( '.acf-field' ).length ) {
+				return;
+			}
+
+			// Some browsers (safari) force their browser validation before our AJAX validation,
+			// so we need to make sure fields are visible earlier than showErrors().
+			ensureInvalidFieldVisibility( $form );
+
 			this.set( 'originalEvent', e );
 		},
 

--- a/assets/src/js/pro/_acf-blocks.js
+++ b/assets/src/js/pro/_acf-blocks.js
@@ -740,10 +740,14 @@ const md5 = require( 'md5' );
 				// Replace names for JSX counterparts.
 				name = getJSXName( name );
 
-				// Convert JSON values.
+				// Convert JSON values. Ignore values that merely start with a
+				// JSON-like character but aren't valid JSON (e.g. an oEmbed
+				// title beginning with "[" or "{").
 				const c1 = value.charAt( 0 );
 				if ( c1 === '[' || c1 === '{' ) {
-					value = JSON.parse( value );
+					try {
+						value = JSON.parse( value );
+					} catch ( err ) {}
 				}
 
 				// Convert bool values.

--- a/assets/src/js/pro/blocks-v3/components/block-edit.js
+++ b/assets/src/js/pro/blocks-v3/components/block-edit.js
@@ -94,6 +94,63 @@ const useBlockEditorInspectorSidebarOpen = () => {
 };
 
 /**
+ * Converts serialized Google Map field values from JSON strings back into
+ * objects so they aren't double-encoded when the block's data is stored as
+ * a JSON block attribute. Google Map fields keep their value as a JSON
+ * string in a hidden input, which acf.serialize() would otherwise pass
+ * through as a string.
+ *
+ * @param {Object} $form          The block form jQuery element that was serialized.
+ * @param {Object} serializedData The data returned by acf.serialize(); modified in place.
+ * @param {string} clientId       The block client ID.
+ * @return {void}
+ */
+function deserializeGoogleMapValues( $form, serializedData, clientId ) {
+	const inputPrefix = `acf-block_${ clientId }`;
+
+	$form
+		.find( '.acf-field-google-map input[type="hidden"][name]' )
+		.each( function () {
+			if ( this.name.indexOf( inputPrefix ) !== 0 ) {
+				return;
+			}
+
+			// Extract the bracketed key path, e.g. "[field_abc][field_def]" -> [ 'field_abc', 'field_def' ].
+			const keyPath = this.name
+				.slice( inputPrefix.length )
+				.match( /([^\[\]])+/g );
+			if ( ! keyPath ) {
+				return;
+			}
+
+			// Walk the serialized data down to the parent of the leaf key.
+			let parent = serializedData;
+			for ( let i = 0; i < keyPath.length - 1; i++ ) {
+				if ( parent === null || typeof parent !== 'object' ) {
+					return;
+				}
+				parent = parent[ keyPath[ i ] ];
+			}
+			if ( parent === null || typeof parent !== 'object' ) {
+				return;
+			}
+
+			const leafKey = keyPath[ keyPath.length - 1 ];
+			if ( typeof parent[ leafKey ] === 'string' ) {
+				try {
+					const parsedValue = JSON.parse( parent[ leafKey ] );
+					if (
+						typeof parsedValue === 'object' &&
+						parsedValue !== null
+					) {
+						parent[ leafKey ] = parsedValue;
+					}
+				} catch ( err ) {}
+			}
+		} );
+}
+
+/**
  * Main BlockEdit component wrapper
  * Manages block data fetching and initial setup
  *
@@ -925,6 +982,7 @@ function BlockEditInner( props ) {
 			`acf-block_${ clientId }`
 		);
 		if ( serializedData ) {
+			deserializeGoogleMapValues( $form, serializedData, clientId );
 			setTheSerializedAcfData( JSON.stringify( serializedData ) );
 		} else {
 			setUserHasInteractedWithForm( false );
@@ -1167,6 +1225,11 @@ function BlockEditInner( props ) {
 									`acf-block_${ clientId }`
 								);
 								if ( serializedData ) {
+									deserializeGoogleMapValues(
+										$form,
+										serializedData,
+										clientId
+									);
 									setTheSerializedAcfData(
 										JSON.stringify( serializedData )
 									);

--- a/assets/src/js/pro/blocks-v3/components/jsx-parser.js
+++ b/assets/src/js/pro/blocks-v3/components/jsx-parser.js
@@ -137,9 +137,13 @@ function parseAttribute( attribute ) {
 			}
 
 			attrName = getJSXNameReplacement( attrName );
+			// Ignore values that merely start with a JSON-like character but
+			// aren't valid JSON (e.g. an oEmbed title beginning with "[" or "{").
 			const firstChar = attrValue.charAt( 0 );
 			if ( firstChar === '[' || firstChar === '{' ) {
-				attrValue = JSON.parse( attrValue );
+				try {
+					attrValue = JSON.parse( attrValue );
+				} catch ( err ) {}
 			}
 			if ( attrValue === 'true' || attrValue === 'false' ) {
 				attrValue = attrValue === 'true';

--- a/assets/src/sass/_fields.scss
+++ b/assets/src/sass/_fields.scss
@@ -562,6 +562,12 @@ body.acf-browser-firefox .acf-field select {
 		border-color: $wp38-input-border;
 		min-height: 28px;
 	}
+
+	// WP 7.0+
+	@include wp-admin("7-0") {
+		min-height: 40px;
+		padding: 9px 8px;
+	}
 }
 
 .acf-input-prepend {
@@ -701,10 +707,9 @@ html[dir="rtl"] input.acf-is-prepended.acf-is-appended {
 *-----------------------------------------------------------------------------*/
 
 .acf-url {
+
 	i {
 		position: absolute;
-		// SCF: vertically center the globe icon (SCF #500; ACF adopted
-		// the same change in ACF 6.8.6).
 		top: 50%;
 		left: 5px;
 		transform: translateY(-50%);
@@ -735,6 +740,11 @@ html[dir="rtl"] input.acf-is-prepended.acf-is-appended {
 		border-color: #ddd;
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.07) inset;
 		min-height: 31px;
+
+		// WP 7.0+
+		@include wp-admin("7-0") {
+			min-height: 40px;
+		}
 
 		.select2-search-choice {
 			margin: 5px 0 5px 5px;
@@ -869,6 +879,40 @@ html[dir="rtl"] .select2-container.-acf {
 		// WP Admin 3.8
 		@include wp-admin("3-8") {
 			border-color: #aaa;
+		}
+	}
+
+	// WP 7.0+
+	@include wp-admin("7-0") {
+		.select2-selection--single {
+			height: 40px;
+
+			.select2-selection__rendered {
+				line-height: 38px;
+			}
+		}
+
+		.select2-selection--multiple {
+			min-height: 40px;
+			line-height: 0;
+
+			.select2-selection__rendered {
+				line-height: normal;
+				display: flex;
+				align-items: center;
+				flex-wrap: wrap;
+				min-height: 38px;
+			}
+
+			.select2-search__field {
+				margin-top: 0;
+			}
+
+			.select2-selection__choice {
+				margin-top: 0;
+				padding-top: 4px;
+				padding-bottom: 4px;
+			}
 		}
 	}
 

--- a/includes/admin/admin.php
+++ b/includes/admin/admin.php
@@ -82,6 +82,10 @@ if ( ! class_exists( 'ACF_Admin' ) ) :
 			// Add body class.
 			$classes .= ' acf-admin-5-3';
 
+			if ( version_compare( $wp_version, '7.0', '>=' ) ) {
+				$classes .= ' acf-admin-7-0';
+			}
+
 			// Add browser for specific CSS.
 			$classes .= ' acf-browser-' . esc_attr( acf_get_browser() );
 

--- a/includes/blocks-auto-inline-editing.php
+++ b/includes/blocks-auto-inline-editing.php
@@ -48,9 +48,17 @@ function get_non_auto_inline_editing_fields(): array {
  */
 function populate_auto_inline_editing_values( $field_value, $post_id, $field ) {
 
-	global $acf_fields_used_in_block_render_template, $acf_blocks_doing_auto_inline_editing;
+	global $acf_fields_used_in_block_render_template, $acf_blocks_doing_auto_inline_editing, $acf_blocks_doing_auto_inline_editing_block_id;
 
 	if ( ! $acf_blocks_doing_auto_inline_editing || ! empty( $field['parent_repeater'] ) ) {
+		return $field_value;
+	}
+
+	// Only modify values for fields fetched against the current block's own post id.
+	// Calls like get_field( 'foo', $other_post_id ) target a different post and must be returned unmodified
+	// so block templates can rely on real values (e.g. for conditional logic) instead of placeholder strings.
+	if ( ! empty( $acf_blocks_doing_auto_inline_editing_block_id )
+		&& (string) $post_id !== (string) $acf_blocks_doing_auto_inline_editing_block_id ) {
 		return $field_value;
 	}
 
@@ -90,21 +98,33 @@ add_filter( 'acf/format_value', __NAMESPACE__ . '\populate_auto_inline_editing_v
  * @return string
  */
 function apply_inline_editing_attributes_to_render_template( $path, $block, $content, $is_preview, $post_id, $wp_block, $context ): string {
-	global $acf_fields_used_in_block_render_template, $acf_blocks_doing_auto_inline_editing;
+	global $acf_fields_used_in_block_render_template, $acf_blocks_doing_auto_inline_editing, $acf_blocks_doing_auto_inline_editing_block_id;
 
 	unset( $content, $is_preview, $post_id, $wp_block, $context );
 
-	$acf_fields_used_in_block_render_template = array();
+	// Save the entire previous render context (fields collected, doing-flag, block id) so a
+	// nested SCF block render does not clobber the parent's tracked fields or active block id.
+	$previous_fields                    = is_array( $acf_fields_used_in_block_render_template ) ? $acf_fields_used_in_block_render_template : array();
+	$previous_doing_auto_inline_editing = ! empty( $acf_blocks_doing_auto_inline_editing );
+	$previous_block_id                  = $acf_blocks_doing_auto_inline_editing_block_id ?? null;
 
-	$acf_blocks_doing_auto_inline_editing = true;
+	$acf_fields_used_in_block_render_template      = array();
+	$acf_blocks_doing_auto_inline_editing          = true;
+	$acf_blocks_doing_auto_inline_editing_block_id = $block['id'] ?? null;
 
 	ob_start();
 	include $path;
 	$html = ob_get_clean();
 
-	$acf_blocks_doing_auto_inline_editing = false;
+	// Process the HTML before restoring the parent context - apply_inline_editing_attributes_to_html_string()
+	// reads $acf_fields_used_in_block_render_template via global, so it must see THIS block's field list.
+	$processed_html = apply_inline_editing_attributes_to_html_string( $html, $block );
 
-	return apply_inline_editing_attributes_to_html_string( $html, $block );
+	$acf_fields_used_in_block_render_template      = $previous_fields;
+	$acf_blocks_doing_auto_inline_editing          = $previous_doing_auto_inline_editing;
+	$acf_blocks_doing_auto_inline_editing_block_id = $previous_block_id;
+
+	return $processed_html;
 }
 
 /**
@@ -120,19 +140,31 @@ function apply_inline_editing_attributes_to_render_template( $path, $block, $con
  * @return string
  */
 function apply_inline_editing_attributes_to_render_callback( $render_callback, $block, $content, $is_preview, $post_id, $wp_block, $context ): string {
-	global $acf_fields_used_in_block_render_template, $acf_blocks_doing_auto_inline_editing;
+	global $acf_fields_used_in_block_render_template, $acf_blocks_doing_auto_inline_editing, $acf_blocks_doing_auto_inline_editing_block_id;
 
-	$acf_fields_used_in_block_render_template = array();
+	// Save the entire previous render context (fields collected, doing-flag, block id) so a
+	// nested SCF block render does not clobber the parent's tracked fields or active block id.
+	$previous_fields                    = is_array( $acf_fields_used_in_block_render_template ) ? $acf_fields_used_in_block_render_template : array();
+	$previous_doing_auto_inline_editing = ! empty( $acf_blocks_doing_auto_inline_editing );
+	$previous_block_id                  = $acf_blocks_doing_auto_inline_editing_block_id ?? null;
 
-	$acf_blocks_doing_auto_inline_editing = true;
+	$acf_fields_used_in_block_render_template      = array();
+	$acf_blocks_doing_auto_inline_editing          = true;
+	$acf_blocks_doing_auto_inline_editing_block_id = $block['id'] ?? null;
 
 	ob_start();
 	call_user_func( $render_callback, $block, $content, $is_preview, $post_id, $wp_block, $context );
 	$html = ob_get_clean();
 
-	$acf_blocks_doing_auto_inline_editing = false;
+	// Process the HTML before restoring the parent context - apply_inline_editing_attributes_to_html_string()
+	// reads $acf_fields_used_in_block_render_template via global, so it must see THIS block's field list.
+	$processed_html = apply_inline_editing_attributes_to_html_string( $html, $block );
 
-	return apply_inline_editing_attributes_to_html_string( $html, $block );
+	$acf_fields_used_in_block_render_template      = $previous_fields;
+	$acf_blocks_doing_auto_inline_editing          = $previous_doing_auto_inline_editing;
+	$acf_blocks_doing_auto_inline_editing_block_id = $previous_block_id;
+
+	return $processed_html;
 }
 
 /**

--- a/includes/forms/WC_Order.php
+++ b/includes/forms/WC_Order.php
@@ -39,6 +39,31 @@ class WC_Order {
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 10, 2 );
 		// Only attach the save handler on order edit screens.
 		add_action( 'woocommerce_update_order', array( $this, 'save_order' ), 10, 1 );
+		add_filter( 'acf/form-post/skip_save', array( $this, 'skip_post_save_for_orders' ), 10, 3 );
+	}
+
+	/**
+	 * Prevents ACF_Form_Post from saving order posts so that save_order()
+	 * remains the single save entry-point. Without this, the backfill
+	 * triggered by WooCommerce Compatibility Mode fires save_post before
+	 * woocommerce_update_order, consuming the ACF nonce and causing
+	 * save_order() to bail.
+	 *
+	 * @since ACF 6.8.6
+	 *
+	 * @param boolean  $skip    Whether to skip the save.
+	 * @param integer  $post_id The post ID being saved.
+	 * @param \WP_Post $post    The post being saved.
+	 * @return boolean
+	 */
+	public function skip_post_save_for_orders( $skip, $post_id, $post ) {
+		$order_types = function_exists( 'wc_get_order_types' ) ? wc_get_order_types( 'view-orders' ) : array( 'shop_order', 'shop_subscription' );
+
+		if ( $post instanceof \WP_Post && in_array( $post->post_type, $order_types, true ) ) {
+			return true;
+		}
+
+		return $skip;
 	}
 
 	/**

--- a/includes/locations/abstract-acf-location.php
+++ b/includes/locations/abstract-acf-location.php
@@ -164,20 +164,22 @@ if ( ! class_exists( 'ACF_Location' ) ) :
 		 * @date    17/9/19
 		 * @since   ACF 5.8.1
 		 *
-		 * @param   array $rule  The location rule data.
 		 * @param   mixed $value The value to compare against.
+		 * @param   array $rule  The location rule data.
 		 * @return  boolean
 		 */
 		public function compare_to_rule( $value, $rule ) {
-			$result = ( $value == $rule['value'] );
+			$rule_value = $rule['value'] ?? '';
+			// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual, WordPress.PHP.StrictComparisons.LooseComparison -- Values may be mixed int/string types; loose comparison is intentional for upstream parity.
+			$result = ( $value == $rule_value );
 
 			// Allow "all" to match any value.
-			if ( $rule['value'] === 'all' ) {
+			if ( 'all' === $rule_value ) {
 				$result = true;
 			}
 
 			// Reverse result for "!=" operator.
-			if ( $rule['operator'] === '!=' ) {
+			if ( ( $rule['operator'] ?? '' ) === '!=' ) {
 				return ! $result;
 			}
 			return $result;

--- a/includes/locations/class-acf-location-attachment.php
+++ b/includes/locations/class-acf-location-attachment.php
@@ -48,12 +48,13 @@ if ( ! class_exists( 'ACF_Location_Attachment' ) ) :
 			$mime_type = get_post_mime_type( $attachment );
 
 			// Allow for unspecific mim_type matching such as "image" or "video".
-			if ( ! strpos( $rule['value'], '/' ) ) {
+			$rule_value = $rule['value'] ?? '';
+			if ( $rule_value && ! strpos( $rule_value, '/' ) ) {
 
 				// Explode mime_type into bits ([0] => type, [1] => subtype) and match type.
 				$bits = explode( '/', $mime_type );
-				if ( $bits[0] === $rule['value'] ) {
-					$mime_type = $rule['value'];
+				if ( $bits[0] === $rule_value ) {
+					$mime_type = $rule_value;
 				}
 			}
 			return $this->compare_to_rule( $mime_type, $rule );

--- a/includes/locations/class-acf-location-current-user-role.php
+++ b/includes/locations/class-acf-location-current-user-role.php
@@ -42,16 +42,17 @@ if ( ! class_exists( 'ACF_Location_Current_User_Role' ) ) :
 			}
 
 			// Check super_admin value.
-			if ( $rule['value'] == 'super_admin' ) {
+			$rule_value = $rule['value'] ?? '';
+			if ( 'super_admin' === $rule_value ) {
 				$result = is_super_admin( $user->ID );
 
 				// Check role.
 			} else {
-				$result = in_array( $rule['value'], $user->roles );
+				$result = in_array( $rule_value, $user->roles, true );
 			}
 
 			// Reverse result for "!=" operator.
-			if ( $rule['operator'] === '!=' ) {
+			if ( ( $rule['operator'] ?? '' ) === '!=' ) {
 				return ! $result;
 			}
 			return $result;

--- a/includes/locations/class-acf-location-current-user.php
+++ b/includes/locations/class-acf-location-current-user.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'ACF_Location_Current_User' ) ) :
 		 * @return  boolean
 		 */
 		public function match( $rule, $screen, $field_group ) {
-			switch ( $rule['value'] ) {
+			switch ( $rule['value'] ?? '' ) {
 				case 'logged_in':
 					$result = is_user_logged_in();
 					break;
@@ -50,7 +50,7 @@ if ( ! class_exists( 'ACF_Location_Current_User' ) ) :
 			}
 
 			// Reverse result for "!=" operator.
-			if ( $rule['operator'] === '!=' ) {
+			if ( ( $rule['operator'] ?? '' ) === '!=' ) {
 				return ! $result;
 			}
 			return $result;

--- a/includes/locations/class-acf-location-nav-menu.php
+++ b/includes/locations/class-acf-location-nav-menu.php
@@ -44,7 +44,8 @@ if ( ! class_exists( 'ACF_Location_Nav_Menu' ) ) :
 			}
 
 			// Allow for "location/xxx" rule value.
-			$bits = explode( '/', $rule['value'] );
+			$rule['value'] = $rule['value'] ?? '';
+			$bits          = explode( '/', $rule['value'] );
 			if ( $bits[0] === 'location' ) {
 				$location = $bits[1];
 

--- a/includes/locations/class-acf-location-page-template.php
+++ b/includes/locations/class-acf-location-page-template.php
@@ -48,7 +48,7 @@ if ( ! class_exists( 'ACF_Location_Page_Template' ) ) :
 
 			// Page templates were extended in WordPress version 4.7 for all post types.
 			// Prevent this rule (which is scoped to the "page" post type) appearing on all post types without a template selected (default template).
-			if ( $rule['value'] === 'default' && $post_type !== 'page' ) {
+			if ( 'default' === ( $rule['value'] ?? '' ) && 'page' !== $post_type ) {
 				return false;
 			}
 

--- a/includes/locations/class-acf-location-page-type.php
+++ b/includes/locations/class-acf-location-page-type.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'ACF_Location_Page_Type' ) ) :
 			}
 
 			// Compare.
-			switch ( $rule['value'] ) {
+			switch ( $rule['value'] ?? '' ) {
 				case 'front_page':
 					$front_page = (int) get_option( 'page_on_front' );
 					$result     = ( $front_page === $post->ID );
@@ -89,7 +89,7 @@ if ( ! class_exists( 'ACF_Location_Page_Type' ) ) :
 			}
 
 			// Reverse result for "!=" operator.
-			if ( $rule['operator'] === '!=' ) {
+			if ( ( $rule['operator'] ?? '' ) === '!=' ) {
 				return ! $result;
 			}
 			return $result;

--- a/includes/locations/class-acf-location-post-taxonomy.php
+++ b/includes/locations/class-acf-location-post-taxonomy.php
@@ -46,7 +46,7 @@ if ( ! class_exists( 'ACF_Location_Post_Taxonomy' ) ) :
 			}
 
 			// Get WP_Term from rule value.
-			$term = acf_get_term( $rule['value'] );
+			$term = acf_get_term( $rule['value'] ?? '' );
 			if ( ! $term || is_wp_error( $term ) ) {
 				return false;
 			}
@@ -67,7 +67,7 @@ if ( ! class_exists( 'ACF_Location_Post_Taxonomy' ) ) :
 			$result = ( in_array( $term->term_id, $post_terms ) || in_array( $term->slug, $post_terms ) );
 
 			// Reverse result for "!=" operator.
-			if ( $rule['operator'] === '!=' ) {
+			if ( ( $rule['operator'] ?? '' ) === '!=' ) {
 				return ! $result;
 			}
 			return $result;
@@ -96,8 +96,8 @@ if ( ! class_exists( 'ACF_Location_Post_Taxonomy' ) ) :
 		 * @return  string|array
 		 */
 		public function get_object_subtype( $rule ) {
-			if ( $rule['operator'] === '==' ) {
-				$term = acf_decode_term( $rule['value'] );
+			if ( ( $rule['operator'] ?? '' ) === '==' ) {
+				$term = acf_decode_term( $rule['value'] ?? '' );
 				if ( $term ) {
 					$taxonomy = get_taxonomy( $term['taxonomy'] );
 					if ( $taxonomy ) {

--- a/includes/locations/class-acf-location-post-template.php
+++ b/includes/locations/class-acf-location-post-template.php
@@ -97,18 +97,19 @@ if ( ! class_exists( 'ACF_Location_Post_Template' ) ) :
 		 * @return  string|array
 		 */
 		public function get_object_subtype( $rule ) {
-			if ( $rule['operator'] === '==' ) {
+			if ( ( $rule['operator'] ?? '' ) === '==' ) {
 				$post_templates = acf_get_post_templates();
+				$value          = $rule['value'] ?? '';
 
 				// If "default", return array of all post types which have templates.
-				if ( $rule['value'] === 'default' ) {
+				if ( 'default' === $value ) {
 					return array_keys( $post_templates );
 
 					// Otherwise, generate list of post types that have the selected template.
 				} else {
 					$post_types = array();
 					foreach ( $post_templates as $post_type => $templates ) {
-						if ( isset( $templates[ $rule['value'] ] ) ) {
+						if ( isset( $templates[ $value ] ) ) {
 							$post_types[] = $post_type;
 						}
 					}

--- a/includes/locations/class-acf-location-post-type.php
+++ b/includes/locations/class-acf-location-post-type.php
@@ -82,8 +82,8 @@ if ( ! class_exists( 'ACF_Location_Post_Type' ) ) :
 		 * @return  string|array
 		 */
 		public function get_object_subtype( $rule ) {
-			if ( $rule['operator'] === '==' ) {
-				return $rule['value'];
+			if ( ( $rule['operator'] ?? '' ) === '==' ) {
+				return $rule['value'] ?? '';
 			}
 			return '';
 		}

--- a/includes/locations/class-acf-location-taxonomy.php
+++ b/includes/locations/class-acf-location-taxonomy.php
@@ -74,9 +74,9 @@ if ( ! class_exists( 'ACF_Location_Taxonomy' ) ) :
 		 * @param   array $rule A location rule.
 		 * @return  string|array
 		 */
-		function get_object_subtype( $rule ) {
-			if ( $rule['operator'] === '==' ) {
-				return $rule['value'];
+		public function get_object_subtype( $rule ) {
+			if ( ( $rule['operator'] ?? '' ) === '==' ) {
+				return $rule['value'] ?? '';
 			}
 			return '';
 		}

--- a/includes/locations/class-acf-location-user-form.php
+++ b/includes/locations/class-acf-location-user-form.php
@@ -48,7 +48,7 @@ if ( ! class_exists( 'ACF_Location_User_Form' ) ) :
 			}
 
 			// The "Add / Edit" choice (foolishly valued "edit") should match true for either "add" or "edit".
-			if ( $rule['value'] === 'edit' && $user_form === 'add' ) {
+			if ( 'edit' === ( $rule['value'] ?? '' ) && 'add' === $user_form ) {
 				$user_form = 'edit';
 			}
 

--- a/includes/locations/class-acf-location-user-role.php
+++ b/includes/locations/class-acf-location-user-role.php
@@ -50,7 +50,7 @@ if ( ! class_exists( 'ACF_Location_User_Role' ) ) :
 					$user_role = get_option( 'default_role' );
 
 					// Check if user can, and if so, set the value allowing them to match.
-				} elseif ( user_can( $user_id, $rule['value'] ) ) {
+				} elseif ( ( $rule['value'] ?? '' ) && user_can( $user_id, $rule['value'] ) ) {
 					$user_role = $rule['value'];
 				}
 			} else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 		"": {
 			"dependencies": {
 				"@wordpress/icons": "^10.26.0",
-				"dompurify": "3.3.0",
+				"dompurify": "3.4.11",
 				"md5": "^2.3.0"
 			},
 			"devDependencies": {
@@ -13590,9 +13590,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
-			"integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
+			"version": "3.4.11",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+			"integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	},
 	"dependencies": {
 		"@wordpress/icons": "^10.26.0",
-		"dompurify": "3.3.0",
+		"dompurify": "3.4.11",
 		"md5": "^2.3.0"
 	},
 	"devDependencies": {

--- a/tests/js/blocks-v3/jsx-parser.test.js
+++ b/tests/js/blocks-v3/jsx-parser.test.js
@@ -139,16 +139,18 @@ describe( 'parseJSX', () => {
 			expect( result.props.config ).toEqual( { key: 'value' } );
 		} );
 
-		test( 'throws SyntaxError on invalid JSON array attribute', () => {
-			expect( () => {
-				parseJSX( '<div items="[invalid json">Content</div>' );
-			} ).toThrow( SyntaxError );
+		test( 'keeps invalid JSON array attribute as a string', () => {
+			const result = parseJSX(
+				'<div items="[invalid json">Content</div>'
+			);
+			expect( result.props.items ).toBe( '[invalid json' );
 		} );
 
-		test( 'throws SyntaxError on invalid JSON object attribute', () => {
-			expect( () => {
-				parseJSX( '<div config="{not: valid}">Content</div>' );
-			} ).toThrow( SyntaxError );
+		test( 'keeps invalid JSON object attribute as a string', () => {
+			const result = parseJSX(
+				'<div config="{not: valid}">Content</div>'
+			);
+			expect( result.props.config ).toBe( '{not: valid}' );
 		} );
 	} );
 


### PR DESCRIPTION
## Description

Ports the ACF 6.8.6 point release (2026-07-14) into SCF. Upstream range: ACF `6.8.5 → 6.8.6` (ACF 6.8.5 was verified to be fully covered already by earlier SCF work: #462, #467, #491 and related commits).

All seven changelog fixes from upstream are included:

- **Location rules**: guard against missing rule `value`/`operator` keys to avoid PHP warnings on page load (`includes/locations/*`). Ported from the free ACF repo (canonical for non-Pro files).
- **WP 7.0+ field appearance**: add `acf-admin-7-0` body class and port the improved URL/Number/Select field CSS. Rebased after #506: the styles are now upstream's own 6.8.6 `_fields.scss` patch applied to the partial (its `.acf-url` hunk was already on trunk via #500/#506), leaving `_fields.scss` byte-identical to upstream 6.8.6.
- **Blocks auto inline editing**: only substitute placeholder values for fields fetched against the block's own post id, and save/restore the render context so nested block renders don't clobber the parent (`includes/blocks-auto-inline-editing.php`; the stale, unloaded `pro/` copy is untouched).
- **WooCommerce HPOS compatibility mode**: register `acf/form-post/skip_save` so `save_order()` stays the single save entry-point and the backfill-triggered `save_post` no longer consumes the ACF nonce. Adapted to cover all registered order types via `wc_get_order_types()`, matching SCF's existing multi-order-type support.
- **Validation JS**: scope submit-click validation to the button's own form so unrelated UI (e.g. the Classic Editor link inserter) no longer triggers premature validation of a Link field; use `validity.valid` instead of `checkValidity()` to avoid dispatching native `invalid` events.
- **Blocks V2/V3**: don't crash on attribute values that merely start with `[` or `{` (e.g. oEmbed titles) — `JSON.parse` is now try/caught in both the V2 parser (`_acf-blocks.js`) and V3 (`jsx-parser.js`). Two jsx-parser tests asserting the old throwing behavior were updated.
- **Blocks V3**: deserialize Google Map field values after `acf.serialize()` so they aren't double-encoded in block attributes (`block-edit.js`).
- **DOMPurify**: bump 3.3.0 → 3.4.11 to match upstream's bundled upgrade.

The two block fixes only ship minified upstream; both bundle versions were pretty-printed and diffed (a string-literal set comparison confirmed these were the only substantive changes), then implemented in maintainable source — no decompiled output was pasted.

**Intentionally not ported**: the ACF email opt-in marketing banner (admin page, view, JS, CSS, images — collects emails for ACF's newsletter, not applicable to SCF), readme/version bumps, and `lang/**` translation churn (SCF has its own translation workflow).

## Testing

- `php -l` clean on all changed PHP files; `npm run build` passes (DOMPurify 3.4.11 bundles cleanly)
- phpcs-changed pre-commit hook passes; no new PHPStan or ESLint findings vs trunk (ESLint count actually drops by 3)
- PHPUnit: 2845 tests, 21611 assertions, all passing
- Jest: 951 tests, all passing
- E2E (local wp-env): 249/253 passed; the 4 failures (`post-type-admin.spec.ts` ×3, `block-bindings-site-editor.spec.ts` ×1) reproduce identically on trunk and are unrelated to this PR

## Use of AI Tools

This PR was created with assistance from Claude Code (Anthropic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
