### PR TITLE
Add command palette commands to navigate to options pages

### DIFF
--- a/assets/src/js/commands/admin-commands.js
+++ b/assets/src/js/commands/admin-commands.js
@@ -23,6 +23,7 @@ import {
 	tool,
 	upload,
 	download,
+	page,
 } from '@wordpress/icons';
 
 /**
@@ -165,10 +166,34 @@ const registerAdminCommands = () => {
 		} );
 	};
 
+	// Options page commands — one per registered SCF options page.
+	const optionsPageCommands = [];
+	if ( Array.isArray( window.scfOptionsPages ) ) {
+		window.scfOptionsPages.forEach( ( optionsPage ) => {
+			if ( ! optionsPage?.menu_slug ) {
+				return;
+			}
+			optionsPageCommands.push( {
+				name: 'options-page-' + optionsPage.menu_slug,
+				label: optionsPage.menu_title || optionsPage.page_title,
+				url: 'admin.php',
+				urlArgs: { page: optionsPage.menu_slug },
+				icon: page,
+				keywords: [
+					'options',
+					'settings',
+					'scf',
+					optionsPage.menu_title,
+					optionsPage.page_title,
+				].filter( Boolean ),
+			} );
+		} );
+	}
+
 	// WordPress 6.9+ adds Command Palette commands for all admin menu items.
 	// For older versions, we need to register them manually. The most reliable way to
 	// detect this is to check if the commands are already registered.
-	viewCommands.forEach( ( command ) => {
+	const registerIfNotAutoRegistered = ( command ) => {
 		const commandUrl = addQueryArgs( command.url, command.urlArgs );
 		// WordPress stores destination URLs in the command *name*, appended to
 		// the menu slug (which is also a relative URL), resulting in somewhat
@@ -178,11 +203,15 @@ const registerAdminCommands = () => {
 			return;
 		}
 		registerCommand( command );
-	} );
+	};
+
+	viewCommands.forEach( registerIfNotAutoRegistered );
 
 	// "Create New" commands are not automatically registered by WordPress,
 	// so we always register them.
 	createCommands.forEach( registerCommand );
+
+	optionsPageCommands.forEach( registerIfNotAutoRegistered );
 };
 
 if ( 'requestIdleCallback' in window ) {

--- a/includes/admin/admin-commands.php
+++ b/includes/admin/admin-commands.php
@@ -39,6 +39,31 @@ function acf_commands_init() {
 	// Only load admin commands if user has SCF admin capabilities.
 	if ( current_user_can( acf_get_setting( 'capability' ) ) ) {
 		wp_enqueue_script( 'scf-commands-admin' );
+
+		// Localize registered options pages so the JS can register a palette
+		// command per page. Filtered by capability so users only see pages
+		// they can access.
+		$pages = acf_get_options_pages();
+		if ( ! empty( $pages ) ) {
+			$localized = array();
+			foreach ( $pages as $page ) {
+				if ( ! current_user_can( $page['capability'] ) ) {
+					continue;
+				}
+				$localized[] = array(
+					'menu_slug'  => $page['menu_slug'],
+					'menu_title' => $page['menu_title'],
+					'page_title' => $page['page_title'],
+				);
+			}
+			if ( ! empty( $localized ) ) {
+				wp_localize_script(
+					'scf-commands-admin',
+					'scfOptionsPages',
+					$localized
+				);
+			}
+		}
 	}
 }
 

--- a/tests/e2e/command-palette.spec.ts
+++ b/tests/e2e/command-palette.spec.ts
@@ -171,6 +171,56 @@ test.describe( 'Command Palette', () => {
 					).toHaveValue( 'SCF E2E Test Type' );
 				} );
 			} );
+
+			test.describe( 'Options page-specific commands', () => {
+				test.beforeAll( async ( { requestUtils } ) => {
+					await requestUtils.activatePlugin(
+						'scf-test-setup-options-page'
+					);
+				} );
+
+				test.afterAll( async ( { requestUtils } ) => {
+					await requestUtils.deactivatePlugin(
+						'scf-test-setup-options-page'
+					);
+				} );
+
+				test( 'should register a command for the registered options page', async ( {
+					page,
+				} ) => {
+					await openCommandPalette( page );
+
+					const input = getCommandPaletteInput( page );
+
+					await input.fill( 'SCF E2E Test Options' );
+
+					const option = page.getByRole( 'option', {
+						name: /SCF E2E Test Options/,
+					} );
+
+					await expect( option ).toHaveCount( 1 );
+				} );
+
+				test( 'should navigate to the options page via command palette', async ( {
+					page,
+				} ) => {
+					await openCommandPalette( page );
+
+					const input = getCommandPaletteInput( page );
+
+					await input.fill( 'SCF E2E Test Options' );
+
+					await page
+						.getByRole( 'option', {
+							name: /SCF E2E Test Options/,
+						} )
+						.click();
+
+					await expect( page ).toHaveURL(
+						/admin\.php\?page=scf-e2e-test-options/
+					);
+				} );
+			} );
 		} );
 	} );
 } );

--- a/tests/e2e/plugins/scf-test-setup-options-page.php
+++ b/tests/e2e/plugins/scf-test-setup-options-page.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Plugin Name: SCF Test Setup Options Page
+ * Description: Creates SCF options page for E2E testing
+ * Version: 1.0.0
+ * Author: SCF Testing
+ * Requires Plugins: secure-custom-fields
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register an options page for command palette E2E tests.
+ */
+function scf_test_register_options_page() {
+	if ( ! function_exists( 'acf_update_options_page' ) || acf_get_options_page( 'scf-e2e-test-options' ) ) {
+		return;
+	}
+
+	acf_update_options_page(
+		'scf-e2e-test-options',
+		array(
+			'page_title' => 'SCF E2E Test Options',
+			'menu_title' => 'SCF E2E Test Options',
+			'menu_slug'  => 'scf-e2e-test-options',
+			'capability' => 'edit_posts',
+			'redirect'   => false,
+		)
+	);
+}
+
+add_action( 'acf/init', 'scf_test_register_options_page', 20 );


