### PR TITLE
fix(validation): validate required fields on pending, future, and private saves

### DIFF
--- a/includes/forms/form-post.php
+++ b/includes/forms/form-post.php
@@ -329,6 +329,24 @@ if ( ! class_exists( 'ACF_Form_Post' ) ) :
 		}
 
 		/**
+		 * Returns whether required-field validation should run for a given post.
+		 *
+		 * Statuses that represent a post leaving the author's hands (publish,
+		 * pending review, scheduled, private) require validation; intermediate
+		 * statuses (draft, auto-draft, inherit, trash) save without enforcement
+		 * so authors can keep iterating.
+		 *
+		 * @since ACF 6.8.1
+		 *
+		 * @param WP_Post $post The post being saved.
+		 * @return boolean
+		 */
+		public function should_validate_post( $post ) {
+			$validating_statuses = array( 'publish', 'pending', 'future', 'private' );
+			return in_array( $post->post_status, $validating_statuses, true );
+		}
+
+		/**
 		 * Triggers during the 'save_post' action to save the $_POST data.
 		 *
 		 * @since   ACF 1.0.0.0.0
@@ -364,8 +382,8 @@ if ( ! class_exists( 'ACF_Form_Post' ) ) :
 				return $post_id;
 			}
 
-			// Validate for published post (allow draft to save without validation).
-			if ( 'publish' === $post->post_status ) {
+			// Validate on statuses where the post leaves the author's hands.
+			if ( $this->should_validate_post( $post ) ) {
 				// Bail early if validation fails.
 				if ( ! acf_validate_save_post() ) {
 					return;

--- a/tests/php/includes/forms/test-form-post.php
+++ b/tests/php/includes/forms/test-form-post.php
@@ -279,4 +279,46 @@ class Test_Form_Post extends BaseTestCase {
 			'Field group with block location among other rules should be identified as block field group'
 		);
 	}
+
+	/**
+	 * Test should_validate_post returns true for statuses that publish the post
+	 * or hand it off for review.
+	 */
+	public function test_should_validate_post_for_publishing_statuses() {
+		$form_post = new ACF_Form_Post();
+
+		foreach ( array( 'publish', 'pending', 'future', 'private' ) as $status ) {
+			$post = (object) array(
+				'ID'          => 1,
+				'post_type'   => 'post',
+				'post_status' => $status,
+			);
+
+			$this->assertTrue(
+				$form_post->should_validate_post( $post ),
+				sprintf( 'Status "%s" should trigger required-field validation', $status )
+			);
+		}
+	}
+
+	/**
+	 * Test should_validate_post returns false for intermediate statuses so
+	 * drafts and auto-drafts keep saving without enforcement.
+	 */
+	public function test_should_validate_post_for_drafting_statuses() {
+		$form_post = new ACF_Form_Post();
+
+		foreach ( array( 'draft', 'auto-draft', 'inherit', 'trash' ) as $status ) {
+			$post = (object) array(
+				'ID'          => 1,
+				'post_type'   => 'post',
+				'post_status' => $status,
+			);
+
+			$this->assertFalse(
+				$form_post->should_validate_post( $post ),
+				sprintf( 'Status "%s" should bypass required-field validation', $status )
+			);
+		}
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Secure Custom Fields (SCF)! Please have a look at the Contributing Guidelines:
https://github.com/WordPress/secure-custom-fields/blob/trunk/docs/contributing/index.md -->

## Summary

A contributor who lacks `publish_*` capability can submit a custom post type for review (status `pending`), schedule it (`future`), or make it private (`private`) without required SCF fields being filled. The `save_post` gate in `ACF_Form_Post` only checked for `publish`, so the `acf_validate_save_post()` call was skipped on every other status that moves the post out of the author's hands.

This PR widens the gate to the statuses where the post leaves the author (`publish`, `pending`, `future`, `private`) by extracting the check into a small `should_validate_post()` helper. Intermediate statuses (`draft`, `auto-draft`, `inherit`, `trash`) keep saving without enforcement, matching today's behaviour.

Closes #197

## Changes

### `includes/forms/form-post.php`

Adds a `should_validate_post()` method that returns true for the validating status set:

```php
public function should_validate_post( $post ) {
    $validating_statuses = array( 'publish', 'pending', 'future', 'private' );
    return in_array( $post->post_status, $validating_statuses, true );
}
```

And replaces the inline `if ( 'publish' === $post->post_status )` in `save_post()` with:

```php
if ( $this->should_validate_post( $post ) ) {
    if ( ! acf_validate_save_post() ) {
        return;
    }
}
```

### `tests/php/includes/forms/test-form-post.php`

Two new tests on `Test_Form_Post`:

- `test_should_validate_post_for_publishing_statuses` — asserts `publish`, `pending`, `future`, `private` all return `true`.
- `test_should_validate_post_for_drafting_statuses` — asserts `draft`, `auto-draft`, `inherit`, `trash` return `false`.

## Why this is enough

- Statuses that demand validator scrutiny now include `pending` (Submit for Review — the bug), `future` (scheduled, required fields matter), and `private` (visible only to authors/editors but still exits draft mode).
- Statuses for a work-in-progress (`draft`, `auto-draft`) keep saving without enforcement so authors can keep iterating.
- `inherit` (revisions) and `trash` already short-circuit earlier in `allow_save_post()`.

The frontend validation paths (`assets/src/js/_acf-validation.js`) remain unchanged: they already fire AJAX validation on Save/Submit clicks. The classic-editor and Gutenberg `useValidation` flags are a separate UX concern (which transitions trigger JS validation) and are out of scope for this server-side safety net.

The other save paths I checked (`includes/Datastore/REST_Save.php`, `includes/forms/form-front.php`, `includes/forms/form-gutenberg.php`, options page, attachment, comment, blocks, internal post types) do not go through this gate for unrelated reasons and are not affected.

## How to test

1. Activate this build on a wp-env install.
2. Create a custom post type (`events`) and a SCF field group attached to it with one required text field (`event_location`).
3. Create a user role with `read` + `edit_events` but not `publish_events`.
4. As that role, go to Events → Add New, leave `event_location` empty, click **Submit for Review**.
   - Expected: form blocked with a required-field error on `event_location`. Status does not advance to `pending`.
5. Fill `event_location`, click **Submit for Review** again.
   - Expected: post saves with status `pending`.
6. Click **Save Draft** with `event_location` empty.
   - Expected: draft saves successfully (regression guard).

A manual test plan is included in `TESTING_INSTRUCTIONS.md` (in this PR's commit message thread, not committed to the repo).

## Automated tests

Run with wp-env running:

```bash
composer test:php -- --filter=Test_Form_Post
```

14 tests pass (2 new + 12 existing), 26 assertions.

## Use of AI Tools

AI tooling was used to navigate the codebase, run targeted static analysis and tests, and draft the PR text. The change itself was implemented, reviewed, and validated by the contributor.
