### PR TITLE
fix(blocks): reset local meta after preview render

### DIFF
--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -782,10 +782,14 @@ function acf_rendered_block( $attributes, $content = '', $is_preview = false, $p
 
 		$block = acf_prepare_block( $attributes );
 		$block = acf_add_block_meta_values( $block, $post_id );
-		acf_setup_meta( $block['data'], $block['id'], true );
+		try {
+			acf_setup_meta( $block['data'], $block['id'], true );
 
-		if ( ! empty( $block['validate'] ) ) {
-			$validation = acf_get_block_validation_state( $block, false, false, true );
+			if ( ! empty( $block['validate'] ) ) {
+				$validation = acf_get_block_validation_state( $block, false, false, true );
+			}
+		} finally {
+			acf_reset_meta( $block['id'] );
 		}
 
 		$fields = acf_get_block_fields( $block );
@@ -816,9 +820,13 @@ function acf_rendered_block( $attributes, $content = '', $is_preview = false, $p
 			$block_toolbar_fields = acf_process_block_toolbar_fields( apply_filters( 'acf/blocks/top_toolbar_fields', array(), $block, $content, $is_preview, $post_id, $wp_block, $context ) );
 			$fields               = acf_get_block_fields( $block );
 
-			acf_setup_meta( $block['data'], $block['id'], true );
-			if ( ! empty( $block['validate'] ) ) {
-				$validation = acf_get_block_validation_state( $block, false, false, true );
+			try {
+				acf_setup_meta( $block['data'], $block['id'], true );
+				if ( ! empty( $block['validate'] ) ) {
+					$validation = acf_get_block_validation_state( $block, false, false, true );
+				}
+			} finally {
+				acf_reset_meta( $block['id'] );
 			}
 		}
 	}
@@ -920,37 +928,41 @@ function acf_rendered_block_v3( $attributes, $content = '', $is_preview = false,
 
 	$block = acf_prepare_block( $attributes );
 	$block = acf_add_block_meta_values( $block, $post_id );
-	acf_setup_meta( $block['data'], $block['id'], true );
+	try {
+		acf_setup_meta( $block['data'], $block['id'], true );
 
-	// Only render the block form in the admin/preview context to avoid
-	// enqueueing editor assets (e.g. wp_editor) on the front end.
-	if ( $is_preview ) {
-		// Load the block form since we're in edit mode.
-		// Set flag for post REST cleanup of media enqueue count during preloads.
-		acf_set_data( 'acf_did_render_block_form', true );
+		// Only render the block form in the admin/preview context to avoid
+		// enqueueing editor assets (e.g. wp_editor) on the front end.
+		if ( $is_preview ) {
+			// Load the block form since we're in edit mode.
+			// Set flag for post REST cleanup of media enqueue count during preloads.
+			acf_set_data( 'acf_did_render_block_form', true );
 
-		if ( ! empty( $block['validate'] ) ) {
-			$validation = acf_get_block_validation_state( $block, false, false, true );
+			if ( ! empty( $block['validate'] ) ) {
+				$validation = acf_get_block_validation_state( $block, false, false, true );
+			}
+
+			$fields = acf_get_block_fields( $block );
+			if ( $fields ) {
+				acf_prefix_fields( $fields, "acf-{$block['id']}" );
+
+				ob_start();
+				echo '<div class="acf-block-fields acf-fields" data-block-id="' . esc_attr( $block['id'] ) . '">';
+				acf_render_fields( $fields, acf_ensure_block_id_prefix( $block['id'] ), 'div', 'field' );
+				echo '</div>';
+				$form = ob_get_clean();
+			} else {
+				ob_start();
+				echo acf_get_empty_block_form_html( $attributes['name'] ); //phpcs:ignore -- Output of acf_get_empty_block_form_html() is already escaped via acc_esc_html() for use as text within this HTML container.
+				$form = ob_get_clean();
+			}
+
+			// Now that the form has been rendered, reset field values as they may need to be
+			// different depending on if acf_doing_block_preview is true or false.
+			acf_get_store( 'values' )->reset();
 		}
-
-		$fields = acf_get_block_fields( $block );
-		if ( $fields ) {
-			acf_prefix_fields( $fields, "acf-{$block['id']}" );
-
-			ob_start();
-			echo '<div class="acf-block-fields acf-fields" data-block-id="' . esc_attr( $block['id'] ) . '">';
-			acf_render_fields( $fields, acf_ensure_block_id_prefix( $block['id'] ), 'div', 'field' );
-			echo '</div>';
-			$form = ob_get_clean();
-		} else {
-			ob_start();
-			echo acf_get_empty_block_form_html( $attributes['name'] ); //phpcs:ignore -- Output of acf_get_empty_block_form_html() is already escaped via acf_esc_html() for use as text within this HTML container.
-			$form = ob_get_clean();
-		}
-
-		// Now that the form has been rendered, reset field values as they may need to be
-		// different depending on if acf_doing_block_preview is true or false.
-		acf_get_store( 'values' )->reset();
+	} finally {
+		acf_reset_meta( $block['id'] );
 	}
 
 	// Capture block render output.

--- a/tests/php/includes/blocks/test-blocks-auto-inline-editing.php
+++ b/tests/php/includes/blocks/test-blocks-auto-inline-editing.php
@@ -53,13 +53,6 @@ class Test_Blocks_Auto_Inline_Editing extends BaseTestCase {
 	private $temp_files = array();
 
 	/**
-	 * Block IDs that had local meta set up during a test.
-	 *
-	 * @var array
-	 */
-	private $meta_block_ids = array();
-
-	/**
 	 * Set up test fixtures.
 	 */
 	public function set_up() {
@@ -106,11 +99,6 @@ class Test_Blocks_Auto_Inline_Editing extends BaseTestCase {
 			}
 		}
 		$this->temp_files = array();
-
-		foreach ( $this->meta_block_ids as $block_id ) {
-			acf_reset_meta( $block_id );
-		}
-		$this->meta_block_ids = array();
 
 		acf_set_data( 'acf_current_block_version', null );
 		acf_set_data( 'acf_doing_block_preview', false );
@@ -403,8 +391,7 @@ class Test_Blocks_Auto_Inline_Editing extends BaseTestCase {
 			'mode' => 'preview',
 		);
 
-		$html                   = acf_rendered_block( $attributes, '', true, 0 );
-		$this->meta_block_ids[] = 'block_aiepreview';
+		$html = acf_rendered_block( $attributes, '', true, 0 );
 
 		$this->assertStringContainsString( 'Editable Headline', $html );
 		$this->assertStringContainsString( 'data-acf-inline-contenteditable-field-slug="auto_inline_text"', $html );

--- a/tests/php/includes/blocks/test-blocks-render.php
+++ b/tests/php/includes/blocks/test-blocks-render.php
@@ -49,13 +49,6 @@ class Test_Blocks_Render extends BaseTestCase {
 	private $temp_files = array();
 
 	/**
-	 * Block IDs that had local meta set up during a test.
-	 *
-	 * @var array
-	 */
-	private $meta_block_ids = array();
-
-	/**
 	 * Set up test fixtures.
 	 */
 	public function set_up() {
@@ -116,17 +109,6 @@ class Test_Blocks_Render extends BaseTestCase {
 			}
 		}
 		$this->temp_files = array();
-
-		// NOTE: documents current behavior — possible bug: the preview render
-		// paths in acf_rendered_block()/acf_rendered_block_v3() call
-		// acf_setup_meta() for validation after rendering without a matching
-		// acf_reset_meta(), leaving block-scoped local meta active after the
-		// function returns. Reset it to avoid leaking into other tests.
-		// Tracked in #455.
-		foreach ( $this->meta_block_ids as $block_id ) {
-			acf_reset_meta( $block_id );
-		}
-		$this->meta_block_ids = array();
 
 		acf_set_data( 'acf_current_block_version', null );
 		acf_set_data( 'acf_doing_block_preview', false );
@@ -276,8 +258,7 @@ class Test_Blocks_Render extends BaseTestCase {
 		// the front-end render that was just cached for the same block ID.
 		acf_get_store( 'block-cache' )->reset();
 
-		$preview_html           = acf_rendered_block( $attributes, '', true, 0 );
-		$this->meta_block_ids[] = 'block_missingtpl';
+		$preview_html = acf_rendered_block( $attributes, '', true, 0 );
 		$this->assertStringContainsString( 'The render template for this ACF Block was not found', $preview_html );
 	}
 
@@ -358,8 +339,7 @@ class Test_Blocks_Render extends BaseTestCase {
 			'mode' => 'preview',
 		);
 
-		$html                   = acf_rendered_block( $attributes, '', true, 0 );
-		$this->meta_block_ids[] = 'block_previewcache';
+		$html = acf_rendered_block( $attributes, '', true, 0 );
 
 		$this->assertTrue( $captured_preview );
 		$this->assertStringContainsString( 'PREVIEW-HTML', $html );
@@ -566,7 +546,6 @@ class Test_Blocks_Render extends BaseTestCase {
 			'block_inlineempty',
 			true
 		);
-		$this->meta_block_ids[] = 'block_inlineempty';
 
 		// The auto inline editing placeholder counts as empty.
 		$this->assertTrue( acf_inline_editing_field_is_empty( 'inline_empty_text' ) );
@@ -579,7 +558,6 @@ class Test_Blocks_Render extends BaseTestCase {
 			'block_inlineempty2',
 			true
 		);
-		$this->meta_block_ids[] = 'block_inlineempty2';
 		acf_get_store( 'values' )->reset();
 
 		$this->assertFalse( acf_inline_editing_field_is_empty( 'inline_empty_text' ) );
@@ -667,7 +645,6 @@ class Test_Blocks_Render extends BaseTestCase {
 		// V3 in a block preview with block-scoped local meta renders attributes.
 		acf_set_data( 'acf_doing_block_preview', true );
 		acf_setup_meta( array(), 'block_toolbar1', true );
-		$this->meta_block_ids[] = 'block_toolbar1';
 
 		$attrs = acf_inline_toolbar_editing_attrs( array( 'toolbar_text' ) );
 		$this->assertStringContainsString( 'data-acf-inline-fields-uid="block_toolbar1toolbar_text"', $attrs );
@@ -704,5 +681,102 @@ class Test_Blocks_Render extends BaseTestCase {
 		// Unknown fields are skipped entirely.
 		$attrs = acf_inline_toolbar_editing_attrs( array( 'this_field_does_not_exist' ) );
 		$this->assertStringContainsString( 'data-acf-inline-fields="[]"', $attrs );
+	}
+
+	/**
+	 * Regression test for #455. Preview renders of both v1/v2 and v3 paths
+	 * must call acf_reset_meta() after acf_setup_meta() so unrelated
+	 * get_field()/get_post_meta() reads against the same post id continue
+	 * to return real DB values once the preview render returns.
+	 */
+	public function test_rendered_block_does_not_leak_meta() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_title'  => 'Leak Regression',
+				'post_status' => 'publish',
+			)
+		);
+		update_post_meta( $post_id, 'unrelated_field', 'db_value' );
+
+		// v1/v2 form branch.
+		$this->register_block(
+			array(
+				'name'            => 'leak-v1-block',
+				'title'           => 'Leak V1 Block',
+				'render_callback' => function () {
+					echo 'v1';
+				},
+			)
+		);
+		$block = array(
+			'id'   => 'block_leakv1',
+			'name' => 'acf/leak-v1-block',
+			'data' => array(),
+		);
+		$html  = acf_rendered_block( $block, '', true, $post_id, null, array( 'mode' => 'edit' ), false /* not ajax */ );
+		$this->assertStringContainsString( 'v1', $html );
+		$this->assertSame(
+			'db_value',
+			get_post_meta( $post_id, 'unrelated_field', true ),
+			'Form-branch preview must not leak meta'
+		);
+
+		// v1/v2 preloaded preview re-setup path. Use a different block id so
+		// the block-cache short-circuit cannot serve the previous render.
+		acf_get_store( 'block-cache' )->reset();
+		$this->register_block(
+			array(
+				'name'            => 'leak-v1-preload-block',
+				'title'           => 'Leak V1 Preload Block',
+				'render_callback' => function () {
+					echo 'v1preload';
+				},
+			)
+		);
+		$block = array(
+			'id'   => 'block_leakv1preload',
+			'name' => 'acf/leak-v1-preload-block',
+			'data' => array(),
+		);
+		// First non-ajax non-preview render to populate cache and reach
+		// the preloaded-preview re-setup branch on a subsequent preview call.
+		acf_rendered_block( $block, '', false, $post_id, null, array(), false /* not ajax */ );
+		acf_set_data( 'acf_doing_block_preview', true );
+		$preview_html = acf_rendered_block( $block, '', true, $post_id, null, array(), false /* not ajax */ );
+		acf_set_data( 'acf_doing_block_preview', false );
+		$this->assertStringContainsString( 'v1preload', $preview_html );
+		$this->assertSame(
+			'db_value',
+			get_post_meta( $post_id, 'unrelated_field', true ),
+			'Preloaded-preview re-setup must not leak meta'
+		);
+
+		// v3 path.
+		acf_get_store( 'block-cache' )->reset();
+		$this->register_block(
+			array(
+				'name'              => 'leak-v3-block',
+				'title'             => 'Leak V3 Block',
+				'acf_block_version' => 3,
+				'render_callback'   => function () {
+					echo 'v3';
+				},
+			)
+		);
+		$block = array(
+			'id'   => 'block_leakv3',
+			'name' => 'acf/leak-v3-block',
+			'data' => array(),
+		);
+		$html  = acf_rendered_block_v3( $block, '', true, $post_id, null, array() );
+		$this->assertStringContainsString( 'v3', $html );
+		$this->assertSame(
+			'db_value',
+			get_post_meta( $post_id, 'unrelated_field', true ),
+			'V3 preview must not leak meta'
+		);
+
+		wp_delete_post( $post_id, true );
 	}
 }

--- a/tests/php/includes/test-local-meta.php
+++ b/tests/php/includes/test-local-meta.php
@@ -228,10 +228,11 @@ class Test_Local_Meta extends BaseTestCase {
 			$post_id
 		);
 
-		// NOTE: documents current behavior — while local meta is active for a
-		// post id, any meta name not present in the local set returns null,
-		// shadowing real database values. Harmful interplay with leaked
-		// setup_meta state is tracked in #455.
+		// While local meta is active for a post id, any meta name not
+		// present in the local set returns null, shadowing real DB values
+		// for that post id. Block preview paths must call acf_reset_meta()
+		// after acf_setup_meta() to avoid this shadowing leaking past the
+		// preview render.
 		$this->assertNull( acf_get_metadata( $post_id, 'other_meta' ), 'Names missing from local meta should resolve to null' );
 
 		acf_reset_meta( $post_id );


### PR DESCRIPTION
The preview paths of `acf_rendered_block()` and `acf_rendered_block_v3()` call `acf_setup_meta()` for post-render validation without a matching `acf_reset_meta()`. While local meta is active for a post id, `ACF_Local_Meta::pre_load_metadata()` (`includes/local-meta.php:194-203`) returns null for any meta name not present in the local set, so unrelated `get_field()` calls for the same post id silently return null after a block preview render.

This affects three sites in `includes/blocks.php`:
- `acf_rendered_block()`, the `$form` branch (preview edit form)
- `acf_rendered_block()`, the preloaded preview re-setup after the inner render call
- `acf_rendered_block_v3()`, the unconditional setup used by v3 block previews

Fix wraps each `acf_setup_meta()` in a `try/finally` block with `acf_reset_meta( $block['id'] )`, matching the existing pair inside the inner `acf_render_block()` helper. The regression test `test_rendered_block_does_not_leak_meta` inserts a post with a known DB value, exercises all three preview paths, and asserts `get_post_meta()` still returns the DB value. The PHPUnit workaround that tracked leaked block ids and reset them manually in `tear_down` is removed from `tests/php/includes/blocks/test-blocks-render.php` and `tests/php/includes/blocks/test-blocks-auto-inline-editing.php` since the fix prevents the leak.

Closes #455

## Use of AI Tools

This pull request was prepared with assistance from Claude Code. The change was implemented, tested, and reviewed by hand before submission; the AI was used to find the relevant code paths and run the verification steps outlined in the issue.