### PR TITLE
fix(geo): port schema select2 dropdown hooks

### DIFF
--- a/assets/src/js/_acf-internal-post-type.js
+++ b/assets/src/js/_acf-internal-post-type.js
@@ -1,5 +1,146 @@
 ( function ( $, undefined ) {
 	/**
+	 * Select2 hooks for the GEO Schema.org fields.
+	 *
+	 * Ported from ACF 6.8.5 assets/src/js/_acf-internal-post-type.js so the
+	 * schema_property and schema_output_format selects render with the styled
+	 * "field-type-picker" dropdown instead of generic select2. CSS for the
+	 * dropdown classes ships via _admin-inputs.scss (see #506).
+	 *
+	 * @since 6.8.5
+	 */
+	/**
+	 * Minimal select2 template for Schema.org dropdowns.
+	 *
+	 * @param {Object} selection select2 selection object.
+	 */
+	const schemaSelect2Template = function ( selection ) {
+		const $selection = $( '<span></span>' ).text( selection.text );
+		$selection.data( 'element', selection.element );
+		return $selection;
+	};
+
+	acf.addFilter( 'select2_args', function ( args, $select ) {
+		const name = $select.attr( 'name' ) || '';
+		const schemaFields = [
+			'schema_type',
+			'schema_property',
+			'schema_output_format',
+		];
+		const schemaField = schemaFields.find( ( f ) => name.includes( f ) );
+		if ( ! schemaField ) {
+			return args;
+		}
+
+		args.dropdownCssClass =
+			schemaField.replaceAll( '_', '-' ) + '-select-results';
+		args.templateResult = schemaSelect2Template;
+		args.templateSelection = schemaSelect2Template;
+
+		if ( schemaField === 'schema_type' ) {
+			args.allowReorder = false;
+		}
+
+		// Disable the output format dropdown if there is only one option.
+		// Uses lock/unlock + prop directly because acf.enable respects all
+		// locks and won't enable if the conditions system still holds a lock.
+		if ( schemaField === 'schema_output_format' ) {
+			const optionCount = $select.find( 'option' ).length;
+			if ( optionCount <= 1 ) {
+				acf.lock( $select, 'disabled', 'schema_single_option' );
+				$select.prop( 'disabled', true );
+			} else {
+				acf.unlock( $select, 'disabled', 'schema_single_option' );
+				// Only clear `disabled` if no other ACF lock still holds,
+				// so conditionals and other lock-holders keep control.
+				if ( ! acf.isLocked( $select, 'disabled' ) ) {
+					$select.prop( 'disabled', false );
+				}
+			}
+		}
+
+		// Check for a full modern version of select2 like the one provided by ACF.
+		try {
+			$.fn.select2.amd.require( 'select2/compat/dropdownCss' );
+		} catch {
+			delete args.dropdownCssClass;
+		}
+
+		// Add optgroup-aware matcher for schema property.
+		if ( schemaField === 'schema_property' ) {
+			args.matcher = function ( params, data ) {
+				if ( ! params.term || params.term.trim() === '' ) {
+					return data;
+				}
+
+				// Handle optgroups.
+				if ( data.children && data.children.length > 0 ) {
+					if (
+						data.text
+							.toLowerCase()
+							.includes( params.term.toLowerCase() )
+					) {
+						return data; // Group matches, return all children.
+					}
+					return $.fn.select2.defaults.defaults.matcher(
+						params,
+						data
+					);
+				}
+
+				const searchTerm = params.term.toLowerCase();
+				const optionText = data.text.toLowerCase();
+
+				if ( optionText.includes( searchTerm ) ) {
+					return data;
+				}
+
+				if ( data.element?.parentElement ) {
+					const optgroup = data.element.parentElement;
+					if ( optgroup.tagName === 'OPTGROUP' && optgroup.label ) {
+						if (
+							optgroup.label.toLowerCase().includes( searchTerm )
+						) {
+							return data;
+						}
+					}
+				}
+
+				return null;
+			};
+		}
+
+		return args;
+	} );
+
+	acf.addAction( 'select2_init', function ( $select ) {
+		const name = $select.attr( 'name' ) || '';
+		if (
+			! name.includes( 'schema_property' ) &&
+			! name.includes( 'schema_output_format' )
+		) {
+			return;
+		}
+
+		$select.on( 'select2:open', function () {
+			const dropdownClass = name.includes( 'schema_property' )
+				? 'schema-property-select-results'
+				: 'schema-output-format-select-results';
+			// Prefer class lookup; fall back to any open select2 container
+			// when the `dropdownCssClass` was dropped by the compat check.
+			const $searchInput = $(
+				'.' + dropdownClass + ' input.select2-search__field'
+			).first();
+			const $fallback = $searchInput.length
+				? $searchInput
+				: $(
+						'.select2-container--open input.select2-search__field'
+				  ).first();
+			$fallback.attr( 'placeholder', acf.__( 'Type to search…' ) );
+		} );
+	} );
+
+	/**
 	 *  internalPostTypeSettingsManager
 	 *
 	 *  Model for handling events in the settings metaboxes of internal post types


### PR DESCRIPTION
<!-- Thanks for contributing to Secure Custom Fields (SCF)! Please have a look at the Contributing Guidelines:
https://github.com/WordPress/secure-custom-fields/blob/trunk/docs/contributing/index.md -->

Ports the ACF 6.8.5 schema select2 hooks so the GEO Schema.org Property and Schema.org Output Format dropdowns render with the styled field-type-picker chrome instead of unstyled select2.

SCF renders both selects with select2 (`'ui' => 1`) in `src/AI/GEO/FieldSettings.php`, but the local `assets/src/js/_acf-internal-post-type.js` predates the schema code, so the dropdown panels miss the `schema-property-select-results` / `schema-output-format-select-results` / `schema-type-select-results` classes and the styled search input. SCF already has the SCSS for those classes via `assets/src/sass/_admin-inputs.scss` (#506), so porting only the JS is enough to light up the styled dropdown.

What is ported from ACF 6.8.5 `_acf-internal-post-type.js`:

- a shared `schemaSelect2Template` for `templateResult` / `templateSelection`
- a `select2_args` filter that sets `args.dropdownCssClass` for any select whose `name` includes `schema_type`, `schema_property`, or `schema_output_format`
- an optgroup-aware `args.matcher` for `schema_property` so typing matches parent group labels as well as child option text
- lock + `prop('disabled', true)` for `schema_output_format` when only one format is valid; `acf.unlock` plus an `acf.isLocked` guard on the way out so other locks (e.g. conditionals) still hold
- `args.allowReorder = false` for `schema_type`
- a `select2_init` action that on `select2:open` sets the search input placeholder to `Type to search…` for property and output format dropdowns, falling back to any open select2 container if `dropdownCssClass` was dropped by the `$.fn.select2.amd.require` compat check

CSS reference: `assets/src/sass/_admin-inputs.scss:999-1011` declares the three schema-X-select-results selectors and `@extend`s the `.field-type-select-results` chrome that already shipped.

Field-name sources it targets: `src/AI/GEO/FieldSettings.php:145` (`schema_property`), `src/AI/GEO/FieldSettings.php:169` (`schema_output_format`), `src/AI/GEO/GEO.php:97-98` (`schema_type`). All three selects are picked up by the new filter.

Closes #507

## Use of AI Tools

AI tooling was used to assist with investigation, porting from upstream ACF 6.8.5, and PR preparation. Final code was reviewed and is held to the same standard as human-authored code.
