### PR TITLE
fix(js): make _acf-compatibility.js strict-mode safe

### DIFF
--- a/assets/src/js/_acf-compatibility.js
+++ b/assets/src/js/_acf-compatibility.js
@@ -207,7 +207,7 @@
 		}
 
 		// get keys
-		keys = String( key ).split( '.' );
+		var keys = String( key ).split( '.' );
 
 		// acf.isget
 		for ( var i = 0; i < keys.length; i++ ) {
@@ -262,8 +262,7 @@
 		var length = actions.length;
 		if ( length > 1 ) {
 			for ( var i = 0; i < length; i++ ) {
-				action = actions[ i ];
-				_acf.add_action.apply( this, arguments );
+				_acf.add_action( actions[ i ], callback, priority, context );
 			}
 			return this;
 		}

--- a/tests/js/compatibility.test.js
+++ b/tests/js/compatibility.test.js
@@ -40,12 +40,12 @@ describe( 'SCF Compatibility Layer', () => {
 		window.acf.screen = { check: jest.fn(), set: jest.fn() };
 
 		// The production webpack bundle executes this module in sloppy
-		// (non-strict) mode and the legacy code relies on it: maybe_get()
-		// assigns to an undeclared `keys` variable and add_action() relies
-		// on `arguments` aliasing its named parameters. babel-jest compiles
-		// required modules to strict mode which breaks both, so evaluate
-		// the raw source instead to match production semantics.
-		// The strict-mode fragility is tracked in #460.
+		// (non-strict) mode. babel-jest compiles required modules to strict
+		// mode, which would clobber the `acf` global. Evaluate the raw
+		// source in indirect-eval scope so the IIFE gets its own `acf`
+		// binding like in production. The strict-mode fragility previously
+		// tracked in #460 is fixed in this file; the static check below
+		// guards against regression.
 		// eslint-disable-next-line no-eval
 		( 0, eval )( compatibilitySource );
 
@@ -281,6 +281,84 @@ describe( 'SCF Compatibility Layer', () => {
 			model.set( 'status', 'ready' );
 
 			expect( model._set_status ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'strict-mode safety (regression for #460)', () => {
+		// The source must not rely on sloppy-mode semantics. Two specific
+		// patterns are forbidden because they break under strict mode:
+		//   1. Assigning to an undeclared identifier inside `maybe_get`
+		//      throws ReferenceError under strict mode.
+		//   2. Recursive calls in `add_action` that forward `arguments`
+		//      break because strict mode disables the aliasing of named
+		//      parameters by `arguments`.
+		// The static checks below fail loudly if either pattern returns.
+
+		// Extract a function body by walking braces from the line that
+		// contains the function name. Avoids matching unrelated blocks
+		// that happen to also call `.apply( this, arguments )`.
+		const extractFunctionBody = ( source, fnName ) => {
+			const lines = source
+				.replace( /\/\*[\s\S]*?\*\//g, '' )
+				.split( '\n' );
+			const start = lines.findIndex( ( l ) => l.includes( fnName ) );
+			if ( start === -1 ) {
+				return null;
+			}
+			let depth = 0;
+			let sawOpen = false;
+			const body = [];
+			for ( let i = start; i < lines.length; i++ ) {
+				const line = lines[ i ];
+				for ( const ch of line ) {
+					if ( ch === '{' ) {
+						depth++;
+						sawOpen = true;
+					} else if ( ch === '}' ) {
+						depth--;
+					}
+				}
+				if ( sawOpen && depth === 0 ) {
+					break;
+				}
+				if ( sawOpen ) {
+					body.push( line );
+				}
+			}
+			return body.join( '\n' );
+		};
+
+		it( 'should not assign to an undeclared `keys` in maybe_get()', () => {
+			const body = extractFunctionBody(
+				compatibilitySource,
+				'_acf.maybe_get'
+			);
+			expect( body ).not.toBeNull();
+			// `keys` must be declared with `var` before any assignment to
+			// it. Ignore `keys ==` / `keys ===` comparisons (regex `(?!=)`).
+			let declared = false;
+			const offenders = body.split( '\n' ).filter( ( l ) => {
+				if ( /^[\s]*var\s+keys\b/.test( l ) ) {
+					declared = true;
+					return false;
+				}
+				return (
+					! declared &&
+					/(^|[\s;{(])keys\s*=(?!=)/.test( l )
+				);
+			} );
+			expect( offenders ).toEqual( [] );
+		} );
+
+		it( 'should not forward `arguments` from the multi-action recursion in add_action()', () => {
+			const body = extractFunctionBody(
+				compatibilitySource,
+				'_acf.add_action = function'
+			);
+			expect( body ).not.toBeNull();
+			expect( body ).not.toMatch(
+				/_acf\.add_action\.apply\(\s*this\s*,\s*arguments\s*\)/
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Secure Custom Fields (SCF)! Please have a look at the Contributing Guidelines:
https://github.com/WordPress/secure-custom-fields/blob/trunk/docs/contributing/index.md -->

The legacy compatibility layer in `assets/src/js/_acf-compatibility.js` relied on sloppy-mode (non-strict) JavaScript semantics. Two patterns break the moment the module is forced into strict mode (e.g. via an ES module conversion or a bundler default change):

1. `maybe_get()` assigned to an undeclared `keys` variable — a global leak that becomes a `ReferenceError` under strict mode.
2. `add_action()`'s multi-action split used `_acf.add_action.apply(this, arguments)` to forward the named `action` parameter — strict mode disables `arguments` aliasing of named parameters, so the recursive call silently stopped wrapping user callbacks.

Both spots are fixed without behavior change. Static regression tests added under `strict-mode safety (regression for #460)` in `tests/js/compatibility.test.js` fail loudly if either pattern returns.

Verification:
- `npm run test:unit` — 953/953 pass
- `npm run test:unit -- tests/js/compatibility.test.js` — 28/28 pass including 2 new strict-mode tests
- `coderabbit review --agent` — 0 findings
- 3 parallel sub-agents confirmed 0 affected call sites and 0 deprecated patterns
- Net 5 fewer lint errors vs trunk (the `var` addition and the removed `action = actions[i]` reassignment)

Closes #460

## Use of AI Tools

Portions of this PR were authored with the assistance of AI tooling. All changes have been reviewed, tested, and verified by a human contributor.