### PR TITLE
fix(js): correct acf.get, isObject, _e edge cases

### DIFF
--- a/assets/src/js/_acf-compatibility.js
+++ b/assets/src/js/_acf-compatibility.js
@@ -108,8 +108,9 @@
 		// try k1
 		var string = this.l10n[ k1 ] || '';
 
-		// try k2
-		if ( k2 ) {
+		// try k2 (only when k1 resolved to a nested object, otherwise a
+		// string value would be indexed and leak String.prototype methods).
+		if ( k2 && this.isObject( string ) ) {
 			string = string[ k2 ] || '';
 		}
 

--- a/assets/src/js/_acf.js
+++ b/assets/src/js/_acf.js
@@ -33,7 +33,7 @@
 	 */
 
 	acf.get = function ( name ) {
-		return this.data[ name ] || null;
+		return this.data.hasOwnProperty( name ) ? this.data[ name ] : null;
 	};
 
 	/**
@@ -766,7 +766,7 @@
 	};
 
 	acf.isObject = function ( a ) {
-		return typeof a === 'object';
+		return a !== null && typeof a === 'object';
 	};
 
 	/**

--- a/tests/js/acf-utilities.test.js
+++ b/tests/js/acf-utilities.test.js
@@ -47,14 +47,16 @@ describe( 'SCF Core Utilities', () => {
 			expect( acf.get( 'unknown' ) ).toBeNull();
 		} );
 
-		it( 'should return null for falsy stored values', () => {
-			// NOTE: documents current behavior — acf.get() uses `|| null`,
-			// so stored falsy values (0, '', false) are unreadable.
-			// Tracked in #461.
+		it( 'should return stored falsy values', () => {
 			acf.set( 'zero', 0 );
+			acf.set( 'empty', '' );
+			acf.set( 'flag', false );
 
-			expect( acf.get( 'zero' ) ).toBeNull();
-			expect( acf.has( 'zero' ) ).toBe( false );
+			expect( acf.get( 'zero' ) ).toBe( 0 );
+			expect( acf.get( 'empty' ) ).toBe( '' );
+			expect( acf.get( 'flag' ) ).toBe( false );
+			expect( acf.has( 'zero' ) ).toBe( true );
+			expect( acf.has( 'flag' ) ).toBe( true );
 		} );
 
 		it( 'should support chaining on set()', () => {
@@ -232,10 +234,7 @@ describe( 'SCF Core Utilities', () => {
 			expect( acf.isObject( {} ) ).toBe( true );
 			expect( acf.isObject( [] ) ).toBe( true );
 			expect( acf.isObject( 'a' ) ).toBe( false );
-			// NOTE: documents current behavior — possible bug:
-			// typeof null === 'object', so isObject( null ) returns true.
-			// Tracked in #461.
-			expect( acf.isObject( null ) ).toBe( true );
+			expect( acf.isObject( null ) ).toBe( false );
 		} );
 
 		it( 'isNumeric() should detect numbers and numeric strings', () => {

--- a/tests/js/compatibility.test.js
+++ b/tests/js/compatibility.test.js
@@ -137,11 +137,7 @@ describe( 'SCF Compatibility Layer', () => {
 		it( 'should return an empty string for unknown keys', () => {
 			expect( acf._e( 'missing' ) ).toBe( '' );
 			expect( acf._e( 'missing', 'nope' ) ).toBe( '' );
-			// NOTE: documents current behavior — possible bug: when k1 is
-			// unknown, _e() indexes into the empty string, so a k2 naming a
-			// String.prototype method (e.g. 'sub') returns that function
-			// instead of ''. Tracked in #461.
-			expect( typeof acf._e( 'missing', 'sub' ) ).toBe( 'function' );
+			expect( acf._e( 'missing', 'sub' ) ).toBe( '' );
 		} );
 	} );
 


### PR DESCRIPTION
## Summary

Fixes three long-standing edge-case bugs in the core `acf` JS utilities, grouped in #461 because the fixes land together. All three were characterized (not fixed) by PR #450 with `Tracked in #461` notes; this PR corrects the source and flips those characterization assertions to the correct behavior.

Fixes #461

## Changes

### `acf.get()` — `assets/src/js/_acf.js`

**Before:**
```js
acf.get = function ( name ) {
	return this.data[ name ] || null;
};
```

**After:**
```js
acf.get = function ( name ) {
	return this.data.hasOwnProperty( name ) ? this.data[ name ] : null;
};
```

**Why:** The `|| null` collapsed stored `0`, `''`, and `false` into `null`, so falsy values were unreadable. `acf.has()` inherited the bug (it is `get() !== null`), so stored falsy values reported as missing. The existence check preserves the real value.

### `acf.isObject()` — `assets/src/js/_acf.js`

**Before:**
```js
acf.isObject = function ( a ) {
	return typeof a === 'object';
};
```

**After:**
```js
acf.isObject = function ( a ) {
	return a !== null && typeof a === 'object';
};
```

**Why:** `typeof null === 'object'`, so `isObject(null)` returned `true`. The flexible-content normalizers that call `isObject` then hit `Object.keys(null)` and threw. The guard short-circuits on `null`.

### `acf._e()` — `assets/src/js/_acf-compatibility.js`

**Before:**
```js
if ( k2 ) {
	string = string[ k2 ] || '';
}
```

**After:**
```js
if ( k2 && this.isObject( string ) ) {
	string = string[ k2 ] || '';
}
```

**Why:** When `k1` was unknown, `string` was `''`, and indexing it with `k2` leaked a `String.prototype` method (for example `acf._e('missing','sub')` returned `String.prototype.sub`). The guard only drills into `k2` when `k1` resolved to a nested object.

### Tests

The three characterization assertions added in #450 that asserted the buggy behavior now assert the corrected behavior (the `Tracked in #461` notes are removed). The known-good assertions (image strings, nested l10n, chaining, array detection) are unchanged.

## Reproduction

In the browser console on any SCF admin screen, against `trunk`:

```js
acf.set( 'zero', 0 );
acf.get( 'zero' );              // null (should be 0)
acf.isObject( null );           // true  (should be false)
typeof acf._e( 'missing', 'sub' ); // 'function' (should be 'string')
```

After this branch, each returns the corrected value.

## Testing

**Automated:** `npm run test:unit` passes (37 suites, 951 tests), including the three flipped assertions. `npx wp-scripts lint-js` reports no new issues (pre-existing counts unchanged from trunk).

**Manual:**
1. Activate a build of this branch.
2. Open a field group editor or a post with custom fields.
3. Run the reproduction snippets above in the console; confirm corrected values.
4. Spot-check common screens still behave normally: field group editor save, post custom fields save, flexible content add/move/remove layouts, image field media modal.
5. Expected: all corrected values hold and no regression on the spot-checked screens.

## Notes for extension authors

The coupled `acf.has()` contract changes alongside `get()`: `acf.set('x', false); acf.has('x')` now returns `true` instead of `false`. No in-repo caller sets a falsy value and then checks `acf.has()`, so there is no in-tree regression. The one user-visible side effect is a one-time localStorage preference-key reset on auto-draft / new posts (where `post_id` is `0`): the key suffix changes from `-null` to `-0`. No data is lost and no error occurs.