### PR TITLE
Exclude some unnecessary files from release zip

### DIFF
--- a/bin/create-release-zip.sh
+++ b/bin/create-release-zip.sh
@@ -116,6 +116,9 @@ for dir in "${REQUIRED_DIRS[@]}"; do
     cp -r "$dir" "$PLUGIN_DIR/"
 done
 
+# Remove uncompiled sources (JS partials and Sass); only assets/build is used at runtime
+rm -rf "$PLUGIN_DIR/assets/src"
+
 # Install production dependencies
 echo "Installing production dependencies..."
 composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist
@@ -127,6 +130,10 @@ cp -r vendor "$PLUGIN_DIR/"
 if [[ -d "$PLUGIN_DIR/vendor/bin" && -z "$(ls -A "$PLUGIN_DIR/vendor/bin")" ]]; then
     rm -rf "$PLUGIN_DIR/vendor/bin"
 fi
+
+# Remove macOS Finder metadata anywhere in the tree; gitignored, so the
+# untracked-files check above doesn't catch it, but cp -r copies it along
+find "$PLUGIN_DIR" -name '.DS_Store' -type f -delete
 
 # Create the zip file
 cd "$TEMP_DIR"


### PR DESCRIPTION
## What

Two small additions to `bin/create-release-zip.sh` to keep unnecessary files out of the distribution zip:

- **Remove `assets/src/`** from the staged plugin directory (~1.4 MB of uncompiled JS partials and Sass). Nothing references it at runtime — only `assets/build` is loaded. This also matches ACF's WordPress.org distribution, whose `assets/` dir contains only `build`, `images`, and `inc`.
- **Delete `.DS_Store` files anywhere in the staged tree**, as the last step before zipping. These are gitignored, so the script's untracked-files guard (`git ls-files --others --exclude-standard`) never flags them, but the plain `cp -r` copies them into the staging dir anyway — the current release zip ships an `includes/.DS_Store`. The cleanup runs after the `vendor/` copy so it sweeps the whole tree.

## Why

The current zip (6.9.2) includes both of these; neither is needed by users. Other candidates (source maps, unminified builds, `.po` files) were deliberately left in — sourcemaps help users debug, and ACF ships `.po` files too.

## Testing

- `bash -n bin/create-release-zip.sh` passes.
- Run `bin/create-release-zip.sh` on a clean tree and verify the resulting zip contains no `assets/src/` directory and no `.DS_Store` files: `unzip -l release/secure-custom-fields.zip | grep -E 'assets/src|DS_Store'` should return nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)