### PR TITLE
fix(list-table): port ACF _acf-copyable.js for click-to-copy field keys

### DIFF
--- a/assets/src/js/_acf-copyable.js
+++ b/assets/src/js/_acf-copyable.js
@@ -1,0 +1,79 @@
+/* global acf, jQuery, navigator, pagenow */
+( function ( $, undefined ) {
+	acf.copyable = new acf.Model( {
+		events: {
+			'click .copyable': 'copyCopyable',
+		},
+
+		wait: 'ready',
+
+		initialize: function () {
+			if ( 'undefined' === typeof pagenow ) {
+				return;
+			}
+
+			const copyablePages = [
+				'edit-acf-field-group',
+				'edit-acf-post-type',
+				'edit-acf-taxonomy',
+				'edit-acf-ui-options-page',
+			];
+
+			if ( ! copyablePages.includes( pagenow ) ) {
+				return;
+			}
+
+			// To be expanded in the future to more copyable elements.
+			const $copyableElements = $( document ).find( '.column-acf-key' );
+
+			// If there are no elements, there is nothing copyable.
+			if ( ! $copyableElements.length ) {
+				return;
+			}
+
+			// For each key, check the copyable class.
+			$copyableElements.each( function () {
+				$( this ).html( acf.copyable.makeCopyable( $( this ) ) );
+			} );
+		},
+
+		makeCopyable: function ( $element ) {
+			const copyableText = acf.strSanitize( $element.text() );
+			const markup = $element.html();
+
+			let copyableClass = 'copyable';
+			if ( ! navigator.clipboard ) {
+				copyableClass = `${ copyableClass } copy-unsupported`;
+			}
+
+			return markup.replace(
+				copyableText,
+				`<span class="${ copyableClass }">${ copyableText }</span>`
+			);
+		},
+
+		copyCopyable: function ( e ) {
+			e.stopPropagation();
+			if ( ! navigator.clipboard || $( e.target ).is( 'input' ) ) {
+				return;
+			}
+
+			// Find the value to copy depending on input or text elements.
+			let copyValue;
+			if ( $( e.target ).hasClass( 'acf-input-wrap' ) ) {
+				copyValue = $( e.target ).find( 'input' ).first().val();
+			} else {
+				copyValue = $( e.target ).text().trim();
+			}
+
+			navigator.clipboard.writeText( copyValue ).then( () => {
+				$( e.target ).closest( '.copyable' ).addClass( 'copied' );
+				setTimeout( function () {
+					$( e.target )
+						.closest( '.copyable' )
+						.removeClass( 'copied' );
+				}, 2000 );
+			} );
+		},
+	} );
+} )( jQuery );

--- a/assets/src/js/acf.js
+++ b/assets/src/js/acf.js
@@ -6,3 +6,4 @@ import './_acf-modal.js';
 import './_acf-panel.js';
 import './_acf-notice.js';
 import './_acf-tooltip.js';
+import './_acf-copyable.js';


### PR DESCRIPTION
Ports upstream ACF 6.8.5's `assets/src/js/_acf-copyable.js` so the Key column on the Field Groups / Post Types / Taxonomies / Options Pages list tables becomes click-to-copy, matching the existing field-group editor behavior.

The CSS for the hover copy icon and the green check on `.copied` was already synced from ACF 6.8.5 in #506, but was inert because no JS was emitting the `.copyable` markup. This PR adds the JS half and wires it into the `acf.js` entry bundle. The `acf` script handle is already enqueued on the four `edit-acf-*` list screens, so no PHP or CSS change is required.

Diff:

- **assets/src/js/_acf-copyable.js** (new) - `acf.Model` gated on `pagenow` matching `edit-acf-field-group`, `edit-acf-post-type`, `edit-acf-taxonomy`, `edit-acf-ui-options-page`. Finds `.column-acf-key` cells, wraps the key text in a `span.copyable` (adds `copy-unsupported` when `navigator.clipboard` is unavailable), and handles the copy click.
- **assets/src/js/acf.js** - added `import './_acf-copyable.js';` after the `_acf-tooltip.js` import, matching upstream's entry ordering.

## How to test

1. Build the assets (the bundled `acf.js` is checked in under `assets/build/` and shipped; verify locally with `npm run build` if needed).
2. On the WP admin, open Field Groups / Post Types / Taxonomies / Options Pages. Make the Key column visible via Screen Options if needed.
3. Hover any row's Key cell - a copy icon now appears next to the key.
4. Click the key - the field group / post type / taxonomy / options page key is copied to the clipboard, and the icon briefly turns into a green check for about two seconds.
5. Open a Field Group for editing and click a field name/key to copy. Same behavior as before, no double-fire or console errors.
6. (Optional) Test over plain HTTP (not localhost/HTTPS): the icon hides because `navigator.clipboard` is unavailable in non-secure contexts; no JS errors.

## Screenshots

<img width="1048" height="475" alt="SCR-20260724-twpz" src="https://github.com/user-attachments/assets/0eebb699-9922-4c89-8869-85bce0fd49d3"/>
<img width="1171" height="511" alt="SCR-20260724-twsb" src="https://github.com/user-attachments/assets/6b9bff7c-c03e-45d5-96f2-dca55a9eabd4"/>
<img width="1748" height="444" alt="SCR-20260724-twwe" src="https://github.com/user-attachments/assets/a70944f7-5ee4-46c8-866d-139198dba1c5"/>