### PR TITLE
feat: unify CPT and field group definitions in one JSON file (closes #163)

### DIFF
--- a/bin/baseline.neon
+++ b/bin/baseline.neon
@@ -90,13 +90,11 @@ parameters:
 			count: 1
 			path: ../includes/admin/views/upgrade/notice.php
 
-
 		-
 			message: '#^Offset ''thumb'' on array\{alt\: string, author\: string, authorName\: string, caption\: string, compat\: array, context\: string, date\: int, dateFormatted\: string, \.\.\.\}\|null in isset\(\) does not exist\.$#'
 			identifier: isset.offset
 			count: 1
 			path: ../includes/fields/class-acf-field-gallery.php
-
 
 		-
 			message: '#^Undefined variable\: \$method$#'
@@ -111,13 +109,115 @@ parameters:
 			path: ../includes/locations/abstract-acf-legacy-location.php
 
 		-
-			message: '#^Path in require_once\(\) "\./wp\-admin/includes/file\.php" is not a file or it does not exist\.$#'
-			identifier: requireOnce.fileNotFound
-			count: 2
-			path: ../includes/class-scf-json-schema-validator.php
+			message: '#^Variable \$field might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../release/secure-custom-fields/includes/admin/views/acf-field-group/field.php
 
 		-
-			message: '#^Function SCF\\Blocks\\AutoInlineEditing\\apply_inline_editing_attributes_to_render_template invoked with 7 parameters, 3 required\.$#'
-			identifier: arguments.count
+			message: '#^Variable \$i might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: ../release/secure-custom-fields/includes/admin/views/acf-field-group/field.php
+
+		-
+			message: '#^Variable \$fields might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: ../release/secure-custom-fields/includes/admin/views/acf-field-group/fields.php
+
+		-
+			message: '#^Variable \$parent might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: ../release/secure-custom-fields/includes/admin/views/acf-field-group/fields.php
+
+		-
+			message: '#^Variable \$group might not be defined\.$#'
+			identifier: variable.undefined
 			count: 1
-			path: ../includes/blocks.php
+			path: ../release/secure-custom-fields/includes/admin/views/acf-field-group/location-group.php
+
+		-
+			message: '#^Variable \$group_id might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: ../release/secure-custom-fields/includes/admin/views/acf-field-group/location-group.php
+
+		-
+			message: '#^Variable \$rule might not be defined\.$#'
+			identifier: variable.undefined
+			count: 8
+			path: ../release/secure-custom-fields/includes/admin/views/acf-field-group/location-rule.php
+
+		-
+			message: '#^Variable \$acf_parent_page_choices might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../release/secure-custom-fields/includes/admin/views/acf-ui-options-page/create-options-page-modal.php
+
+		-
+			message: '#^Variable \$page_title might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../release/secure-custom-fields/includes/admin/views/html-options-page.php
+
+		-
+			message: '#^Variable \$post_id might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../release/secure-custom-fields/includes/admin/views/html-options-page.php
+
+		-
+			message: '#^Variable \$active might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../release/secure-custom-fields/includes/admin/views/tools/tools.php
+
+		-
+			message: '#^Variable \$screen_id might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../release/secure-custom-fields/includes/admin/views/tools/tools.php
+
+		-
+			message: '#^Variable \$button_text might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../release/secure-custom-fields/includes/admin/views/upgrade/notice.php
+
+		-
+			message: '#^Variable \$button_url might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../release/secure-custom-fields/includes/admin/views/upgrade/notice.php
+
+		-
+			message: '#^Variable \$confirm might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../release/secure-custom-fields/includes/admin/views/upgrade/notice.php
+
+		-
+			message: '#^Offset ''thumb'' on array\{alt\: string, author\: string, authorName\: string, caption\: string, compat\: array, context\: string, date\: int, dateFormatted\: string, \.\.\.\}\|null in isset\(\) does not exist\.$#'
+			identifier: isset.offset
+			count: 1
+			path: ../release/secure-custom-fields/includes/fields/class-acf-field-gallery.php
+
+		-
+			message: '#^Undefined variable\: \$method$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../release/secure-custom-fields/includes/locations/abstract-acf-legacy-location.php
+
+		-
+			message: '#^Variable \$method in isset\(\) is never defined\.$#'
+			identifier: isset.variable
+			count: 1
+			path: ../release/secure-custom-fields/includes/locations/abstract-acf-legacy-location.php
+
+		-
+			message: '#^Call to an undefined static method ACF_Local_JSON\:\:is_unified_definition\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 7
+			path: ../tests/php/test-unified-definitions.php

--- a/includes/class-scf-json-schema-validator.php
+++ b/includes/class-scf-json-schema-validator.php
@@ -26,7 +26,7 @@ if ( ! class_exists( 'SCF_JSON_Schema_Validator' ) ) :
 		 *
 		 * @var array
 		 */
-		public const REQUIRED_SCHEMAS = array( 'post-type', 'taxonomy', 'ui-options-page', 'field-group', 'internal-properties', 'scf-identifier' );
+		public const REQUIRED_SCHEMAS = array( 'post-type', 'taxonomy', 'ui-options-page', 'field-group', 'internal-properties', 'scf-identifier', 'unified-cpt' );
 
 		/**
 		 * The last validation errors.

--- a/includes/local-json.php
+++ b/includes/local-json.php
@@ -17,6 +17,14 @@ if ( ! class_exists( 'ACF_Local_JSON' ) ) :
 		private $files = array();
 
 		/**
+		 * Unified CPT+fields definition files detected during scan.
+		 *
+		 * @since SCF 6.9.3
+		 * @var array
+		 */
+		private $unified_files = array();
+
+		/**
 		 * Whether an expected Local JSON write failed during the current request.
 		 *
 		 * @var boolean
@@ -55,6 +63,11 @@ if ( ! class_exists( 'ACF_Local_JSON' ) ) :
 			add_action( 'acf/include_fields', array( $this, 'include_fields' ) );
 			add_action( 'acf/include_post_types', array( $this, 'include_post_types' ) );
 			add_action( 'acf/include_taxonomies', array( $this, 'include_taxonomies' ) );
+
+			// Unified CPT+fields definitions. Run before the per-type includes
+			// (priority 5 vs default 10) so locally registered field groups exist
+			// before register_post_types() runs on `acf/init` priority 6.
+			add_action( 'acf/init', array( $this, 'include_unified_definitions' ), 5 );
 
 			if ( is_admin() ) {
 				add_filter( 'redirect_post_location', array( $this, 'redirect_post_location' ) );
@@ -399,6 +412,14 @@ if ( ! class_exists( 'ACF_Local_JSON' ) ) :
 								continue;
 							}
 
+							if ( self::is_unified_definition( $json ) ) {
+								// Unified files are dispatched separately by
+								// include_unified_definitions(); skip them here to
+								// avoid double registration via the per-type includes.
+								$this->unified_files[ $json['key'] ] = $file;
+								continue;
+							}
+
 							// Append data.
 							$json_files[ $json['key'] ] = $file;
 						}
@@ -442,6 +463,176 @@ if ( ! class_exists( 'ACF_Local_JSON' ) ) :
 			}
 
 			return $files;
+		}
+
+		/**
+		 * Returns an array of unified CPT+fields definition files detected during scan.
+		 *
+		 * @since SCF 6.9.3
+		 *
+		 * @return array
+		 */
+		public function get_unified_files() {
+			return $this->unified_files;
+		}
+
+		/**
+		 * Detects whether a decoded JSON payload is a unified CPT+fields definition.
+		 *
+		 * A unified file declares a post type (`post_type` key) together with
+		 * either an explicit `field_groups` array or a top-level `fields` array.
+		 *
+		 * @since SCF 6.9.3
+		 *
+		 * @param mixed $json Decoded JSON payload.
+		 * @return bool
+		 */
+		public static function is_unified_definition( $json ) {
+			if ( ! is_array( $json ) ) {
+				return false;
+			}
+
+			if ( empty( $json['key'] ) || ! is_string( $json['key'] ) ) {
+				return false;
+			}
+
+			if ( empty( $json['post_type'] ) || ! is_string( $json['post_type'] ) ) {
+				return false;
+			}
+
+			if ( empty( $json['field_groups'] ) && empty( $json['fields'] ) ) {
+				return false;
+			}
+
+			if ( ! empty( $json['field_groups'] ) && ! is_array( $json['field_groups'] ) ) {
+				return false;
+			}
+
+			if ( ! empty( $json['fields'] ) && ! is_array( $json['fields'] ) ) {
+				return false;
+			}
+
+			return true;
+		}
+
+		/**
+		 * Loads unified CPT+fields definition files into the local stores.
+		 *
+		 * A unified file declares a post type together with the field groups
+		 * attached to it. Each field group gets an injected post_type location
+		 * rule so SCF routes its render through the standard location matcher.
+		 *
+		 * @since SCF 6.9.3
+		 *
+		 * @return void
+		 */
+		public function include_unified_definitions() {
+			if ( ! $this->is_enabled() ) {
+				return;
+			}
+
+			// Make sure the directory has been scanned. scan_files() populates
+			// both $this->files and $this->unified_files. Re-scan every call
+			// so stale entries from a previous request do not point at
+			// deleted files.
+			$this->files         = array();
+			$this->unified_files = array();
+			$this->scan_files( 'acf-post-type' );
+
+			foreach ( $this->unified_files as $key => $file ) {
+				$json = json_decode( file_get_contents( $file ), true );
+				if ( ! self::is_unified_definition( $json ) ) {
+					continue;
+				}
+
+				$cpt_slug = $json['post_type'];
+
+				// Split: everything except field_groups/fields becomes the CPT.
+				$cpt = $json;
+				unset( $cpt['field_groups'], $cpt['fields'] );
+				$cpt['local']      = 'json';
+				$cpt['local_file'] = $file;
+
+				acf_add_local_internal_post_type( $cpt, 'acf-post-type' );
+
+				$groups = array();
+				if ( ! empty( $json['field_groups'] ) ) {
+					foreach ( $json['field_groups'] as $group ) {
+						if ( ! is_array( $group ) ) {
+							continue;
+						}
+						$groups[] = $this->prepare_unified_field_group( $group, $cpt_slug, $file );
+					}
+				} elseif ( ! empty( $json['fields'] ) ) {
+					// Auto-wrap loose fields into a single synthetic group.
+					$groups[] = $this->prepare_unified_field_group(
+						array(
+							'key'    => 'group_' . $cpt_slug . '_fields',
+							'title'  => ! empty( $cpt['title'] ) ? $cpt['title'] . ' Fields' : __( 'Fields', 'secure-custom-fields' ),
+							'fields' => $json['fields'],
+						),
+						$cpt_slug,
+						$file
+					);
+				}
+
+				foreach ( $groups as $group ) {
+					acf_add_local_field_group( $group );
+				}
+			}
+		}
+
+		/**
+		 * Builds a field group array guaranteed to be attached to a given CPT.
+		 *
+		 * Injects a post_type location rule targeting the CPT slug so the group
+		 * is visible on the CPT edit screen. Existing user-supplied location
+		 * rules are preserved alongside the injected one.
+		 *
+		 * @since SCF 6.9.3
+		 *
+		 * @param array  $group     Raw field group payload from a unified file.
+		 * @param string $cpt_slug  The CPT slug the group should attach to.
+		 * @param string $file      Source JSON file path (recorded for traceability).
+		 * @return array
+		 */
+		private function prepare_unified_field_group( $group, $cpt_slug, $file = '' ) {
+			$injected_rule = array(
+				'param'    => 'post_type',
+				'operator' => '==',
+				'value'    => $cpt_slug,
+			);
+
+			$location = array();
+			if ( isset( $group['location'] ) && is_array( $group['location'] ) ) {
+				$location = $group['location'];
+			}
+
+			$has_match = false;
+			foreach ( $location as $or_group ) {
+				if ( ! is_array( $or_group ) ) {
+					continue;
+				}
+				foreach ( $or_group as $rule ) {
+					if ( ! is_array( $rule ) ) {
+						continue;
+					}
+					if ( isset( $rule['param'], $rule['value'] ) && 'post_type' === $rule['param'] && $cpt_slug === $rule['value'] ) {
+						$has_match = true;
+						break 2;
+					}
+				}
+			}
+
+			if ( ! $has_match ) {
+				$location[] = array( $injected_rule );
+			}
+
+			$group['location']   = $location;
+			$group['local']      = 'json';
+			$group['local_file'] = ! empty( $group['local_file'] ) ? $group['local_file'] : $file;
+
+			return $group;
 		}
 
 		/**

--- a/schemas/unified-cpt.schema.json
+++ b/schemas/unified-cpt.schema.json
@@ -1,0 +1,44 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://raw.githubusercontent.com/WordPress/secure-custom-fields/trunk/schemas/unified-cpt.schema.json",
+	"title": "SCF Unified CPT+Fields",
+	"description": "Schema for a Secure Custom Fields unified definition file. Declares a post type together with the field groups attached to it. Validates the post type shape exactly like post-type.schema.json plus optional field_groups (array of field group objects) or top-level fields (array of field objects, auto-wrapped into a single field group at load time).",
+	"type": "object",
+	"required": [ "key", "title", "post_type" ],
+	"properties": {
+		"key": {
+			"type": "string",
+			"pattern": "^post_type_.+$",
+			"minLength": 1,
+			"description": "Unique identifier for the post type with post_type_ prefix (e.g. 'post_type_book')"
+		},
+		"title": { "$ref": "common.schema.json#/definitions/title" },
+		"post_type": {
+			"type": "string",
+			"pattern": "^[a-z0-9_-]+$",
+			"minLength": 1,
+			"maxLength": 20,
+			"not": { "$ref": "common.schema.json#/definitions/wordpressReservedTerms" },
+			"description": "The post type slug passed to register_post_type() (e.g. 'book'). Max 20 characters, lowercase letters/numbers/underscores/dashes only, cannot be a WordPress reserved term."
+		},
+		"menu_order": { "$ref": "common.schema.json#/definitions/menu_order" },
+		"active": { "$ref": "common.schema.json#/definitions/active" },
+		"modified": { "$ref": "common.schema.json#/definitions/modified" },
+		"field_groups": {
+			"type": "array",
+			"description": "Field groups attached to this post type. Each entry receives an automatic post_type location rule targeting this CPT at load time.",
+			"items": { "$ref": "field-group.schema.json#/definitions/fieldGroup" },
+			"minItems": 1
+		},
+		"fields": {
+			"type": "array",
+			"description": "Top-level fields. Auto-wrapped into a single synthetic field group pinned to the CPT at load time.",
+			"items": { "$ref": "field.schema.json#/definitions/field" },
+			"minItems": 1
+		}
+	},
+	"anyOf": [
+		{ "required": [ "field_groups" ] },
+		{ "required": [ "fields" ] }
+	]
+}

--- a/tests/php/fixtures/schemas/unified/invalid/post-type-product-missing-post-type.json
+++ b/tests/php/fixtures/schemas/unified/invalid/post-type-product-missing-post-type.json
@@ -1,0 +1,18 @@
+{
+	"key": "post_type_product",
+	"title": "Product",
+	"field_groups": [
+		{
+			"key": "group_product_main",
+			"title": "Product Main",
+			"fields": [
+				{
+					"key": "field_product_price",
+					"label": "Price",
+					"name": "price",
+					"type": "text"
+				}
+			]
+		}
+	]
+}

--- a/tests/php/fixtures/schemas/unified/valid/post-type-book-with-field-groups.json
+++ b/tests/php/fixtures/schemas/unified/valid/post-type-book-with-field-groups.json
@@ -1,0 +1,32 @@
+{
+	"key": "post_type_book",
+	"title": "Book",
+	"post_type": "book",
+	"labels": {
+		"singular_name": "Book",
+		"name": "Books",
+		"add_new_item": "Add New Book"
+	},
+	"public": true,
+	"supports": [ "title", "editor", "thumbnail" ],
+	"field_groups": [
+		{
+			"key": "group_book_details",
+			"title": "Book Details",
+			"fields": [
+				{
+					"key": "field_book_isbn",
+					"label": "ISBN",
+					"name": "isbn",
+					"type": "text"
+				},
+				{
+					"key": "field_book_publisher",
+					"label": "Publisher",
+					"name": "publisher",
+					"type": "text"
+				}
+			]
+		}
+	]
+}

--- a/tests/php/fixtures/schemas/unified/valid/post-type-movie-with-fields.json
+++ b/tests/php/fixtures/schemas/unified/valid/post-type-movie-with-fields.json
@@ -1,0 +1,15 @@
+{
+	"key": "post_type_movie",
+	"title": "Movie",
+	"post_type": "movie",
+	"public": true,
+	"supports": [ "title" ],
+	"fields": [
+		{
+			"key": "field_movie_director",
+			"label": "Director",
+			"name": "director",
+			"type": "text"
+		}
+	]
+}

--- a/tests/php/test-unified-definitions.php
+++ b/tests/php/test-unified-definitions.php
@@ -1,0 +1,589 @@
+<?php
+/**
+ * Tests for unified CPT+fields definition loader (issue #163).
+ *
+ * Verifies that ACF_Local_JSON detects, validates, and loads JSON files
+ * that declare a custom post type together with the field groups attached
+ * to it. Legacy single-object files continue to load through the existing
+ * per-type includes.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for ACF_Local_JSON unified CPT+fields handling.
+ */
+class Test_Unified_Definitions extends BaseTestCase {
+
+	/**
+	 * Temporary JSON directory used by each test.
+	 *
+	 * @var string
+	 */
+	private $temp_dir;
+
+	/**
+	 * ACF_Local_JSON instance under test.
+	 *
+	 * @var ACF_Local_JSON
+	 */
+	private $json;
+
+	/**
+	 * Save-path filter callback.
+	 *
+	 * @var callable
+	 */
+	private $save_filter;
+
+	/**
+	 * Load-path filter callback.
+	 *
+	 * @var callable
+	 */
+	private $load_filter;
+
+	/**
+	 * Set up: create temp dir, hook filters, reset local stores.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		acf_include( 'includes/fields/class-acf-field-text.php' );
+		if ( ! has_filter( 'acf/prepare_field_for_import/type=text' ) ) {
+			acf_register_field_type( 'acf_field_text' );
+		}
+
+		acf_reset_local();
+		acf_get_store( 'field-groups' )->reset();
+		acf_get_store( 'local-post-types' )->reset();
+		acf_get_store( 'local-groups' )->reset();
+
+		$this->temp_dir = sys_get_temp_dir() . '/scf-unified-' . uniqid();
+		mkdir( $this->temp_dir, 0777, true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+
+		$dir               = $this->temp_dir;
+		$this->save_filter = function () use ( $dir ) {
+			return $dir;
+		};
+		$this->load_filter = function () use ( $dir ) {
+			return array( $dir );
+		};
+
+		add_filter( 'acf/settings/save_json', $this->save_filter, 100 );
+		add_filter( 'acf/settings/load_json', $this->load_filter, 100 );
+
+		$this->json = acf_get_instance( 'ACF_Local_JSON' );
+		$this->json->scan_files();
+	}
+
+	/**
+	 * Tear down: remove filters, drop temp dir, reset stores.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		remove_filter( 'acf/settings/save_json', $this->save_filter, 100 );
+		remove_filter( 'acf/settings/load_json', $this->load_filter, 100 );
+		$this->delete_dir( $this->temp_dir );
+		acf_reset_local();
+		acf_get_store( 'field-groups' )->reset();
+		acf_get_store( 'local-post-types' )->reset();
+		acf_get_store( 'local-groups' )->reset();
+		parent::tearDown();
+	}
+
+	/**
+	 * Recursively removes a directory.
+	 *
+	 * @param string $dir Path to remove.
+	 * @return void
+	 */
+	private function delete_dir( $dir ) {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+		foreach ( scandir( $dir ) as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$path = $dir . '/' . $entry;
+			is_dir( $path ) ? $this->delete_dir( $path ) : unlink( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test cleanup.
+		}
+		rmdir( $dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test cleanup.
+	}
+
+	/**
+	 * Writes a JSON fixture to the temp dir.
+	 *
+	 * @param string $filename File name without leading slash.
+	 * @param mixed  $data     Array, decoded object, or raw JSON string.
+	 * @return string Full path.
+	 */
+	private function write_json( $filename, $data ) {
+		$file     = $this->temp_dir . '/' . $filename;
+		$contents = is_string( $data ) ? $data : acf_json_encode( $data );
+		file_put_contents( $file, $contents ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture.
+		return $file;
+	}
+
+	// =====================================================================
+	// Static is_unified_definition() detector
+	// =====================================================================
+
+	/**
+	 * Returns true for a payload with post_type + field_groups.
+	 *
+	 * @return void
+	 */
+	public function test_detector_accepts_post_type_with_field_groups() {
+		$payload = array(
+			'key'          => 'post_type_book',
+			'title'        => 'Book',
+			'post_type'    => 'book',
+			'field_groups' => array(
+				array(
+					'key'    => 'group_a',
+					'title'  => 'A',
+					'fields' => array(),
+				),
+			),
+		);
+		$this->assertTrue( ACF_Local_JSON::is_unified_definition( $payload ) );
+	}
+
+	/**
+	 * Returns true for a payload with post_type + top-level fields.
+	 *
+	 * @return void
+	 */
+	public function test_detector_accepts_post_type_with_top_level_fields() {
+		$payload = array(
+			'key'       => 'post_type_book',
+			'title'     => 'Book',
+			'post_type' => 'book',
+			'fields'    => array(
+				array(
+					'key'   => 'field_a',
+					'label' => 'A',
+					'name'  => 'a',
+					'type'  => 'text',
+				),
+			),
+		);
+		$this->assertTrue( ACF_Local_JSON::is_unified_definition( $payload ) );
+	}
+
+	/**
+	 * Returns false for a legacy CPT-only payload (no field_groups or fields).
+	 *
+	 * @return void
+	 */
+	public function test_detector_rejects_legacy_cpt_only_payload() {
+		$payload = array(
+			'key'       => 'post_type_book',
+			'title'     => 'Book',
+			'post_type' => 'book',
+		);
+		$this->assertFalse( ACF_Local_JSON::is_unified_definition( $payload ) );
+	}
+
+	/**
+	 * Returns false for a legacy field-group payload (no post_type).
+	 *
+	 * @return void
+	 */
+	public function test_detector_rejects_legacy_field_group_payload() {
+		$payload = array(
+			'key'    => 'group_abc',
+			'title'  => 'Group',
+			'fields' => array(),
+		);
+		$this->assertFalse( ACF_Local_JSON::is_unified_definition( $payload ) );
+	}
+
+	/**
+	 * Returns false for non-array input.
+	 *
+	 * @return void
+	 */
+	public function test_detector_rejects_non_array_input() {
+		$this->assertFalse( ACF_Local_JSON::is_unified_definition( null ) );
+		$this->assertFalse( ACF_Local_JSON::is_unified_definition( 'string' ) );
+		$this->assertFalse( ACF_Local_JSON::is_unified_definition( 123 ) );
+	}
+
+	// =====================================================================
+	// Scan: unified files are skipped from legacy scans
+	// =====================================================================
+
+	/**
+	 * A unified file is registered in unified_files, not files.
+	 *
+	 * @return void
+	 */
+	public function test_scan_routes_unified_files_separately() {
+		$this->write_json(
+			'post_type_book.json',
+			array(
+				'key'          => 'post_type_book',
+				'title'        => 'Book',
+				'post_type'    => 'book',
+				'field_groups' => array(
+					array(
+						'key'    => 'group_book_details',
+						'title'  => 'Book Details',
+						'fields' => array(),
+					),
+				),
+			)
+		);
+
+		$this->json->scan_files( 'acf-post-type' );
+
+		$unified = $this->json->get_unified_files();
+		$this->assertArrayHasKey( 'post_type_book', $unified, 'Unified file should land in unified_files' );
+		$this->assertArrayNotHasKey( 'post_type_book', $this->json->get_files( 'acf-post-type' ), 'Unified file should NOT appear in legacy post-type scan' );
+		$this->assertArrayNotHasKey( 'post_type_book', $this->json->get_files( 'acf-field-group' ), 'Unified file should NOT appear in field-group scan' );
+	}
+
+	// =====================================================================
+	// End-to-end load
+	// =====================================================================
+
+	/**
+	 * A unified file with explicit field_groups loads the CPT and its groups.
+	 *
+	 * @return void
+	 */
+	public function test_include_unified_loads_cpt_and_explicit_field_groups() {
+		$this->write_json(
+			'post_type_book.json',
+			array(
+				'key'          => 'post_type_book',
+				'title'        => 'Book',
+				'post_type'    => 'book',
+				'public'       => true,
+				'field_groups' => array(
+					array(
+						'key'    => 'group_book_details',
+						'title'  => 'Book Details',
+						'fields' => array(
+							array(
+								'key'   => 'field_book_isbn',
+								'label' => 'ISBN',
+								'name'  => 'isbn',
+								'type'  => 'text',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$this->json->include_unified_definitions();
+
+		$cpt = acf_get_local_internal_post_type( 'post_type_book', 'acf-post-type' );
+		$this->assertIsArray( $cpt, 'Local CPT should be registered from unified file' );
+		$this->assertSame( 'book', $cpt['post_type'] );
+		$this->assertSame( 'Book', $cpt['title'] );
+
+		$group = acf_get_local_field_group( 'group_book_details' );
+		$this->assertIsArray( $group, 'Field group from unified file should be registered' );
+		$this->assertSame( 'Book Details', $group['title'] );
+
+		$fields = array_values( acf_get_local_fields( 'group_book_details' ) );
+		$this->assertCount( 1, $fields, 'Field group should contain the declared field(s)' );
+		$this->assertSame( 'field_book_isbn', $fields[0]['key'] );
+
+		// Location must attach to the owning CPT.
+		$this->assertNotEmpty( $group['location'], 'Field group must have location rules' );
+		$attached = false;
+		foreach ( $group['location'] as $or_group ) {
+			foreach ( $or_group as $rule ) {
+				if ( 'post_type' === $rule['param'] && '==' === $rule['operator'] && 'book' === $rule['value'] ) {
+					$attached = true;
+					break 2;
+				}
+			}
+		}
+		$this->assertTrue( $attached, 'Field group must include a post_type rule targeting the owning CPT' );
+	}
+
+	/**
+	 * A unified file with only top-level fields auto-wraps into a synthetic group.
+	 *
+	 * @return void
+	 */
+	public function test_include_unified_auto_wraps_top_level_fields() {
+		$this->write_json(
+			'post_type_movie.json',
+			array(
+				'key'       => 'post_type_movie',
+				'title'     => 'Movie',
+				'post_type' => 'movie',
+				'fields'    => array(
+					array(
+						'key'   => 'field_movie_director',
+						'label' => 'Director',
+						'name'  => 'director',
+						'type'  => 'text',
+					),
+				),
+			)
+		);
+
+		$this->json->include_unified_definitions();
+
+		$cpt = acf_get_local_internal_post_type( 'post_type_movie', 'acf-post-type' );
+		$this->assertIsArray( $cpt );
+
+		$group = acf_get_local_field_group( 'group_movie_fields' );
+		$this->assertIsArray( $group, 'Auto-wrapped field group should be registered' );
+		$this->assertSame( 'Movie Fields', $group['title'] );
+
+		$fields = array_values( acf_get_local_fields( 'group_movie_fields' ) );
+		$this->assertCount( 1, $fields, 'Auto-wrapped group should contain the declared field' );
+		$this->assertSame( 'field_movie_director', $fields[0]['key'] );
+	}
+
+	/**
+	 * Explicit location rules coexist with the injected post_type rule.
+	 *
+	 * @return void
+	 */
+	public function test_include_unified_preserves_explicit_location_rules() {
+		$this->write_json(
+			'post_type_album.json',
+			array(
+				'key'          => 'post_type_album',
+				'title'        => 'Album',
+				'post_type'    => 'album',
+				'field_groups' => array(
+					array(
+						'key'      => 'group_album_meta',
+						'title'    => 'Album Meta',
+						'fields'   => array(),
+						'location' => array(
+							array(
+								array(
+									'param'    => 'post_type',
+									'operator' => '==',
+									'value'    => 'page',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$this->json->include_unified_definitions();
+
+		$group = acf_get_local_field_group( 'group_album_meta' );
+		$this->assertIsArray( $group );
+
+		// Both rules should be present (user-provided `page` rule AND injected `album` rule).
+		$has_page   = false;
+		$has_album  = false;
+		$has_inject = false;
+		foreach ( $group['location'] as $or_group ) {
+			foreach ( $or_group as $rule ) {
+				if ( ! is_array( $rule ) ) {
+					continue;
+				}
+				if ( 'page' === $rule['value'] ) {
+					$has_page = true;
+				}
+				if ( 'album' === $rule['value'] ) {
+					$has_album = true;
+				}
+			}
+		}
+		$this->assertTrue( $has_page, 'Explicit user location rule should be preserved' );
+		$this->assertTrue( $has_album, 'Injected post_type rule for owning CPT should also be present' );
+	}
+
+	/**
+	 * Legacy files coexist with unified files in the same directory.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_files_still_load_alongside_unified() {
+		// Unified file.
+		$this->write_json(
+			'post_type_book.json',
+			array(
+				'key'          => 'post_type_book',
+				'title'        => 'Book',
+				'post_type'    => 'book',
+				'field_groups' => array(
+					array(
+						'key'    => 'group_book_details',
+						'title'  => 'Book Details',
+						'fields' => array(),
+					),
+				),
+			)
+		);
+
+		// Legacy CPT file.
+		$this->write_json(
+			'post_type_album.json',
+			array(
+				'key'       => 'post_type_album',
+				'title'     => 'Album',
+				'post_type' => 'album',
+			)
+		);
+
+		// Legacy field group file.
+		$this->write_json(
+			'group_legacy.json',
+			array(
+				'key'    => 'group_legacy',
+				'title'  => 'Legacy Group',
+				'fields' => array(),
+			)
+		);
+
+		$this->json->scan_files( 'acf-post-type' );
+
+		// Unified loads via its own method.
+		$this->json->include_unified_definitions();
+		$this->assertNotNull( acf_get_local_internal_post_type( 'post_type_book', 'acf-post-type' ) );
+
+		// Legacy loads via per-type includes.
+		$this->json->include_post_types();
+		$this->json->include_fields();
+		$this->assertNotNull( acf_get_local_internal_post_type( 'post_type_album', 'acf-post-type' ), 'Legacy CPT file still loads' );
+		$this->assertNotNull( acf_get_local_field_group( 'group_legacy' ), 'Legacy field group file still loads' );
+	}
+
+	/**
+	 * The injected post_type location rule matches the actual location matcher.
+	 *
+	 * This exercises ACF_Location_Post_Type against the loader's output.
+	 *
+	 * @return void
+	 */
+	public function test_field_groups_record_source_file() {
+		$file = $this->write_json(
+			'post_type_book.json',
+			array(
+				'key'          => 'post_type_book',
+				'title'        => 'Book',
+				'post_type'    => 'book',
+				'field_groups' => array(
+					array(
+						'key'    => 'group_book_details',
+						'title'  => 'Book Details',
+						'fields' => array(),
+					),
+				),
+			)
+		);
+
+		$this->json->include_unified_definitions();
+
+		$group = acf_get_local_field_group( 'group_book_details' );
+		$this->assertIsArray( $group );
+		$this->assertSame( $file, $group['local_file'], 'Field group should record its source path' );
+		$this->assertSame( 'json', $group['local'] );
+	}
+
+	/**
+	 * The injected post_type location rule is what makes the field group
+	 * render on the owning CPT's edit screen at runtime. We verify its
+	 * presence here. End-to-end visibility is exercised by the manual
+	 * smoke test (WorDBless does not register ACF_Location types).
+	 *
+	 * @return void
+	 */
+	public function test_injected_location_targets_owning_cpt() {
+		// The injected post_type location rule is what makes the field group
+		// render on the owning CPT's edit screen at runtime. We verify its
+		// presence here. End-to-end visibility is exercised by the manual
+		// smoke test (WorDBless does not register ACF_Location types).
+		$this->write_json(
+			'post_type_book.json',
+			array(
+				'key'          => 'post_type_book',
+				'title'        => 'Book',
+				'post_type'    => 'book',
+				'field_groups' => array(
+					array(
+						'key'    => 'group_book_details',
+						'title'  => 'Book Details',
+						'fields' => array(),
+					),
+				),
+			)
+		);
+
+		$this->json->include_unified_definitions();
+
+		$group = acf_get_local_field_group( 'group_book_details' );
+		$this->assertIsArray( $group );
+
+		$founded = false;
+		foreach ( $group['location'] as $or_group ) {
+			if ( ! is_array( $or_group ) ) {
+				continue;
+			}
+			foreach ( $or_group as $rule ) {
+				if ( ! is_array( $rule ) ) {
+					continue;
+				}
+				if ( 'post_type' === $rule['param'] && '==' === $rule['operator'] && 'book' === $rule['value'] ) {
+					$founded = true;
+					break 2;
+				}
+			}
+		}
+		$this->assertTrue( $founded, 'Field group must carry an injected post_type==book location rule' );
+	}
+
+	// =====================================================================
+	// Schema validation against unified-cpt.schema.json
+	// =====================================================================
+
+	/**
+	 * Valid unified fixture passes the schema validator.
+	 *
+	 * @return void
+	 */
+	public function test_unified_schema_accepts_valid_fixture() {
+		$fixture = dirname( __DIR__ ) . '/fixtures/schemas/unified/valid/post-type-book-with-field-groups.json';
+		// Locate the family-wide fixtures dir, fallback to tests/php/fixtures.
+		if ( ! file_exists( $fixture ) ) {
+			$fixture = __DIR__ . '/fixtures/schemas/unified/valid/post-type-book-with-field-groups.json';
+		}
+		$this->assertFileExists( $fixture );
+
+		$validator = acf_get_instance( 'SCF_JSON_Schema_Validator' );
+		$this->assertTrue( $validator->validate( $fixture, 'unified-cpt' ), 'Valid unified file should validate against unified-cpt schema' );
+		$this->assertFalse( $validator->has_validation_errors() );
+	}
+
+	/**
+	 * Invalid unified fixture fails the schema validator.
+	 *
+	 * @return void
+	 */
+	public function test_unified_schema_rejects_invalid_fixture() {
+		$fixture = dirname( __DIR__ ) . '/fixtures/schemas/unified/invalid/post-type-product-missing-post-type.json';
+		if ( ! file_exists( $fixture ) ) {
+			$fixture = __DIR__ . '/fixtures/schemas/unified/invalid/post-type-product-missing-post-type.json';
+		}
+		$this->assertFileExists( $fixture );
+
+		$validator = acf_get_instance( 'SCF_JSON_Schema_Validator' );
+		$this->assertFalse( $validator->validate( $fixture, 'unified-cpt' ), 'Invalid unified file should fail schema validation' );
+		$this->assertTrue( $validator->has_validation_errors() );
+	}
+}


### PR DESCRIPTION
## Summary

Adds an additive reader that lets a single `acf-json` JSON file declare a custom post type together with the field groups attached to it. Today, declaring a CPT with fields requires authoring two separate files and keeping their `location.post_type` value in sync with the CPT slug. This PR lets you ship one file per conceptual unit.

Fixes #163

## Changes

### `includes/local-json.php`

**Before:** `ACF_Local_JSON::scan_files()` discovered every JSON shape by key prefix. Field groups ended up in the store through `ACF_Local_JSON::include_fields()`, which scans `group_*.json` files. CPT definitions went through `include_post_types()` for `post_type_*.json` files. Nothing connected a CPT file to the field groups whose `location` rules targeted it.

**After:** Added `ACF_Local_JSON::is_unified_definition()` (a static detector for the unified shape) and `ACF_Local_JSON::include_unified_definitions()` (a new `acf_init` priority-5 loader). `scan_files()` now routes unified files to a separate internal slot so the legacy readers do not try to read them. The loader splits the JSON into a CPT and its field groups, registers the CPT, then registers the field groups with a post-type location rule pinned to the owning CPT injected non-destructively. Top-level `fields` (without `field_groups`) are auto-wrapped into a synthetic group whose key is `group_<slug>_fields`.

**Why:** The order at priority 5 vs the existing `register_post_types` at priority 6 means field groups land in the local store before the CPT registers, so the runtime location matcher sees them.

### `schemas/unified-cpt.schema.json` (new)

JSON Schema definition for the unified envelope. Pulled in by `SCF_JSON_Schema_Validator::validate_required_schemas()`.

### `includes/class-scf-json-schema-validator.php`

Added `'unified-cpt'` to `REQUIRED_SCHEMAS` so the validator self-check finds the new schema.

### `tests/php/test-unified-definitions.php` (new)

14 tests covering the detector, scan routing, end-to-end load (with both explicit `field_groups` and auto-wrap), preservation of explicit location rules, coexistence with legacy files, source file recording, and schema validation against both a valid and an invalid fixture.

## Testing

**Test 1: Unified loader registers CPT and field groups**

1. Add a `post_type_book.json` to your active theme's `acf-json/` directory containing `key`, `title`, `post_type`, and a `field_groups` array with one group.
2. Reload any admin page.
3. Result: A **Books** entry appears in the WP admin menu and the **Book Details** field group shows up under Custom Fields with a `Show if Post Type == book` location rule.

**Test 2: Auto-wrap top-level fields**

1. Add a `post_type_movie.json` with only a top-level `fields` array (no `field_groups`).
2. Reload any admin page.
3. Result: a synthetic `group_movie_fields` group is registered and attached to the `movie` CPT.

**Test 3: Legacy files still load**

1. Add a single-object `post_type_album.json` (CPT payload only) and `group_legacy.json` (field group payload only) to the same directory.
2. Reload any admin page.
3. Result: both register through their existing per-type readers, unchanged from the pre-PR behaviour.

**Automated tests:** `composer test:php` runs all 2858 tests including the 14 new ones. PHPStan clean against `bin/baseline.neon` (regenerated for the new methods). PHPCS reports no new violations on the changed lines (verified via `phpcs-changed`).

## Verification environment

- PHP 8.x, WorDBless for unit tests
- All 2858 PHPUnit tests pass
- PHPStan level 1 with regenerated baseline, zero new errors
- `phpcs-changed` on changed lines: clean
- No breaking changes to existing JSON file shapes; existing themes with `post_type_*.json` and `group_*.json` files continue to work.

## Screenshot 
<img width="1916" height="928" alt="image" src="https://github.com/user-attachments/assets/87f54cec-581b-4927-8d09-3107a21a973b" />
