### PR TITLE
docs: add admin screen performance PR testing checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,9 @@
 <!-- Thanks for contributing to Secure Custom Fields (SCF)! Please have a look at the Contributing Guidelines:
 https://github.com/WordPress/secure-custom-fields/blob/trunk/docs/contributing/index.md -->
 
+<!-- For PRs touching admin screen rendering, see the performance testing checklist:
+https://github.com/WordPress/secure-custom-fields/blob/trunk/docs/contributing/admin-performance-testing.md -->
+
 <!-- Insert a description of your changes here -->
 
 <!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

--- a/docs/bin/manifest.json
+++ b/docs/bin/manifest.json
@@ -229,6 +229,11 @@
         "parent": "concepts",
         "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/concepts/security.md"
     },
+    "contributing/admin-performance-testing": {
+        "slug": "admin-performance-testing",
+        "parent": "contributing",
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/contributing/admin-performance-testing.md"
+    },
     "contributing/documentation": {
         "slug": "documentation",
         "parent": "contributing",

--- a/docs/contributing/admin-performance-testing.md
+++ b/docs/contributing/admin-performance-testing.md
@@ -1,0 +1,70 @@
+# Performance Testing for Admin Screens
+
+Use this checklist before opening a PR that changes how an SCF admin screen renders or loads. It catches performance regressions that automated tests miss, since the project has no dedicated performance harness.
+
+## When to run this
+
+Run through this checklist when a PR touches any of the following:
+
+- Field group or options page rendering
+- Field list tables or field group editors
+- The Tools screens (import or export)
+- Asset enqueuing on admin screens
+
+For docs-only or non-admin changes, the regular test suite is enough.
+
+## Prerequisites
+
+Make sure your environment is running and assets are current:
+
+```sh
+npm install
+composer install
+npm run wp-env -- start
+npm run build
+```
+
+## Screens to test
+
+These are the heaviest admin screens and the most likely to regress:
+
+- Field Groups list: `edit.php?post_type=acf-field-group`
+- Field Group editor: `post-new.php?post_type=acf-field-group` to create a group, or `post.php?post=<id>` to edit an existing one
+- UI Options Pages list: `edit.php?post_type=acf-ui-options-page`
+- UI Options Page editor: `post-new.php?post_type=acf-ui-options-page`
+- Runtime options page: `admin.php?page=<your-options-page-slug>`
+- Tools: `admin.php?page=acf-tools`
+
+## Browser checks
+
+Open each screen in your browser with DevTools open. There is no new tooling required for these checks:
+
+1. Open the Network panel and disable cache. Reload the screen and confirm no new large or duplicate asset requests were introduced.
+2. Check the Console for new JavaScript errors or warnings.
+3. For PHP warnings, inspect the response body in the Network panel or check the server debug log (`wp-content/debug.log` when `WP_DEBUG_LOG` is on). The browser Console does not reliably surface these.
+4. Confirm the layout matches the previous state. No shifted columns, broken metaboxes, or missing icons.
+5. In the Field Group editor, add several fields and drag them around. The drag and drop should stay responsive with no visible lag.
+6. Open a field group with many fields (20 or more) via its `post.php?post=<id>` edit URL. It should render without a long pause.
+
+## Playwright smoke
+
+The existing end-to-end tests do not measure performance, but they confirm the screens still load after your change. Run the specs that cover the affected screens:
+
+```sh
+npm run wp-env -- start
+npm run test:e2e -- tests/e2e/field-group-duplication.spec.ts
+npm run test:e2e -- tests/e2e/options-page-admin.spec.ts
+```
+
+If your PR touches a different screen, pick the matching spec from `tests/e2e/` instead.
+
+## Optional ad-hoc profiling
+
+For a deeper look, use your browser's built-in profiler on a logged-in session. This needs no new tooling and does not run in CI:
+
+1. Open the admin screen in your browser while logged in to wp-admin.
+2. Open DevTools and go to the Performance panel.
+3. Start a recording, reload the page, then stop the recording once it finishes loading.
+4. Compare the script timing and layout cost against the same recording on `trunk`. A meaningful jump on the same screen is a regression to investigate.
+
+The Network panel's "Disable cache" option and the CPU throttling preset (for example, 4x slowdown) make the comparison more consistent across runs.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -21,6 +21,7 @@ Guide for contributing to Secure Custom Fields development.
    - Integration testing
    - Bug reporting
    - Feature validation
+   - For PRs that change admin screen rendering, see [Performance Testing for Admin Screens](admin-performance-testing.md)
 
 ## Development Setup
 


### PR DESCRIPTION
## Summary

Adds a performance PR testing checklist for admin screens to the contributing docs, so contributors have a copy-pasteable smoke process for the heavy SCF admin screens before opening a PR. The project has no dedicated performance harness, so the checklist walks through manual browser checks plus reuse of the existing Playwright specs as a regression baseline.

Fixes #498

## Changes

### docs/contributing/admin-performance-testing.md (new)
The checklist itself. Covers when to run it, prerequisites, the screens most likely to regress (Field Groups list, Field Group editor, UI Options Pages list/editor, runtime options page, Tools), browser DevTools checks with JS console and PHP debug.log separated, a Playwright smoke block reusing existing e2e specs, and an optional ad-hoc profiling section using the browser's built-in profiler. Three copy-pasteable `sh` blocks.

### docs/contributing/index.md
**Before:**
```markdown
3. **Testing**
   - Unit testing
   - Integration testing
   - Bug reporting
   - Feature validation
```
**After:**
```markdown
3. **Testing**
   - Unit testing
   - Integration testing
   - Bug reporting
   - Feature validation
   - For PRs that change admin screen rendering, see [Performance Testing for Admin Screens](admin-performance-testing.md)
```
**Why:** Discoverability. Contributors land on the index guide first, so the checklist is one click from the entry point.

### .github/pull_request_template.md
**Before:**
```markdown
<!-- Thanks for contributing ... Contributing Guidelines link -->
```
**After:**
```markdown
<!-- Thanks for contributing ... Contributing Guidelines link -->

<!-- For PRs touching admin screen rendering, see the performance testing checklist:
https://github.com/WordPress/secure-custom-fields/blob/trunk/docs/contributing/admin-performance-testing.md -->
```
**Why:** Surfaces the checklist at PR creation time, exactly when a contributor is deciding what to test. Kept as an HTML comment so it does not change the rendered PR body.

### docs/bin/manifest.json
**Before:** no entry for the new doc.
**After:**
```json
{ "contributing/admin-performance-testing": { "slug": "admin-performance-testing", "parent": "contributing", "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/contributing/admin-performance-testing.md" } }
```
**Why:** The manifest is auto-generated and committed (see #385 for the same pattern with releases.md). Regenerated via `php docs/bin/generate-manifest.php` so the new doc is discovered.

## Testing

**Test 1: markdown lint passes on the new doc**
1. Run `npm run lint:md`
Result: no output, exit 0.

**Test 2: internal links resolve**
1. Open `docs/contributing/index.md` and click the new link.
2. Confirm `docs/contributing/admin-performance-testing.md` exists.
3. Open `.github/pull_request_template.md` and confirm the HTML-comment URL points to the new doc on `trunk`.
Result: all three links resolve.

**Test 3: copy-pasteable blocks**
1. Open the new doc.
2. Copy the Prerequisites block into a shell.
Result: the `sh` blocks are runnable as-is (no placeholders that break copy-paste).

## Checklist

- [x] Follows the documentation style guide in `docs/contributing/documentation.md`
- [x] Docs-only change, no runtime impact, backward compatible
- [x] No unrelated refactors (diff limited to the four listed files)
