### PR TITLE
Revert "Fix media modal crash on WP 7.0 due to attachment filters wrapper change"

### DIFF
--- a/assets/src/js/_acf-media.js
+++ b/assets/src/js/_acf-media.js
@@ -369,30 +369,8 @@
 		},
 
 		customizeFilters: function ( toolbar ) {
-			// Get the AttachmentFilters view from the toolbar.
-			// WP < 7.0: toolbar.get('filters') returns the AttachmentFilters view directly.
-			// WP 7.0+: toolbar.get('filters') returns a wrapper View; the
-			//          AttachmentFilters view is nested inside its subviews.
-			var filtersView = toolbar.get( 'filters' );
-			var filters = filtersView;
-
-			if ( filtersView && ! filtersView.filters ) {
-				// WP 7.0+: find the AttachmentFilters view in the container's subviews.
-				var subviews = filtersView.views ? filtersView.views.get() : [];
-				for ( var i = 0; i < subviews.length; i++ ) {
-					if ( subviews[ i ].filters ) {
-						filters = subviews[ i ];
-						break;
-					}
-				}
-			}
-
-			// Bail if the AttachmentFilters view couldn't be resolved (e.g. core
-			// moves the view again), so the modal degrades to the default filters
-			// instead of crashing.
-			if ( ! filters || ! filters.filters ) {
-				return;
-			}
+			// vars
+			var filters = toolbar.get( 'filters' );
 
 			// image
 			if ( this.get( 'type' ) == 'image' ) {


### PR DESCRIPTION
Reverts #399.

That PR worked around a WP 7.0 change (core changeset [61757](https://core.trac.wordpress.org/changeset/61757)) that wrapped the media attachment filters in a container `<div>`, which changed the return value of `toolbar.get( 'filters' )` from the `AttachmentFilters` view to a wrapper `wp.media.View` and crashed `customizeFilters()`.

This has since been fixed upstream: [Trac #64948](https://core.trac.wordpress.org/ticket/64948) reverted the shape change in the attachment filters return value and implemented the accessibility improvement via CSS-based positioning instead (changeset [62326](https://core.trac.wordpress.org/changeset/62326) on trunk, merged to the 7.0 branch in [62327](https://core.trac.wordpress.org/changeset/62327)). WP 7.0 final therefore ships with the original `toolbar.get( 'filters' )` behavior, making the subview-traversal workaround unnecessary complexity.

This revert restores `customizeFilters()` to its previous implementation, which works on both WP < 7.0 and WP 7.0+.

## Use of AI Tools

This PR was created with assistance from Claude Code (Anthropic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)