### PR DESCRIPTION
Closes #140

## Summary

Each registered SCF options page now gets its own Command Palette command, so users can jump straight to a page by typing its name (Cmd/Ctrl+K) instead of clicking through the admin menu. The command is filtered by capability on the server, so users only see pages they can open.

## Changes

### includes/admin/admin-commands.php
**Before:**
```php
if ( current_user_can( acf_get_setting( 'capability' ) ) ) {
    wp_enqueue_script( 'scf-commands-admin' );
}
```
**After:**
```php
if ( current_user_can( acf_get_setting( 'capability' ) ) ) {
    wp_enqueue_script( 'scf-commands-admin' );

    $pages = acf_get_options_pages();
    if ( ! empty( $pages ) ) {
        $localized = array();
        foreach ( $pages as $page ) {
            if ( ! current_user_can( $page['capability'] ) ) {
                continue;
            }
            $localized[] = array(
                'menu_slug'  => $page['menu_slug'],
                'menu_title' => $page['menu_title'],
                'page_title' => $page['page_title'],
            );
        }
        if ( ! empty( $localized ) ) {
            wp_localize_script( 'scf-commands-admin', 'scfOptionsPages', $localized );
        }
    }
}
```
**Why:** Ships the page list to the admin command script. The capability check runs server-side, so inaccessible pages never reach JS.

### assets/src/js/commands/admin-commands.js
**Before:**
```js
viewCommands.forEach( ( command ) => {
    const commandUrl = addQueryArgs( command.url, command.urlArgs );
    if ( registeredCommands.some( ( cmd ) => cmd.name.endsWith( commandUrl ) ) ) {
        return;
    }
    registerCommand( command );
} );
```
**After:**
```js
// Options page commands — one per registered SCF options page.
const optionsPageCommands = [];
if ( Array.isArray( window.scfOptionsPages ) ) {
    window.scfOptionsPages.forEach( ( optionsPage ) => {
        if ( ! optionsPage?.menu_slug ) {
            return;
        }
        optionsPageCommands.push( {
            name: 'options-page-' + optionsPage.menu_slug,
            label: optionsPage.menu_title || optionsPage.page_title,
            url: 'admin.php',
            urlArgs: { page: optionsPage.menu_slug },
            icon: page,
            keywords: [ 'options', 'settings', 'scf', optionsPage.menu_title, optionsPage.page_title ].filter( Boolean ),
        } );
    } );
}

const registerIfNotAutoRegistered = ( command ) => {
    const commandUrl = addQueryArgs( command.url, command.urlArgs );
    if ( registeredCommands.some( ( cmd ) => cmd.name.endsWith( commandUrl ) ) ) {
        return;
    }
    registerCommand( command );
};

viewCommands.forEach( registerIfNotAutoRegistered );
createCommands.forEach( registerCommand );
optionsPageCommands.forEach( registerIfNotAutoRegistered );
```
**Why:** Builds one command per page from the localized data. The dedup check is refactored into a shared helper so the new options page commands skip duplicates the same way `viewCommands` does on WP 6.9+.

## How to test

1. Start wp-env: `npm run wp-env start`.
2. Register an options page (e.g. via the UI, or with a small plugin calling `acf_update_options_page('my-page', ['menu_title' => 'My Page', 'menu_slug' => 'my-page', 'capability' => 'edit_posts'])`).
3. Open any wp-admin screen and trigger the Command Palette (Cmd/Ctrl+K).
4. Type "My Page".
5. Select the command.

Expected: a single command with a page icon appears, and selecting it navigates to `admin.php?page=my-page`.

Automated:
```bash
npm run test:e2e -- tests/e2e/command-palette.spec.ts
```

The new "Options page-specific commands" block asserts the command appears exactly once and navigates to the correct URL.

## Testing already taken place

- Build: `npm run build` clean (only pre-existing sass warnings).
- JS unit tests: 951/951 pass.
- PHPStan: 0 errors.
- PHPCS: clean on changed file.
- E2E: new describe block covers registration and navigation.

## Use of AI Tools

Some drafting assistance from AI tooling (Claude). All code reviewed, tested, and adjusted by hand.

## Screenshot
<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/e8183b1d-b988-440a-a8af-71e839219dc8" />
