### PR TITLE
Defensive hardening improvements for 6.9.3

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -88,6 +88,30 @@ jobs:
               if: always()
               run: npm run wp-env stop
 
+    local-json-multisite:
+        name: Local JSON Multisite Integration
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+        permissions:
+            contents: read
+
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+            - name: Setup Node.js
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version-file: '.nvmrc'
+                  cache: 'npm'
+
+            - name: Install dependencies
+              run: |
+                  npm ci
+                  composer install --prefer-dist --no-progress
+
+            - name: Run Local JSON multisite integration
+              run: npm run test:integration:local-json-multisite
+
     merge-artifacts:
         name: Merge Artifacts
         if: ${{ !cancelled() }}

--- a/docs/bin/manifest.json
+++ b/docs/bin/manifest.json
@@ -244,6 +244,11 @@
         "parent": "features",
         "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/field/index.md"
     },
+    "features/local-json": {
+        "slug": "local-json",
+        "parent": "features",
+        "markdown_source": "https://github.com/wordpress/secure-custom-fields/blob/trunk/docs/features/local-json.md"
+    },
     "features/post-types": {
         "slug": "post-types",
         "parent": "features",

--- a/docs/code-reference/META.md
+++ b/docs/code-reference/META.md
@@ -606,6 +606,7 @@ This file tracks code elements that need documentation.
 - `acf/json/save_file_name`
 - `acf/json/save_paths`
 - `acf/pre_save_json_file`
+- `wp_delete_file`
 
 ## locations.php
 

--- a/docs/code-reference/api/api-helpers-file.md
+++ b/docs/code-reference/api/api-helpers-file.md
@@ -416,8 +416,9 @@ acf_get_grouped_posts
 * This function will return all posts grouped by post_type
 This is handy for select settings
 * @since   ACF 5.0.0
-* @param   $args (array)
-* @return (array)
+* @param array $args                     The query arguments.
+* @param bool  $enforce_read_permissions Whether to exclude posts the current user cannot read.
+* @return array
 
 ## `_acf_orderby_post_type()`
 

--- a/docs/code-reference/blocks-file.md
+++ b/docs/code-reference/blocks-file.md
@@ -200,6 +200,14 @@ Renders the block HTML.
 * @param array    $context    The block context array.
 * @return void|string
 
+## `scf_path_has_stream_wrapper()`
+
+Checks if a path uses a PHP stream wrapper, such as `phar://` or `php://`.
+
+* @since 6.9.3
+* @param string $path The path to check.
+* @return boolean True if the path begins with a stream wrapper.
+
 ## `acf_block_render_template()`
 
 Locate and include an ACF block's template.

--- a/docs/code-reference/rest-api/acf-rest-api-functions-file.md
+++ b/docs/code-reference/rest-api/acf-rest-api-functions-file.md
@@ -19,6 +19,35 @@ in the main request under the_embedded property when the request contains the _e
 * @param array          $field
 * @return array
 
+## `scf_rest_sanitize_user_sub_fields()`
+
+Replaces User subfield data with REST-safe values.
+
+* @param mixed  $formatted_value The formatted parent value.
+* @param mixed  $raw_value       The raw parent value.
+* @param array  $sub_fields      The parent field's subfields.
+* @param string $output_property The subfield property used as the output key.
+* @return mixed
+
+## `scf_rest_sanitize_user_data()`
+
+Replaces formatted User field data with REST-safe values based on the field definition.
+
+* @param mixed $formatted_value The formatted field value.
+* @param mixed $raw_value       The raw field value.
+* @param array $field           The field array.
+* @return mixed
+
+## `scf_rest_format_standard_value()`
+
+Applies standard field formatting while keeping User values safe for REST output.
+
+* This does not apply the public acf/rest/format_value_for_rest filter.
+* @param mixed      $value   The raw field value.
+* @param string|int $post_id The post ID of the current object.
+* @param array      $field   The field array.
+* @return mixed
+
 ## `acf_format_value_for_rest()`
 
 Format a given field's value for output in the REST API.

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -6,6 +6,7 @@ This section details all features available in Secure Custom Fields.
 
 - [Post Types](post-types) - Create and manage custom post types
 - [Fields](fields) - Available field types and their usage
+- [Local JSON](local-json) - Save field definitions as versionable JSON files
 - [API](api) - Programmatic access and integration
 
 ## Feature Categories

--- a/docs/features/local-json.md
+++ b/docs/features/local-json.md
@@ -1,0 +1,34 @@
+# Local JSON
+
+Local JSON saves field group, post type, and taxonomy definitions as JSON files whenever they are edited. These files can be kept in version control, code-reviewed, and synced back into the database on other environments.
+
+## Save and load locations
+
+By default, files are written to and loaded from an `acf-json` directory in the active theme. The locations are configurable:
+
+- `acf/settings/save_json` — the directory new files are written to.
+- `acf/json/save_paths` — the full list of candidate save directories.
+- `acf/settings/load_json` / `acf/json/load_paths` — the directories files are loaded from.
+
+```php
+add_filter( 'acf/settings/save_json', function () {
+    return get_stylesheet_directory() . '/my-json';
+} );
+```
+
+## Multisite
+
+On multisite installations, Local JSON files are only written for network super admins by default. Other requests — site administrators, WP-Cron, and WP-CLI commands run without a super admin `--user` — may only write to save path directories inside the current site's uploads directory, the only filesystem location WordPress isolates per site. The `sites` subdirectory of the uploads directory is always excluded, because on the main site it contains the other sites' files.
+
+This prevents a site administrator from modifying field group definitions in locations shared across the network, such as a theme's `acf-json` directory. Reading (loading) Local JSON is unaffected.
+
+To let a site write Local JSON without super admin involvement, point its save location at an existing directory inside that site's uploads directory:
+
+```php
+add_filter( 'acf/settings/save_json', function () {
+    $uploads = wp_get_upload_dir();
+    return $uploads['basedir'] . '/scf-json';
+} );
+```
+
+Note that the uploads directory is publicly readable on most servers, and files there are typically not tracked in version control. Workflows that keep Local JSON in a shared, version-controlled location on multisite should perform field group changes as a network super admin.

--- a/includes/admin/class-acf-admin-options-page.php
+++ b/includes/admin/class-acf-admin-options-page.php
@@ -94,6 +94,13 @@ if ( ! class_exists( 'acf_admin_options_page' ) ) :
 			// verify and remove nonce
 			if ( acf_verify_nonce( 'options' ) ) {
 
+				// Restrict submitted values to fields assigned to the current options page.
+				// phpcs:disable WordPress.Security.NonceVerification.Missing -- Verified above.
+				if ( isset( $_POST['acf'] ) && is_array( $_POST['acf'] ) ) {
+					$_POST['acf'] = $this->filter_options_page_field_values( $_POST['acf'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Sanitized downstream; save pipeline expects slashed input.
+				}
+				// phpcs:enable WordPress.Security.NonceVerification.Missing
+
 				// save data
 				if ( acf_validate_save_post( true ) ) {
 
@@ -150,6 +157,69 @@ if ( ! class_exists( 'acf_admin_options_page' ) ) :
 			wp_enqueue_script( 'post' );
 		}
 
+		/**
+		 * Returns the field groups assigned to the current options page.
+		 *
+		 * @since SCF 6.9.3
+		 *
+		 * @return array
+		 */
+		protected function get_options_page_field_groups() {
+			return acf_get_field_groups(
+				array(
+					'options_page' => $this->page['menu_slug'],
+				)
+			);
+		}
+
+		/**
+		 * Returns the top-level submitted field keys accepted by the current options page.
+		 *
+		 * Seamless clone subfields are submitted below the clone field's key, which is
+		 * extracted from their input prefix.
+		 *
+		 * @since SCF 6.9.3
+		 *
+		 * @return array
+		 */
+		protected function get_options_page_allowed_field_keys() {
+			$keys = array();
+
+			foreach ( $this->get_options_page_field_groups() as $field_group ) {
+				$fields = acf_get_fields( $field_group );
+
+				if ( ! $fields ) {
+					continue;
+				}
+
+				foreach ( $fields as $field ) {
+					$prefix = $field['prefix'] ?? 'acf';
+
+					if ( 'acf' === $prefix ) {
+						if ( ! empty( $field['key'] ) ) {
+							$keys[] = $field['key'];
+						}
+					} elseif ( is_string( $prefix ) && preg_match( '/^acf\[([^]]+)]$/', $prefix, $matches ) ) {
+						$keys[] = $matches[1];
+					}
+				}
+			}
+
+			return array_values( array_unique( array_filter( $keys ) ) );
+		}
+
+		/**
+		 * Filters submitted ACF values to the roots accepted by the current options page.
+		 *
+		 * @since SCF 6.9.3
+		 *
+		 * @param array $values Submitted ACF values.
+		 * @return array
+		 */
+		protected function filter_options_page_field_values( array $values ): array {
+			return array_intersect_key( $values, array_flip( $this->get_options_page_allowed_field_keys() ) );
+		}
+
 
 		/**
 		 * This action will find and add field groups to the current edit page
@@ -160,11 +230,7 @@ if ( ! class_exists( 'acf_admin_options_page' ) ) :
 		public function admin_head() {
 
 			// get field groups
-			$field_groups = acf_get_field_groups(
-				array(
-					'options_page' => $this->page['menu_slug'],
-				)
-			);
+			$field_groups = $this->get_options_page_field_groups();
 
 			// notices
 			if ( ! empty( $_GET['message'] ) && '1' === $_GET['message'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Used to display a notice.

--- a/includes/api/api-helpers.php
+++ b/includes/api/api-helpers.php
@@ -1279,10 +1279,11 @@ function _acf_query_remove_post_type( $sql ) {
  *
  * @since   ACF 5.0.0
  *
- * @param   $args (array)
- * @return  (array)
+ * @param array $args                     The query arguments.
+ * @param bool  $enforce_read_permissions Whether to exclude posts the current user cannot read.
+ * @return array
  */
-function acf_get_grouped_posts( $args ) {
+function acf_get_grouped_posts( $args, $enforce_read_permissions = false ) {
 
 	// vars
 	$data = array();
@@ -1301,6 +1302,49 @@ function acf_get_grouped_posts( $args ) {
 			'update_post_meta_cache' => false,
 		)
 	);
+
+	// Restrict unauthenticated queries before pagination to avoid non-public posts occupying result pages.
+	if ( $enforce_read_permissions && ! is_user_logged_in() ) {
+		$post_types = acf_get_array( $args['post_type'] );
+
+		if ( in_array( 'any', $post_types, true ) ) {
+			$post_types = get_post_types();
+		}
+
+		$post_types = array_values( array_filter( $post_types, 'is_post_type_viewable' ) );
+
+		if ( empty( $post_types ) ) {
+			return $data;
+		}
+
+		$post_statuses        = acf_get_array( $args['post_status'] );
+		$public_post_statuses = array_values( array_filter( get_post_stati(), 'is_post_status_viewable' ) );
+
+		if ( empty( $post_statuses ) ) {
+			return $data;
+		}
+
+		if ( in_array( 'any', $post_statuses, true ) ) {
+			$post_statuses = $public_post_statuses;
+
+			if ( in_array( 'attachment', $post_types, true ) ) {
+				$post_statuses[] = 'inherit';
+			}
+		} else {
+			$post_statuses = array_values( array_intersect( $post_statuses, $public_post_statuses ) );
+
+			if ( in_array( 'attachment', $post_types, true ) && in_array( 'inherit', acf_get_array( $args['post_status'] ), true ) ) {
+				$post_statuses[] = 'inherit';
+			}
+		}
+
+		if ( empty( $post_statuses ) ) {
+			return $data;
+		}
+
+		$args['post_type']   = $post_types;
+		$args['post_status'] = array_values( array_unique( $post_statuses ) );
+	}
 
 	// find array of post_type
 	$post_types          = acf_get_array( $args['post_type'] );
@@ -1394,6 +1438,19 @@ function acf_get_grouped_posts( $args ) {
 			if ( count( $ordered_posts ) == count( $all_posts ) ) {
 				$this_posts = array_slice( $ordered_posts, $offset, $length );
 			}
+		}
+
+		if ( $enforce_read_permissions ) {
+			$this_posts = array_filter(
+				$this_posts,
+				function ( $post ) {
+					return is_post_publicly_viewable( $post ) || current_user_can( 'read_post', $post->ID );
+				}
+			);
+		}
+
+		if ( empty( $this_posts ) ) {
+			continue;
 		}
 
 		// populate $this_posts

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -631,6 +631,7 @@ function acf_prepare_block( $block ) {
 	$protected = array(
 		'render_template',
 		'render_callback',
+		'path',
 		'enqueue_script',
 		'enqueue_style',
 		'enqueue_assets',
@@ -1091,6 +1092,18 @@ function acf_render_block( $attributes, $content = '', $is_preview = false, $pos
 }
 
 /**
+ * Checks if a path uses a PHP stream wrapper, such as `phar://` or `php://`.
+ *
+ * @since 6.9.3
+ *
+ * @param string $path The path to check.
+ * @return boolean True if the path begins with a stream wrapper.
+ */
+function scf_path_has_stream_wrapper( $path ) {
+	return (bool) preg_match( '#^[a-zA-Z][a-zA-Z0-9.+-]*://#', (string) $path );
+}
+
+/**
  * Locate and include an ACF block's template.
  *
  * @since   ACF 6.0.4
@@ -1103,13 +1116,22 @@ function acf_render_block( $attributes, $content = '', $is_preview = false, $pos
  * @param   array   $context    The block context array.
  */
 function acf_block_render_template( $block, $content, $is_preview, $post_id, $wp_block, $context ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-	// Locate template.
-	if ( isset( $block['path'] ) && file_exists( $block['path'] . '/' . $block['render_template'] ) ) {
-		$path = $block['path'] . '/' . $block['render_template'];
-	} elseif ( file_exists( $block['render_template'] ) ) {
-		$path = $block['render_template'];
+	// Always resolve the block path from the registered block type rather than the
+	// passed block, so a path in the saved block attributes can never be included.
+	$block_type      = acf_get_block_type( $block['name'] ?? '' );
+	$registered_path = $block_type['path'] ?? '';
+	$render_template = $block['render_template'] ?? '';
+
+	// Locate template. Templates are always included from the local filesystem, so
+	// reject stream wrappers such as `phar://` or `php://` before touching the disk.
+	if ( scf_path_has_stream_wrapper( $render_template ) ) {
+		$path = '';
+	} elseif ( $registered_path && file_exists( $registered_path . '/' . $render_template ) ) {
+		$path = $registered_path . '/' . $render_template;
+	} elseif ( file_exists( $render_template ) ) {
+		$path = $render_template;
 	} else {
-		$path = locate_template( $block['render_template'] );
+		$path = locate_template( $render_template );
 	}
 
 	do_action( 'acf/blocks/pre_block_template_render', $block, $content, $is_preview, $post_id, $wp_block, $context );

--- a/includes/fields/class-acf-field-page_link.php
+++ b/includes/fields/class-acf-field-page_link.php
@@ -204,7 +204,7 @@ if ( ! class_exists( 'acf_field_page_link' ) ) :
 			}
 
 			// get posts grouped by post type
-			$groups = acf_get_grouped_posts( $args );
+			$groups = acf_get_grouped_posts( $args, true );
 
 			// loop
 			if ( ! empty( $groups ) ) {

--- a/includes/fields/class-acf-field-post_object.php
+++ b/includes/fields/class-acf-field-post_object.php
@@ -179,7 +179,7 @@ if ( ! class_exists( 'acf_field_post_object' ) ) :
 			$args = apply_filters( 'acf/fields/post_object/query/key=' . $field['key'], $args, $field, $options['post_id'] );
 
 			// get posts grouped by post type
-			$groups = acf_get_grouped_posts( $args );
+			$groups = acf_get_grouped_posts( $args, true );
 
 			// bail early if no posts
 			if ( empty( $groups ) ) {

--- a/includes/fields/class-acf-field-relationship.php
+++ b/includes/fields/class-acf-field-relationship.php
@@ -254,7 +254,7 @@ if ( ! class_exists( 'acf_field_relationship' ) ) :
 			$args = apply_filters( 'acf/fields/relationship/query/key=' . $field['key'], $args, $field, $options['post_id'] );
 
 			// get posts grouped by post type
-			$groups = acf_get_grouped_posts( $args );
+			$groups = acf_get_grouped_posts( $args, true );
 
 			// bail early if no posts
 			if ( empty( $groups ) ) {

--- a/includes/local-json.php
+++ b/includes/local-json.php
@@ -200,6 +200,151 @@ if ( ! class_exists( 'ACF_Local_JSON' ) ) :
 		}
 
 		/**
+		 * Returns whether Local JSON writes must be restricted for this request.
+		 *
+		 * @since SCF 6.9.3
+		 *
+		 * @return boolean
+		 */
+		protected function should_restrict_multisite_writes() {
+			return is_multisite() && ! is_super_admin();
+		}
+
+		/**
+		 * Gets the directories the current request may write to in multisite.
+		 *
+		 * Single-site requests and multisite super admins retain unrestricted
+		 * Local JSON writes. All other multisite requests may only write to
+		 * existing save path directories that canonically reside inside the
+		 * current site's uploads directory — the only location WordPress
+		 * isolates per site. The "sites" subdirectory of the uploads directory
+		 * is always excluded: on the main site it holds the other sites'
+		 * files. Sites that need restricted Local JSON writes can point the
+		 * save_json setting or the acf/json/save_paths filter at a directory
+		 * inside their uploads directory.
+		 *
+		 * @since SCF 6.9.3
+		 *
+		 * @param array $paths The configured save path candidates.
+		 * @return array|null An array of canonical allowed directories, or null when unrestricted.
+		 */
+		private function get_multisite_allowed_write_paths( $paths ) {
+			if ( ! $this->should_restrict_multisite_writes() ) {
+				return null;
+			}
+
+			$uploads  = wp_get_upload_dir();
+			$base_dir = isset( $uploads['basedir'] ) && is_string( $uploads['basedir'] ) ? realpath( $uploads['basedir'] ) : false;
+
+			if ( false === $base_dir ) {
+				return array();
+			}
+
+			$base_dir      = wp_normalize_path( $base_dir );
+			$sites_dir     = trailingslashit( $base_dir ) . 'sites';
+			$allowed_paths = array();
+
+			foreach ( (array) $paths as $path ) {
+				if ( ! is_string( $path ) || '' === $path ) {
+					continue;
+				}
+
+				$real_path = realpath( $path );
+
+				if ( false === $real_path || ! is_dir( $real_path ) ) {
+					continue;
+				}
+
+				$real_path = wp_normalize_path( $real_path );
+
+				if ( $real_path !== $base_dir && 0 !== strpos( $real_path, trailingslashit( $base_dir ) ) ) {
+					continue;
+				}
+
+				if ( $real_path === $sites_dir || 0 === strpos( $real_path, trailingslashit( $sites_dir ) ) ) {
+					continue;
+				}
+
+				$allowed_paths[] = $real_path;
+			}
+
+			return array_values( array_unique( $allowed_paths ) );
+		}
+
+		/**
+		 * Returns whether a Local JSON file target is within an allowed directory.
+		 *
+		 * Saves resolve existing files so symlinks cannot redirect writes outside
+		 * an allowed directory. Deletes resolve the lexical file's parent because
+		 * unlinking a symlink mutates that directory, not the symlink target. New
+		 * targets also resolve their parent directory. Broken or otherwise
+		 * unresolvable symlinks are never authorized. Targets match allowed
+		 * directories by exact canonical path.
+		 *
+		 * @since SCF 6.9.3
+		 *
+		 * @param string     $file          The target file path.
+		 * @param array|null $allowed_paths Canonical allowed directories, or null when unrestricted.
+		 * @param string     $operation     The filesystem operation, either "save" or "delete".
+		 * @return boolean
+		 */
+		private function is_write_path_allowed( $file, $allowed_paths, $operation ) {
+			if ( null === $allowed_paths ) {
+				return true;
+			}
+
+			if ( array() === $allowed_paths ) {
+				return false;
+			}
+
+			if ( is_link( $file ) && false === realpath( $file ) ) {
+				return false;
+			}
+
+			if ( 'save' === $operation && ( file_exists( $file ) || is_link( $file ) ) ) {
+				$real_file = realpath( $file );
+
+				if ( false === $real_file ) {
+					return false;
+				}
+
+				$directory = dirname( $real_file );
+			} else {
+				$directory = realpath( dirname( $file ) );
+
+				if ( false === $directory ) {
+					return false;
+				}
+			}
+
+			return in_array( wp_normalize_path( $directory ), $allowed_paths, true );
+		}
+
+		/**
+		 * Deletes a Local JSON file after checking WordPress's final filtered path.
+		 *
+		 * @since SCF 6.9.3
+		 *
+		 * @param string     $file          The target file path.
+		 * @param array|null $allowed_paths Canonical allowed directories, or null when unrestricted.
+		 * @return void
+		 */
+		private function delete_allowed_file( $file, $allowed_paths ) {
+			if ( null === $allowed_paths ) {
+				wp_delete_file( $file );
+				return;
+			}
+
+			$delete_file = apply_filters( 'wp_delete_file', $file );
+
+			if ( ! is_string( $delete_file ) || empty( $delete_file ) || ! $this->is_write_path_allowed( $delete_file, $allowed_paths, 'delete' ) ) {
+				return;
+			}
+
+			@unlink( $delete_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink, WordPress.PHP.NoSilencedErrors.Discouraged -- Mirrors wp_delete_file() after authorizing its filtered path.
+		}
+
+		/**
 		 * Writes field group data to JSON file.
 		 *
 		 * @date    14/4/20
@@ -496,11 +641,15 @@ if ( ! class_exists( 'ACF_Local_JSON' ) ) :
 		 * @return boolean
 		 */
 		public function save_file( $key, $post ) {
-			$paths             = $this->get_save_paths( $key, $post );
-			$filename          = $this->get_filename( $key, $post );
-			$file              = false;
-			$first_writable    = false;
-			$has_existing_file = is_array( $this->files ) && isset( $this->files[ $key ] );
+			$paths          = $this->get_save_paths( $key, $post );
+			$filename       = $this->get_filename( $key, $post );
+			$allowed_paths  = $this->get_multisite_allowed_write_paths( $paths );
+			$file           = false;
+			$first_writable = false;
+
+			// When writes are restricted, skip the existing-file heuristic so an
+			// authorization denial is not later recorded as a filesystem write failure.
+			$has_existing_file = null === $allowed_paths && is_array( $this->files ) && isset( $this->files[ $key ] );
 
 			if ( ! $filename ) {
 				return false;
@@ -512,6 +661,10 @@ if ( ! class_exists( 'ACF_Local_JSON' ) ) :
 				}
 
 				$file_to_check = trailingslashit( $path ) . $filename;
+
+				if ( ! $this->is_write_path_allowed( $file_to_check, $allowed_paths, 'save' ) ) {
+					continue;
+				}
 
 				if ( is_file( $file_to_check ) ) {
 					$has_existing_file = true;
@@ -578,18 +731,27 @@ if ( ! class_exists( 'ACF_Local_JSON' ) ) :
 		 * @return boolean
 		 */
 		public function delete_file( $key, $post = array() ) {
-			$paths    = $this->get_save_paths( $key, $post );
-			$filename = $this->get_filename( $key, $post );
+			$paths         = $this->get_save_paths( $key, $post );
+			$filename      = $this->get_filename( $key, $post );
+			$allowed_paths = $this->get_multisite_allowed_write_paths( $paths );
 
 			if ( ! $filename ) {
 				return false;
 			}
 
 			foreach ( $paths as $path_to_check ) {
+				if ( ! is_string( $path_to_check ) || '' === $path_to_check ) {
+					continue;
+				}
+
 				$file = untrailingslashit( $path_to_check ) . '/' . $filename;
 
+				if ( ! $this->is_write_path_allowed( $file, $allowed_paths, 'delete' ) ) {
+					continue;
+				}
+
 				if ( is_writable( $file ) ) { //phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- non-compatible function for this purpose.
-					wp_delete_file( $file );
+					$this->delete_allowed_file( $file, $allowed_paths );
 				}
 			}
 

--- a/includes/rest-api/acf-rest-api-functions.php
+++ b/includes/rest-api/acf-rest-api-functions.php
@@ -58,6 +58,161 @@ function acf_get_field_rest_links( $post_id, array $field ) {
 acf_add_filter_variations( 'acf/rest/get_field_links', array( 'type', 'name', 'key' ), 2 );
 
 /**
+ * Replaces User subfield data with REST-safe values.
+ *
+ * @param mixed  $formatted_value The formatted parent value.
+ * @param mixed  $raw_value       The raw parent value.
+ * @param array  $sub_fields      The parent field's subfields.
+ * @param string $output_property The subfield property used as the output key.
+ * @return mixed
+ */
+function scf_rest_sanitize_user_sub_fields( $formatted_value, $raw_value, $sub_fields, $output_property ) {
+	if ( ! is_array( $formatted_value ) || ! is_array( $sub_fields ) ) {
+		return $formatted_value;
+	}
+
+	$raw_value = is_array( $raw_value ) ? $raw_value : array();
+
+	foreach ( $sub_fields as $sub_field ) {
+		if ( ! is_array( $sub_field ) ) {
+			continue;
+		}
+
+		$output_key = array_key_exists( $output_property, $sub_field )
+			? $sub_field[ $output_property ]
+			: $sub_field['name'] ?? '';
+		if ( '' === $output_key || ! array_key_exists( $output_key, $formatted_value ) ) {
+			continue;
+		}
+
+		$raw_key       = $sub_field['key'] ?? '';
+		$raw_sub_value = '' !== $raw_key && array_key_exists( $raw_key, $raw_value )
+			? $raw_value[ $raw_key ]
+			: null;
+
+		$formatted_value[ $output_key ] = scf_rest_sanitize_user_data(
+			$formatted_value[ $output_key ],
+			$raw_sub_value,
+			$sub_field
+		);
+	}
+
+	return $formatted_value;
+}
+
+/**
+ * Replaces formatted User field data with REST-safe values based on the field definition.
+ *
+ * @param mixed $formatted_value The formatted field value.
+ * @param mixed $raw_value       The raw field value.
+ * @param array $field           The field array.
+ * @return mixed
+ */
+function scf_rest_sanitize_user_data( $formatted_value, $raw_value, $field ) {
+	if ( ! is_array( $field ) || empty( $field['type'] ) ) {
+		return $formatted_value;
+	}
+
+	if ( 'user' === $field['type'] ) {
+		if ( ! $formatted_value ) {
+			return $formatted_value;
+		}
+
+		if ( ! empty( $field['multiple'] ) && is_array( $formatted_value ) ) {
+			$user_ids = array();
+			foreach ( $formatted_value as $user ) {
+				$user_ids[] = (int) acf_idval( $user );
+			}
+
+			return $user_ids;
+		}
+
+		return (int) acf_idval( $formatted_value );
+	}
+
+	if ( ! is_array( $formatted_value ) ) {
+		return $formatted_value;
+	}
+
+	$is_clone = 'clone' === $field['type'];
+	$is_group = 'group' === $field['type'];
+
+	if ( $is_group || $is_clone ) {
+		$output_property = $is_clone ? '__name' : '_name';
+
+		return scf_rest_sanitize_user_sub_fields(
+			$formatted_value,
+			$raw_value,
+			$field['sub_fields'] ?? array(),
+			$output_property
+		);
+	}
+
+	if ( 'repeater' === $field['type'] ) {
+		$raw_value = is_array( $raw_value ) ? $raw_value : array();
+
+		foreach ( $formatted_value as $row_index => $formatted_row ) {
+			$raw_row = array_key_exists( $row_index, $raw_value ) ? $raw_value[ $row_index ] : array();
+
+			$formatted_value[ $row_index ] = scf_rest_sanitize_user_sub_fields(
+				$formatted_row,
+				$raw_row,
+				$field['sub_fields'] ?? array(),
+				'_name'
+			);
+		}
+
+		return $formatted_value;
+	}
+
+	if ( 'flexible_content' === $field['type'] ) {
+		$raw_value = is_array( $raw_value ) ? $raw_value : array();
+
+		foreach ( $formatted_value as $row_index => $formatted_row ) {
+			if ( ! is_array( $formatted_row ) ) {
+				continue;
+			}
+
+			$raw_row     = array_key_exists( $row_index, $raw_value ) && is_array( $raw_value[ $row_index ] )
+				? $raw_value[ $row_index ]
+				: array();
+			$layout_name = $formatted_row['acf_fc_layout'] ?? $raw_row['acf_fc_layout'] ?? '';
+
+			foreach ( $field['layouts'] ?? array() as $layout ) {
+				if ( ! isset( $layout['name'] ) || $layout_name !== $layout['name'] ) {
+					continue;
+				}
+
+				$formatted_value[ $row_index ] = scf_rest_sanitize_user_sub_fields(
+					$formatted_row,
+					$raw_row,
+					$layout['sub_fields'] ?? array(),
+					'_name'
+				);
+				break;
+			}
+		}
+	}
+
+	return $formatted_value;
+}
+
+/**
+ * Applies standard field formatting while keeping User values safe for REST output.
+ *
+ * This does not apply the public acf/rest/format_value_for_rest filter.
+ *
+ * @param mixed      $value   The raw field value.
+ * @param string|int $post_id The post ID of the current object.
+ * @param array      $field   The field array.
+ * @return mixed
+ */
+function scf_rest_format_standard_value( $value, $post_id, $field ) {
+	$value_formatted = acf_format_value( $value, $post_id, $field );
+	return scf_rest_sanitize_user_data( $value_formatted, $value, $field );
+}
+
+/**
  * Format a given field's value for output in the REST API.
  *
  * @param        $value
@@ -67,8 +222,8 @@ acf_add_filter_variations( 'acf/rest/get_field_links', array( 'type', 'name', 'k
  * @return mixed
  */
 function acf_format_value_for_rest( $value, $post_id, $field, $format = 'light' ) {
-	if ( $format === 'standard' ) {
-		$value_formatted = acf_format_value( $value, $post_id, $field );
+	if ( 'standard' === $format ) {
+		$value_formatted = scf_rest_format_standard_value( $value, $post_id, $field );
 	} else {
 		$type            = acf_get_field_type( $field['type'] );
 		$value_formatted = $type->format_value_for_rest( $value, $post_id, $field );

--- a/includes/rest-api/class-acf-rest-api.php
+++ b/includes/rest-api/class-acf-rest-api.php
@@ -235,7 +235,7 @@ class ACF_Rest_Api {
 				$rest_value             = acf_format_value_for_rest( $value, $post_id, $field, $format );
 				$source_formatted_value = ( 'oembed' === $field['type'] && 'standard' !== $format )
 					? $rest_value
-					: acf_format_value( $value, $post_id, $field );
+					: scf_rest_format_standard_value( $value, $post_id, $field );
 
 				// We keep this one for backward compatibility with existing code that expects the field value to be.
 				$fields[ $field['name'] ]             = $rest_value;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"test:e2e:debug": "wp-scripts test-playwright --debug --ui",
 		"test:e2e:php-coverage": "rm -rf .php-coverage && PHP_COVERAGE_ENABLED=true wp-scripts test-playwright",
 		"test:e2e:php-coverage:report": "node scripts/merge-php-coverage.js",
+		"test:integration:local-json-multisite": "bash tests/integration/local-json-multisite.sh",
 		"test:unit": "wp-scripts test-unit-js",
 		"test:unit:watch": "wp-scripts test-unit-js --watch",
 		"watch": "webpack --watch",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: fields, custom fields, meta, scf
 Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 6.9.2
+Stable tag: 6.9.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,17 @@ This plugin builds upon and is a fork of the previous work done by the contribut
 
 
 == Changelog ==
+= 6.9.3 =
+*Release Date 28th July 2026*
+
+*Hardening*
+
+- Restricted Local JSON writes for multisite users who are not super admins to save paths inside the current site's uploads directory.
+- Limited Options Page saves to values for fields assigned to the current page.
+- Excluded posts the current user cannot read from Post Object, Page Link, and Relationship field queries.
+- Block render templates are now always resolved from the registered block path, and template paths using stream wrappers are rejected.
+- Reduced User field values in REST API responses to user IDs, including within Group, Clone, Repeater, and Flexible Content fields.
+
 = 6.9.2 =
 *Release Date 21st July 2026*
 

--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -6,7 +6,7 @@
  * Plugin Name:       Secure Custom Fields
  * Plugin URI:        https://developer.wordpress.org/secure-custom-fields/
  * Description:       Secure Custom Fields (SCF) offers an intuitive way for developers to enhance WordPress content management by adding extra fields and options without coding requirements.
- * Version:           6.9.2
+ * Version:           6.9.3
  * Author:            WordPress.org
  * Author URI:        https://wordpress.org/
  * Text Domain:       secure-custom-fields
@@ -33,7 +33,7 @@ if ( ! class_exists( 'ACF' ) ) {
 		 *
 		 * @var string
 		 */
-		public $version = '6.9.2';
+		public $version = '6.9.3';
 
 		/**
 		 * The plugin settings array.

--- a/tests/e2e/options-page-field-scope.spec.ts
+++ b/tests/e2e/options-page-field-scope.spec.ts
@@ -1,0 +1,312 @@
+/**
+ * E2E regression coverage for Options Page field scoping.
+ *
+ * Two local Options Pages intentionally share `options` storage but require
+ * different capabilities. An editor may save the low-capability page without
+ * being allowed to submit fields assigned only to the protected page.
+ */
+const { test, expect } = require( './fixtures' );
+const { PLUGIN_SLUG } = require( './field-helpers' );
+
+const TEST_PLUGIN_SLUG = 'scf-test-options-page-field-scope';
+const FIXTURE_REST_PATH = '/scf-test/v1/options-page-field-scope';
+
+const LOW_PAGE_SLUG = 'scf-test-options-page-field-scope-low';
+const PROTECTED_PAGE_SLUG = 'scf-test-options-page-field-scope-protected';
+const LOW_FIELD_KEY = 'field_scf_test_options_page_field_scope_low';
+const PROTECTED_FIELD_KEY = 'field_scf_test_options_page_field_scope_protected';
+
+const EDITOR_PASSWORD = 'scfE2Epassword!42';
+
+/**
+ * Resets the fixture without accepting arbitrary option names or values.
+ *
+ * @param {Object} requestUtils Playwright WordPress request utilities.
+ * @param {string} mode         Fixed reset mode.
+ * @return {Promise<Object>} Fixture state.
+ */
+async function resetFixture( requestUtils, mode ) {
+	return requestUtils.rest( {
+		method: 'POST',
+		path: FIXTURE_REST_PATH,
+		data: { mode },
+	} );
+}
+
+/**
+ * Reads the fixture's raw values and hidden field references.
+ *
+ * @param {Object} requestUtils Playwright WordPress request utilities.
+ * @return {Promise<Object>} Fixture state.
+ */
+async function getFixtureState( requestUtils ) {
+	return requestUtils.rest( {
+		path: FIXTURE_REST_PATH,
+	} );
+}
+
+/**
+ * Logs a dedicated browser context in as the editor fixture.
+ *
+ * @param {import('@playwright/test').Browser} browser  Playwright browser.
+ * @param {string}                             baseUrl  WordPress origin.
+ * @param {string}                             username Editor username.
+ * @return {Promise<{context: import('@playwright/test').BrowserContext, page: import('@playwright/test').Page}>} Logged-in context and page.
+ */
+async function createEditorContext( browser, baseUrl, username ) {
+	const context = await browser.newContext();
+	const page = await context.newPage();
+
+	const loginResponse = await context.request.post(
+		`${ baseUrl }/wp-login.php`,
+		{
+			form: {
+				log: username,
+				pwd: EDITOR_PASSWORD,
+			},
+		}
+	);
+	expect( loginResponse.ok() ).toBe( true );
+
+	const adminResponse = await page.goto( `${ baseUrl }/wp-admin/` );
+	expect( adminResponse.status() ).toBe( 200 );
+	await expect( page.locator( '#wpadminbar' ) ).toBeVisible();
+
+	return { context, page };
+}
+
+/**
+ * Fetches the low page's nonce and submits explicit field roots to that URL.
+ *
+ * @param {import('@playwright/test').BrowserContext} context Playwright browser context.
+ * @param {import('@playwright/test').Page}           page    Editor page.
+ * @param {string}                                    baseUrl WordPress origin.
+ * @param {Object<string, string>}                    fields  Top-level ACF field values.
+ */
+async function submitLowOptionsPage( context, page, baseUrl, fields ) {
+	const lowPageUrl = `${ baseUrl }/wp-admin/admin.php?page=${ LOW_PAGE_SLUG }`;
+
+	const pageResponse = await page.goto( lowPageUrl );
+	expect( pageResponse.status() ).toBe( 200 );
+	await expect(
+		page.locator( `.acf-field[data-key="${ LOW_FIELD_KEY }"]` )
+	).toBeVisible();
+	await expect(
+		page.locator( `.acf-field[data-key="${ PROTECTED_FIELD_KEY }"]` )
+	).toHaveCount( 0 );
+
+	const nonce = await page.locator( 'input[name="_acf_nonce"]' ).inputValue();
+	const form = {
+		_acf_nonce: nonce,
+		_acf_screen: 'options',
+		_acf_post_id: 'options',
+		_acf_validation: '1',
+		_acf_changed: '1',
+		publish: 'Update',
+	};
+
+	for ( const [ fieldKey, value ] of Object.entries( fields ) ) {
+		form[ `acf[${ fieldKey }]` ] = value;
+	}
+
+	const response = await context.request.post( lowPageUrl, { form } );
+	expect( response.ok() ).toBe( true );
+	expect( new URL( response.url() ).searchParams.get( 'message' ) ).toBe(
+		'1'
+	);
+}
+
+test.describe( 'Options Page field scope', () => {
+	let editorUserId;
+	let editorUsername;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin( PLUGIN_SLUG );
+		await requestUtils.activatePlugin( TEST_PLUGIN_SLUG );
+		await resetFixture( requestUtils, 'cleanup' );
+
+		const uniqueSuffix = Date.now().toString();
+		editorUsername = `scf_options_scope_${ uniqueSuffix }`;
+		const editor = await requestUtils.createUser( {
+			username: editorUsername,
+			email: `${ editorUsername }@example.com`,
+			password: EDITOR_PASSWORD,
+			roles: [ 'editor' ],
+		} );
+		editorUserId = editor.id;
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await resetFixture( requestUtils, 'cleanup' ).catch( () => {} );
+
+		if ( editorUserId ) {
+			await requestUtils
+				.rest( {
+					method: 'DELETE',
+					path: `/wp/v2/users/${ editorUserId }`,
+					params: {
+						force: true,
+						reassign: 1,
+					},
+				} )
+				.catch( () => {} );
+		}
+
+		await requestUtils
+			.deactivatePlugin( TEST_PLUGIN_SLUG )
+			.catch( () => {} );
+		await requestUtils.deactivatePlugin( PLUGIN_SLUG ).catch( () => {} );
+	} );
+
+	test( 'denies an editor access to the protected page', async ( {
+		browser,
+	}, testInfo ) => {
+		const baseUrl = new URL( testInfo.project.use.baseURL ).origin;
+		const { context } = await createEditorContext(
+			browser,
+			baseUrl,
+			editorUsername
+		);
+
+		try {
+			const response = await context.request.get(
+				`${ baseUrl }/wp-admin/admin.php?page=${ PROTECTED_PAGE_SLUG }`
+			);
+			expect( response.status() ).toBe( 403 );
+		} finally {
+			await context.close();
+		}
+	} );
+
+	test( 'saves an allowed root and discards a protected root', async ( {
+		browser,
+		requestUtils,
+	}, testInfo ) => {
+		const baseUrl = new URL( testInfo.project.use.baseURL ).origin;
+		await resetFixture( requestUtils, 'baseline' );
+		const { context, page } = await createEditorContext(
+			browser,
+			baseUrl,
+			editorUsername
+		);
+
+		try {
+			await submitLowOptionsPage( context, page, baseUrl, {
+				[ LOW_FIELD_KEY ]: 'low-updated',
+				[ PROTECTED_FIELD_KEY ]: 'attempted-overwrite',
+			} );
+		} finally {
+			await context.close();
+		}
+
+		const state = await getFixtureState( requestUtils );
+		expect( state.low ).toEqual( {
+			value_exists: true,
+			value: 'low-updated',
+			reference_exists: true,
+			reference: LOW_FIELD_KEY,
+		} );
+		expect( state.protected ).toEqual( {
+			value_exists: true,
+			value: 'protected-original',
+			reference_exists: true,
+			reference: PROTECTED_FIELD_KEY,
+		} );
+	} );
+
+	test( 'removes a foreign required root before validation', async ( {
+		browser,
+		requestUtils,
+	}, testInfo ) => {
+		const baseUrl = new URL( testInfo.project.use.baseURL ).origin;
+		await resetFixture( requestUtils, 'baseline' );
+		const { context, page } = await createEditorContext(
+			browser,
+			baseUrl,
+			editorUsername
+		);
+
+		try {
+			await submitLowOptionsPage( context, page, baseUrl, {
+				[ LOW_FIELD_KEY ]: 'low-updated',
+				[ PROTECTED_FIELD_KEY ]: '',
+			} );
+		} finally {
+			await context.close();
+		}
+
+		const state = await getFixtureState( requestUtils );
+		expect( state.low.value ).toBe( 'low-updated' );
+		expect( state.protected ).toEqual( {
+			value_exists: true,
+			value: 'protected-original',
+			reference_exists: true,
+			reference: PROTECTED_FIELD_KEY,
+		} );
+	} );
+
+	test( 'does not create a value or reference from a foreign-only root', async ( {
+		browser,
+		requestUtils,
+	}, testInfo ) => {
+		const baseUrl = new URL( testInfo.project.use.baseURL ).origin;
+		await resetFixture( requestUtils, 'without-protected' );
+		const { context, page } = await createEditorContext(
+			browser,
+			baseUrl,
+			editorUsername
+		);
+
+		try {
+			await submitLowOptionsPage( context, page, baseUrl, {
+				[ PROTECTED_FIELD_KEY ]: 'attempted-overwrite',
+			} );
+		} finally {
+			await context.close();
+		}
+
+		const state = await getFixtureState( requestUtils );
+		expect( state.low ).toEqual( {
+			value_exists: true,
+			value: 'low-original',
+			reference_exists: true,
+			reference: LOW_FIELD_KEY,
+		} );
+		expect( state.protected ).toEqual( {
+			value_exists: false,
+			value: null,
+			reference_exists: false,
+			reference: null,
+		} );
+	} );
+
+	test( 'allows an administrator to save the protected page', async ( {
+		page,
+		admin,
+		requestUtils,
+	} ) => {
+		await resetFixture( requestUtils, 'baseline' );
+		await admin.visitAdminPage(
+			'admin.php',
+			`page=${ PROTECTED_PAGE_SLUG }`
+		);
+
+		const protectedField = page.locator(
+			`.acf-field[data-key="${ PROTECTED_FIELD_KEY }"] input[type="text"]`
+		);
+		await expect( protectedField ).toHaveValue( 'protected-original' );
+		await protectedField.fill( 'protected-authorized' );
+		await Promise.all( [
+			page.waitForURL( /[?&]message=1/ ),
+			page.locator( '#publish' ).click(),
+		] );
+
+		const state = await getFixtureState( requestUtils );
+		expect( state.protected ).toEqual( {
+			value_exists: true,
+			value: 'protected-authorized',
+			reference_exists: true,
+			reference: PROTECTED_FIELD_KEY,
+		} );
+	} );
+} );

--- a/tests/e2e/plugins/scf-test-options-page-field-scope.php
+++ b/tests/e2e/plugins/scf-test-options-page-field-scope.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Plugin Name: SCF Test Options Page Field Scope
+ * Plugin URI: https://github.com/WordPress/secure-custom-fields
+ * Description: Registers isolated Options Page fixtures for E2E tests.
+ * Author: SCF Team
+ *
+ * @package scf-test-plugins
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_LOW_SLUG       = 'scf-test-options-page-field-scope-low';
+const SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_PROTECTED_SLUG = 'scf-test-options-page-field-scope-protected';
+const SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_LOW_KEY        = 'field_scf_test_options_page_field_scope_low';
+const SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_PROTECTED_KEY  = 'field_scf_test_options_page_field_scope_protected';
+const SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_LOW_NAME       = 'scf_test_options_page_field_scope_low';
+const SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_PROTECTED_NAME = 'scf_test_options_page_field_scope_protected';
+
+/**
+ * Registers the two Options Pages and their local field groups.
+ *
+ * Both pages intentionally use the same `options` storage while requiring
+ * different capabilities.
+ *
+ * @return void
+ */
+function scf_test_options_page_field_scope_register_fixtures() {
+	if ( ! function_exists( 'acf_add_options_page' ) || ! function_exists( 'acf_add_local_field_group' ) ) {
+		return;
+	}
+
+	acf_add_options_page(
+		array(
+			'page_title' => 'SCF Field Scope Low',
+			'menu_title' => 'SCF Field Scope Low',
+			'menu_slug'  => SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_LOW_SLUG,
+			'capability' => 'edit_posts',
+			'post_id'    => 'options',
+			'redirect'   => false,
+		)
+	);
+
+	acf_add_options_page(
+		array(
+			'page_title' => 'SCF Field Scope Protected',
+			'menu_title' => 'SCF Field Scope Protected',
+			'menu_slug'  => SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_PROTECTED_SLUG,
+			'capability' => 'manage_options',
+			'post_id'    => 'options',
+			'redirect'   => false,
+		)
+	);
+
+	acf_add_local_field_group(
+		array(
+			'key'      => 'group_scf_test_options_page_field_scope_low',
+			'title'    => 'SCF Field Scope Low Fields',
+			'fields'   => array(
+				array(
+					'key'      => SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_LOW_KEY,
+					'label'    => 'Low Field',
+					'name'     => SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_LOW_NAME,
+					'type'     => 'text',
+					'required' => 1,
+				),
+			),
+			'location' => array(
+				array(
+					array(
+						'param'    => 'options_page',
+						'operator' => '==',
+						'value'    => SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_LOW_SLUG,
+					),
+				),
+			),
+			'active'   => true,
+		)
+	);
+
+	acf_add_local_field_group(
+		array(
+			'key'      => 'group_scf_test_options_page_field_scope_protected',
+			'title'    => 'SCF Field Scope Protected Fields',
+			'fields'   => array(
+				array(
+					'key'      => SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_PROTECTED_KEY,
+					'label'    => 'Protected Field',
+					'name'     => SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_PROTECTED_NAME,
+					'type'     => 'text',
+					'required' => 1,
+				),
+			),
+			'location' => array(
+				array(
+					array(
+						'param'    => 'options_page',
+						'operator' => '==',
+						'value'    => SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_PROTECTED_SLUG,
+					),
+				),
+			),
+			'active'   => true,
+		)
+	);
+}
+add_action( 'acf/init', 'scf_test_options_page_field_scope_register_fixtures' );
+
+/**
+ * Returns the exact option key used by an Options Page field.
+ *
+ * @param string $field_name Field name.
+ * @param bool   $hidden     Whether to return the hidden reference key.
+ * @return string
+ */
+function scf_test_options_page_field_scope_get_option_key( $field_name, $hidden = false ) {
+	return ( $hidden ? '_options_' : 'options_' ) . $field_name;
+}
+
+/**
+ * Removes only the fixture's known option values and references.
+ *
+ * @return void
+ */
+function scf_test_options_page_field_scope_clear_options() {
+	$field_names = array(
+		SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_LOW_NAME,
+		SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_PROTECTED_NAME,
+	);
+
+	foreach ( $field_names as $field_name ) {
+		delete_option( scf_test_options_page_field_scope_get_option_key( $field_name ) );
+		delete_option( scf_test_options_page_field_scope_get_option_key( $field_name, true ) );
+	}
+}
+
+/**
+ * Reads one fixture field's raw value and hidden reference.
+ *
+ * @param string $field_name Field name.
+ * @return array
+ */
+function scf_test_options_page_field_scope_read_field_state( $field_name ) {
+	$missing       = 'scf-test-options-page-field-scope-missing';
+	$value         = get_option( scf_test_options_page_field_scope_get_option_key( $field_name ), $missing );
+	$reference     = get_option( scf_test_options_page_field_scope_get_option_key( $field_name, true ), $missing );
+	$value_exists  = $missing !== $value;
+	$reference_set = $missing !== $reference;
+
+	return array(
+		'value_exists'     => $value_exists,
+		'value'            => $value_exists ? $value : null,
+		'reference_exists' => $reference_set,
+		'reference'        => $reference_set ? $reference : null,
+	);
+}
+
+/**
+ * Returns the complete, bounded fixture state.
+ *
+ * @return array
+ */
+function scf_test_options_page_field_scope_get_state() {
+	return array(
+		'low'       => scf_test_options_page_field_scope_read_field_state( SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_LOW_NAME ),
+		'protected' => scf_test_options_page_field_scope_read_field_state( SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_PROTECTED_NAME ),
+	);
+}
+
+/**
+ * Checks access to the fixture REST endpoints.
+ *
+ * @return bool
+ */
+function scf_test_options_page_field_scope_rest_permission() {
+	return current_user_can( 'manage_options' );
+}
+
+/**
+ * Handles the fixture state endpoint.
+ *
+ * @return WP_REST_Response
+ */
+function scf_test_options_page_field_scope_rest_get_state() {
+	return rest_ensure_response( scf_test_options_page_field_scope_get_state() );
+}
+
+/**
+ * Resets the fixture to one of three fixed states.
+ *
+ * No caller-provided field value or option name is accepted.
+ *
+ * @param WP_REST_Request $request REST request.
+ * @return WP_REST_Response|WP_Error
+ */
+function scf_test_options_page_field_scope_rest_reset( $request ) {
+	$mode = $request->get_param( 'mode' );
+
+	if ( ! in_array( $mode, array( 'baseline', 'without-protected', 'cleanup' ), true ) ) {
+		return new WP_Error(
+			'scf_test_options_page_field_scope_invalid_mode',
+			'Invalid fixture reset mode.',
+			array( 'status' => 400 )
+		);
+	}
+
+	scf_test_options_page_field_scope_clear_options();
+
+	if ( 'cleanup' === $mode ) {
+		return rest_ensure_response( scf_test_options_page_field_scope_get_state() );
+	}
+
+	if ( ! function_exists( 'update_field' ) ) {
+		return new WP_Error(
+			'scf_test_options_page_field_scope_unavailable',
+			'Secure Custom Fields is unavailable.',
+			array( 'status' => 500 )
+		);
+	}
+
+	update_field( SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_LOW_KEY, 'low-original', 'options' );
+
+	if ( 'baseline' === $mode ) {
+		update_field( SCF_TEST_OPTIONS_PAGE_FIELD_SCOPE_PROTECTED_KEY, 'protected-original', 'options' );
+	}
+
+	return rest_ensure_response( scf_test_options_page_field_scope_get_state() );
+}
+
+/**
+ * Registers the admin-only, bounded state/reset endpoint.
+ *
+ * @return void
+ */
+function scf_test_options_page_field_scope_register_rest_route() {
+	register_rest_route(
+		'scf-test/v1',
+		'/options-page-field-scope',
+		array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'permission_callback' => 'scf_test_options_page_field_scope_rest_permission',
+				'callback'            => 'scf_test_options_page_field_scope_rest_get_state',
+			),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'permission_callback' => 'scf_test_options_page_field_scope_rest_permission',
+				'callback'            => 'scf_test_options_page_field_scope_rest_reset',
+				'args'                => array(
+					'mode' => array(
+						'required'          => true,
+						'type'              => 'string',
+						'enum'              => array( 'baseline', 'without-protected', 'cleanup' ),
+						'sanitize_callback' => 'sanitize_key',
+					),
+				),
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'scf_test_options_page_field_scope_register_rest_route' );
+
+register_deactivation_hook( __FILE__, 'scf_test_options_page_field_scope_clear_options' );

--- a/tests/integration/local-json-multisite.php
+++ b/tests/integration/local-json-multisite.php
@@ -1,0 +1,528 @@
+<?php
+/**
+ * Disposable multisite integration scenarios for Local JSON write authorization.
+ *
+ * This file is executed through separate `wp eval-file` processes. It is not
+ * loaded by PHPUnit and must only run in the disposable wp-env created by
+ * local-json-multisite.sh.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	exit( 1 );
+}
+
+// WP-CLI does not run WordPress's normal `init` action before every command.
+if ( ! acf_get_data( 'acf_did_init' ) ) {
+	acf_init();
+}
+
+/**
+ * Fails the current scenario when a condition is false.
+ *
+ * @param boolean $condition Whether the assertion passed.
+ * @param string  $message   Failure message.
+ * @return void
+ */
+function scf_local_json_integration_assert( $condition, $message ) {
+	if ( ! $condition ) {
+		WP_CLI::error( $message );
+	}
+}
+
+/**
+ * Returns all filesystem paths used by the disposable scenarios.
+ *
+ * @return array
+ */
+function scf_local_json_integration_paths() {
+	$theme_path = get_theme_root() . '/scf-local-json-integration';
+	$uploads    = wp_upload_dir();
+	$site_root  = $uploads['basedir'] . '/scf-local-json-integration';
+
+	return array(
+		'theme'   => $theme_path,
+		'shared'  => $theme_path . '/acf-json',
+		'allowed' => $site_root . '/allowed',
+	);
+}
+
+/**
+ * Builds inert field group data for a JSON fixture or save operation.
+ *
+ * @param string $key       Field group key.
+ * @param string $title     Field group title.
+ * @param string $field_key Optional field key.
+ * @return array
+ */
+function scf_local_json_integration_group( $key, $title, $field_key = '' ) {
+	$fields = array();
+
+	if ( $field_key ) {
+		$fields[] = array(
+			'key'   => $field_key,
+			'label' => 'Canary text',
+			'name'  => 'scf_multisite_canary_text',
+			'type'  => 'text',
+		);
+	}
+
+	return array(
+		'ID'       => 0,
+		'key'      => $key,
+		'title'    => $title,
+		'fields'   => $fields,
+		'location' => array(
+			array(
+				array(
+					'param'    => 'post_type',
+					'operator' => '==',
+					'value'    => 'post',
+				),
+			),
+		),
+		'active'   => true,
+		'modified' => 1700000000,
+	);
+}
+
+/**
+ * Writes an inert Local JSON field group fixture.
+ *
+ * @param string $file      Destination file.
+ * @param string $key       Field group key.
+ * @param string $title     Field group title.
+ * @param string $field_key Optional field key.
+ * @return void
+ */
+function scf_local_json_integration_write_group( $file, $key, $title, $field_key = '' ) {
+	$data = scf_local_json_integration_group( $key, $title, $field_key );
+	unset( $data['ID'] );
+
+	$result = file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Disposable integration fixture.
+		$file,
+		wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . PHP_EOL
+	);
+
+	scf_local_json_integration_assert( false !== $result, 'Could not write fixture: ' . $file );
+}
+
+/**
+ * Adds a save-path filter for one scenario process.
+ *
+ * @param array $paths Paths to return.
+ * @return void
+ */
+function scf_local_json_integration_use_save_paths( $paths ) {
+	add_filter(
+		'acf/json/save_paths',
+		static function () use ( $paths ) {
+			return $paths;
+		},
+		1000
+	);
+}
+
+/**
+ * Asserts that the current user is the site-A-only administrator.
+ *
+ * @return void
+ */
+function scf_local_json_integration_assert_site_admin() {
+	scf_local_json_integration_assert( is_multisite(), 'The integration environment must be multisite.' );
+	scf_local_json_integration_assert( current_user_can( 'manage_options' ), 'The site-A actor must have manage_options.' );
+	scf_local_json_integration_assert( ! is_super_admin(), 'The site-A actor must not be a network super admin.' );
+
+	$other_site_found = false;
+	foreach ( get_sites( array( 'number' => 0 ) ) as $site ) {
+		if ( get_current_blog_id() === (int) $site->blog_id ) {
+			continue;
+		}
+
+		$other_site_found = true;
+		scf_local_json_integration_assert(
+			! is_user_member_of_blog( get_current_user_id(), (int) $site->blog_id ),
+			'The site-A actor must not be a member of site B.'
+		);
+	}
+
+	scf_local_json_integration_assert( $other_site_found, 'The network must contain site B.' );
+}
+
+/**
+ * Returns the Local JSON component.
+ *
+ * @return ACF_Local_JSON
+ */
+function scf_local_json_integration_json() {
+	$json = acf_get_instance( 'ACF_Local_JSON' );
+	scf_local_json_integration_assert( $json instanceof ACF_Local_JSON, 'Local JSON is not available.' );
+	return $json;
+}
+
+/**
+ * Runs the disposable filesystem setup phase.
+ *
+ * @return void
+ */
+function scf_local_json_integration_setup() {
+	scf_local_json_integration_assert( is_multisite(), 'wp-env was not started as multisite.' );
+
+	$paths = scf_local_json_integration_paths();
+	foreach (
+		array(
+			$paths['theme'],
+			$paths['shared'],
+			$paths['allowed'],
+		) as $directory
+	) {
+		scf_local_json_integration_assert( wp_mkdir_p( $directory ), 'Could not create directory: ' . $directory );
+	}
+
+	$style = "/*\nTheme Name: SCF Local JSON Integration\nVersion: 1.0.0\n*/\n";
+	scf_local_json_integration_assert(
+		false !== file_put_contents( $paths['theme'] . '/style.css', $style ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Disposable theme fixture.
+		'Could not create the disposable theme stylesheet.'
+	);
+	scf_local_json_integration_assert(
+		false !== file_put_contents( $paths['theme'] . '/index.php', "<?php\n// Intentionally empty integration theme.\n" ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Disposable theme fixture.
+		'Could not create the disposable theme index.'
+	);
+
+	scf_local_json_integration_write_group(
+		$paths['shared'] . '/group_scf_multisite_canary.json',
+		'group_scf_multisite_canary',
+		'Trusted multisite canary',
+		'field_scf_multisite_canary_text'
+	);
+	scf_local_json_integration_write_group(
+		$paths['shared'] . '/group_scf_multisite_overwrite.json',
+		'group_scf_multisite_overwrite',
+		'Shared overwrite sentinel'
+	);
+	scf_local_json_integration_write_group(
+		$paths['shared'] . '/group_scf_multisite_delete.json',
+		'group_scf_multisite_delete',
+		'Shared delete sentinel'
+	);
+
+	WP_CLI::success( 'Created the disposable shared theme and inert Local JSON fixtures.' );
+}
+
+/**
+ * Proves site-A database persistence while default Local JSON creation is denied.
+ *
+ * @return void
+ */
+function scf_local_json_integration_deny_create() {
+	scf_local_json_integration_assert_site_admin();
+
+	$key       = 'group_scf_multisite_create';
+	$field_key = 'field_scf_multisite_create_text';
+	$paths     = scf_local_json_integration_paths();
+	$saved     = acf_update_field_group(
+		array(
+			'key'      => $key,
+			'title'    => 'Site A database canary',
+			'location' => array(),
+			'active'   => true,
+		)
+	);
+
+	scf_local_json_integration_assert( ! empty( $saved['ID'] ), 'The field group was not saved in site A.' );
+
+	$field = acf_update_field(
+		array(
+			'key'    => $field_key,
+			'label'  => 'Database canary text',
+			'name'   => 'scf_multisite_database_canary',
+			'type'   => 'text',
+			'parent' => $saved['ID'],
+		)
+	);
+	scf_local_json_integration_assert( ! empty( $field['ID'] ), 'The text field was not saved in site A.' );
+
+	// Save the group again after its field exists, matching the normal update flow.
+	$saved = acf_update_field_group( $saved );
+	scf_local_json_integration_assert( ! empty( $saved['ID'] ), 'The field group update did not persist.' );
+	scf_local_json_integration_assert(
+		! file_exists( $paths['shared'] . '/' . $key . '.json' ),
+		'The site-A-only administrator created a file in the shared theme.'
+	);
+
+	$import_key = 'group_scf_multisite_import';
+	$imported   = acf_import_internal_post_type(
+		scf_local_json_integration_group( $import_key, 'Site A imported database canary' ),
+		'acf-field-group'
+	);
+	scf_local_json_integration_assert( ! empty( $imported['ID'] ), 'The imported field group was not saved in site A.' );
+	scf_local_json_integration_assert(
+		! file_exists( $paths['shared'] . '/' . $import_key . '.json' ),
+		'The import wrote a file in the shared theme.'
+	);
+
+	WP_CLI::success( 'Denied shared creation for updates and imports while preserving site-A database saves.' );
+}
+
+/**
+ * Verifies the previous phase in a clean WordPress bootstrap.
+ *
+ * @return void
+ */
+function scf_local_json_integration_verify_database() {
+	scf_local_json_integration_assert_site_admin();
+
+	$paths    = scf_local_json_integration_paths();
+	$group    = acf_get_field_group( 'group_scf_multisite_create' );
+	$field    = acf_get_field( 'field_scf_multisite_create_text' );
+	$imported = acf_get_field_group( 'group_scf_multisite_import' );
+
+	scf_local_json_integration_assert( is_array( $group ), 'The saved field group is missing from site A.' );
+	scf_local_json_integration_assert( 'Site A database canary' === $group['title'], 'The site-A field group changed.' );
+	scf_local_json_integration_assert( is_array( $field ), 'The saved text field is missing from site A.' );
+	scf_local_json_integration_assert( 'text' === $field['type'], 'The site-A field type changed.' );
+	scf_local_json_integration_assert( is_array( $imported ), 'The imported field group is missing from site A.' );
+	scf_local_json_integration_assert(
+		'Site A imported database canary' === $imported['title'],
+		'The imported site-A field group changed.'
+	);
+	scf_local_json_integration_assert(
+		! file_exists( $paths['shared'] . '/group_scf_multisite_create.json' ),
+		'The denied Local JSON file appeared in a clean bootstrap.'
+	);
+	scf_local_json_integration_assert(
+		! file_exists( $paths['shared'] . '/group_scf_multisite_import.json' ),
+		'The denied import Local JSON file appeared in a clean bootstrap.'
+	);
+
+	WP_CLI::success( 'Confirmed site-A database persistence in a clean bootstrap.' );
+}
+
+/**
+ * Denies shared overwrite and delete operations for the site-A-only admin.
+ *
+ * @return void
+ */
+function scf_local_json_integration_deny_overwrite_delete() {
+	scf_local_json_integration_assert_site_admin();
+
+	$paths          = scf_local_json_integration_paths();
+	$overwrite_file = $paths['shared'] . '/group_scf_multisite_overwrite.json';
+	$delete_file    = $paths['shared'] . '/group_scf_multisite_delete.json';
+	$before         = file_get_contents( $overwrite_file );
+
+	$result = acf_write_json_field_group(
+		scf_local_json_integration_group(
+			'group_scf_multisite_overwrite',
+			'Site A attempted overwrite'
+		)
+	);
+	scf_local_json_integration_assert( false === $result, 'The shared overwrite unexpectedly succeeded.' );
+	scf_local_json_integration_assert( file_get_contents( $overwrite_file ) === $before, 'The shared overwrite sentinel changed.' );
+
+	acf_delete_json_field_group( 'group_scf_multisite_delete' );
+	scf_local_json_integration_assert( file_exists( $delete_file ), 'The shared delete sentinel was removed.' );
+	scf_local_json_integration_assert(
+		'Shared delete sentinel' === json_decode( file_get_contents( $delete_file ), true )['title'],
+		'The shared delete sentinel changed.'
+	);
+
+	WP_CLI::success( 'Denied shared overwrite and delete operations.' );
+}
+
+/**
+ * Proves that trusted, pre-existing JSON still loads on the current site.
+ *
+ * @return void
+ */
+function scf_local_json_integration_load_trusted() {
+	$paths = scf_local_json_integration_paths();
+	$json  = scf_local_json_integration_json();
+	$files = $json->scan_files();
+
+	scf_local_json_integration_assert(
+		realpath( get_stylesheet_directory() ) === realpath( $paths['theme'] ),
+		'The current site is not using the disposable shared theme.'
+	);
+	scf_local_json_integration_assert(
+		isset( $files['group_scf_multisite_canary'] ),
+		'The trusted canary was not discovered.'
+	);
+
+	$json->include_fields();
+	$group = acf_get_local_field_group( 'group_scf_multisite_canary' );
+	$field = acf_get_local_field( 'field_scf_multisite_canary_text' );
+
+	scf_local_json_integration_assert( is_array( $group ), 'The trusted field group was not loaded.' );
+	scf_local_json_integration_assert( 'Trusted multisite canary' === $group['title'], 'The trusted group changed.' );
+	scf_local_json_integration_assert( is_array( $field ), 'The trusted text field was not loaded.' );
+	scf_local_json_integration_assert( 'text' === $field['type'], 'The trusted field type changed.' );
+
+	foreach (
+		array(
+			'group_scf_multisite_overwrite' => 'Shared overwrite sentinel',
+			'group_scf_multisite_delete'    => 'Shared delete sentinel',
+		) as $key => $title
+	) {
+		$loaded = acf_get_local_field_group( $key );
+		scf_local_json_integration_assert( is_array( $loaded ), 'A shared sentinel did not load: ' . $key );
+		scf_local_json_integration_assert( $title === $loaded['title'], 'A shared sentinel was mutated: ' . $key );
+	}
+
+	WP_CLI::success( 'Loaded trusted Local JSON from the shared theme.' );
+}
+
+/**
+ * Proves a save path inside the site's uploads directory supports create, overwrite, and delete.
+ *
+ * @return void
+ */
+function scf_local_json_integration_uploads_opt_in() {
+	scf_local_json_integration_assert_site_admin();
+
+	$paths = scf_local_json_integration_paths();
+	$key   = 'group_scf_multisite_opt_in';
+	$file  = $paths['allowed'] . '/' . $key . '.json';
+
+	// A non-canonical configuration must still resolve to its authorized directory.
+	scf_local_json_integration_use_save_paths( array( $paths['allowed'] . '/../allowed/' ) );
+
+	$json = scf_local_json_integration_json();
+	scf_local_json_integration_assert(
+		$json->save_file( $key, scf_local_json_integration_group( $key, 'Opt-in create' ) ),
+		'The uploads save path did not allow creation.'
+	);
+	scf_local_json_integration_assert(
+		$json->save_file( $key, scf_local_json_integration_group( $key, 'Opt-in overwrite' ) ),
+		'The uploads save path did not allow overwrite.'
+	);
+	scf_local_json_integration_assert(
+		'Opt-in overwrite' === json_decode( file_get_contents( $file ), true )['title'],
+		'The uploads save path overwrite did not reach its target.'
+	);
+
+	$json->delete_file( $key );
+	scf_local_json_integration_assert( ! file_exists( $file ), 'The uploads save path did not allow deletion.' );
+	WP_CLI::success( 'Allowed create, overwrite, and delete through a save path inside the site uploads directory.' );
+}
+
+/**
+ * Denies writes into another site's uploads directory from the main site.
+ *
+ * @return void
+ */
+function scf_local_json_integration_deny_other_site_uploads() {
+	scf_local_json_integration_assert_site_admin();
+
+	$uploads   = wp_upload_dir();
+	$other_dir = '';
+
+	foreach ( get_sites( array( 'number' => 0 ) ) as $site ) {
+		if ( get_current_blog_id() !== (int) $site->blog_id ) {
+			$other_dir = $uploads['basedir'] . '/sites/' . (int) $site->blog_id . '/scf-local-json-integration';
+			break;
+		}
+	}
+
+	scf_local_json_integration_assert( '' !== $other_dir, 'The network must contain site B.' );
+	scf_local_json_integration_assert( wp_mkdir_p( $other_dir ), 'Could not create the site-B uploads fixture: ' . $other_dir );
+
+	$key = 'group_scf_multisite_cross_site';
+	scf_local_json_integration_use_save_paths( array( $other_dir ) );
+
+	$json   = scf_local_json_integration_json();
+	$result = $json->save_file( $key, scf_local_json_integration_group( $key, 'Cross-site denied' ) );
+
+	scf_local_json_integration_assert( false === $result, 'A site admin wrote into another site\'s uploads directory.' );
+	scf_local_json_integration_assert(
+		! file_exists( $other_dir . '/' . $key . '.json' ),
+		'A cross-site uploads file was created.'
+	);
+
+	WP_CLI::success( 'Denied writes into another site\'s uploads directory.' );
+}
+
+/**
+ * Applies the same uploads containment policy without a user.
+ *
+ * @return void
+ */
+function scf_local_json_integration_user_zero() {
+	scf_local_json_integration_assert( 0 === get_current_user_id(), 'This phase must run without a WordPress user.' );
+
+	$paths = scf_local_json_integration_paths();
+	$json  = scf_local_json_integration_json();
+	$key   = 'group_scf_multisite_user_zero_denied';
+
+	$result = $json->save_file( $key, scf_local_json_integration_group( $key, 'User-zero denied' ) );
+	scf_local_json_integration_assert( false === $result, 'A no-user process bypassed the shared theme deny policy.' );
+	scf_local_json_integration_assert(
+		! file_exists( $paths['shared'] . '/' . $key . '.json' ),
+		'A no-user process wrote to the shared theme.'
+	);
+
+	scf_local_json_integration_use_save_paths( array( $paths['allowed'] ) );
+
+	$key    = 'group_scf_multisite_user_zero_allowed';
+	$result = $json->save_file( $key, scf_local_json_integration_group( $key, 'User-zero opt-in' ) );
+	scf_local_json_integration_assert( true === $result, 'A no-user process could not write inside the site uploads directory.' );
+	scf_local_json_integration_assert(
+		file_exists( $paths['allowed'] . '/' . $key . '.json' ),
+		'The no-user uploads file is missing.'
+	);
+
+	WP_CLI::success( 'Applied the uploads containment policy to a no-user process.' );
+}
+
+/**
+ * Proves a network super admin retains the legacy write behavior.
+ *
+ * @return void
+ */
+function scf_local_json_integration_super_admin() {
+	scf_local_json_integration_assert( is_super_admin(), 'This phase must run as a network super admin.' );
+	scf_local_json_integration_assert( current_user_can( 'manage_options' ), 'The super admin lacks manage_options.' );
+
+	$paths = scf_local_json_integration_paths();
+	$key   = 'group_scf_multisite_super_admin';
+	$file  = $paths['shared'] . '/' . $key . '.json';
+
+	$json = scf_local_json_integration_json();
+	scf_local_json_integration_assert(
+		$json->save_file( $key, scf_local_json_integration_group( $key, 'Super admin create' ) ),
+		'The super admin could not create shared Local JSON.'
+	);
+	scf_local_json_integration_assert(
+		$json->save_file( $key, scf_local_json_integration_group( $key, 'Super admin overwrite' ) ),
+		'The super admin could not overwrite shared Local JSON.'
+	);
+	scf_local_json_integration_assert(
+		'Super admin overwrite' === json_decode( file_get_contents( $file ), true )['title'],
+		'The super admin overwrite did not reach the shared file.'
+	);
+
+	$json->delete_file( $key );
+	scf_local_json_integration_assert( ! file_exists( $file ), 'The super admin could not delete shared Local JSON.' );
+
+	WP_CLI::success( 'Preserved shared Local JSON writes for the network super admin.' );
+}
+
+$scf_local_json_integration_phase  = isset( $args[0] ) ? $args[0] : '';
+$scf_local_json_integration_phases = array(
+	'setup'                   => 'scf_local_json_integration_setup',
+	'deny-create'             => 'scf_local_json_integration_deny_create',
+	'verify-database'         => 'scf_local_json_integration_verify_database',
+	'deny-overwrite-delete'   => 'scf_local_json_integration_deny_overwrite_delete',
+	'load-trusted'            => 'scf_local_json_integration_load_trusted',
+	'uploads-opt-in'          => 'scf_local_json_integration_uploads_opt_in',
+	'deny-other-site-uploads' => 'scf_local_json_integration_deny_other_site_uploads',
+	'user-zero'               => 'scf_local_json_integration_user_zero',
+	'super-admin'             => 'scf_local_json_integration_super_admin',
+);
+
+if ( ! isset( $scf_local_json_integration_phases[ $scf_local_json_integration_phase ] ) ) {
+	WP_CLI::error( 'Unknown Local JSON multisite integration phase: ' . $scf_local_json_integration_phase );
+}
+
+call_user_func( $scf_local_json_integration_phases[ $scf_local_json_integration_phase ] );

--- a/tests/integration/local-json-multisite.sh
+++ b/tests/integration/local-json-multisite.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCF_INTEGRATION_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$SCF_INTEGRATION_ROOT"
+
+SCF_WP_ENV_HOME="$(mktemp -d "${TMPDIR:-/tmp}/scf-local-json-multisite.XXXXXX")"
+SCF_WP_ENV_PROJECT="${SCF_WP_ENV_HOME}/project"
+SCF_WP_ENV_DESTROY_REQUIRED=false
+
+wp_env() {
+	(
+		cd "$SCF_WP_ENV_PROJECT"
+		"${SCF_INTEGRATION_ROOT}/node_modules/.bin/wp-env" "$@"
+	)
+}
+
+cleanup() {
+	local integration_status=$?
+	local destroy_status=0
+
+	trap - EXIT INT TERM
+	if [[ "$SCF_WP_ENV_DESTROY_REQUIRED" == true ]]; then
+		if (( integration_status != 0 )); then
+			echo "Integration failed with status ${integration_status}; dumping wp-env logs before destroying the environment."
+			wp_env logs all --no-watch || true
+		fi
+
+		printf 'y\n' | wp_env destroy || destroy_status=$?
+	fi
+
+	if [[ -n "$SCF_WP_ENV_HOME" && "$SCF_WP_ENV_HOME" == *"/scf-local-json-multisite."* ]]; then
+		rm -rf -- "$SCF_WP_ENV_HOME"
+	fi
+
+	if (( integration_status != 0 )); then
+		exit "$integration_status"
+	fi
+
+	exit "$destroy_status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+mkdir "$SCF_WP_ENV_PROJECT"
+
+node -e '
+	const fs = require( "node:fs" );
+	const config = {
+		$schema: "https://schemas.wp.org/trunk/wp-env.json",
+		multisite: true,
+		plugins: [ process.argv[ 2 ] ],
+	};
+	fs.writeFileSync( process.argv[ 1 ], `${ JSON.stringify( config, null, 2 ) }\n` );
+' "${SCF_WP_ENV_PROJECT}/.wp-env.json" "$SCF_INTEGRATION_ROOT"
+
+export WP_ENV_HOME="$SCF_WP_ENV_HOME"
+export WP_ENV_MULTISITE=1
+
+read -r WP_ENV_PORT WP_ENV_TESTS_PORT < <(
+	node -e '
+		const net = require( "node:net" );
+		const servers = [ net.createServer(), net.createServer() ];
+		Promise.all(
+			servers.map(
+				( server ) =>
+					new Promise( ( resolve, reject ) => {
+						server.once( "error", reject );
+						server.listen( 0, "127.0.0.1", () => resolve( server.address().port ) );
+					} )
+			)
+		).then( ( ports ) => {
+			process.stdout.write( `${ ports[ 0 ] } ${ ports[ 1 ] }\n` );
+			servers.forEach( ( server ) => server.close() );
+		} );
+	'
+)
+export WP_ENV_PORT
+export WP_ENV_TESTS_PORT
+
+wp_cli() {
+	wp_env run cli wp "$@"
+}
+
+run_phase() {
+	local site_url=$1
+	local user=$2
+	local phase=$3
+
+	echo "Running Local JSON multisite phase: $phase"
+	if [[ -n "$user" ]]; then
+		wp_cli --url="$site_url" --user="$user" eval-file "$SCF_SCENARIO_FILE" "$phase"
+	else
+		wp_cli --url="$site_url" eval-file "$SCF_SCENARIO_FILE" "$phase"
+	fi
+}
+
+SCF_PLUGIN_SLUG="$(basename "$SCF_INTEGRATION_ROOT")"
+SCF_SCENARIO_FILE="wp-content/plugins/${SCF_PLUGIN_SLUG}/tests/integration/local-json-multisite.php"
+SCF_SITE_A_URL="http://localhost:${WP_ENV_PORT}"
+SCF_SITE_B_URL="${SCF_SITE_A_URL}/site-b/"
+SCF_SITE_ADMIN="scfsiteaadmin"
+
+echo "Checking the disposable wp-env status before start"
+wp_env status || true
+
+echo "Starting disposable multisite wp-env on dynamically allocated ports"
+SCF_WP_ENV_DESTROY_REQUIRED=true
+wp_env start
+
+run_phase "$SCF_SITE_A_URL" "" setup
+
+wp_cli --url="$SCF_SITE_A_URL" site create \
+	--slug=site-b \
+	--title="SCF Local JSON Site B" \
+	--email=site-b@example.test
+
+wp_cli --url="$SCF_SITE_A_URL" theme activate scf-local-json-integration
+wp_cli --url="$SCF_SITE_B_URL" plugin activate "$SCF_PLUGIN_SLUG"
+wp_cli --url="$SCF_SITE_B_URL" theme activate scf-local-json-integration
+
+wp_cli --url="$SCF_SITE_A_URL" user create \
+	"$SCF_SITE_ADMIN" \
+	scf-site-a-admin@example.test \
+	--role=administrator \
+	--user_pass=scf-local-json-integration-only
+
+run_phase "$SCF_SITE_A_URL" "$SCF_SITE_ADMIN" deny-create
+run_phase "$SCF_SITE_A_URL" "$SCF_SITE_ADMIN" verify-database
+run_phase "$SCF_SITE_A_URL" admin super-admin
+run_phase "$SCF_SITE_A_URL" "$SCF_SITE_ADMIN" deny-overwrite-delete
+run_phase "$SCF_SITE_A_URL" "" load-trusted
+run_phase "$SCF_SITE_B_URL" "" load-trusted
+run_phase "$SCF_SITE_A_URL" "$SCF_SITE_ADMIN" uploads-opt-in
+run_phase "$SCF_SITE_A_URL" "$SCF_SITE_ADMIN" deny-other-site-uploads
+run_phase "$SCF_SITE_A_URL" "" user-zero
+
+echo "Local JSON multisite integration passed."

--- a/tests/php/includes/admin/test-class-acf-admin-options-page.php
+++ b/tests/php/includes/admin/test-class-acf-admin-options-page.php
@@ -1,0 +1,647 @@
+<?php
+/**
+ * Tests for includes/admin/class-acf-admin-options-page.php.
+ *
+ * Covers field-group discovery and the top-level field allowlist used when an
+ * Options Page submission is validated and saved.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- Test subclass exposes protected helpers.
+
+acf_include( 'includes/admin/class-acf-admin-options-page.php' );
+
+/**
+ * Exposes the Options Page save-scope helpers for unit testing.
+ */
+class Testable_ACF_Admin_Options_Page extends acf_admin_options_page {
+
+	/**
+	 * Exposes get_options_page_field_groups().
+	 *
+	 * @return array
+	 */
+	public function get_test_field_groups() {
+		return $this->get_options_page_field_groups();
+	}
+
+	/**
+	 * Exposes get_options_page_allowed_field_keys().
+	 *
+	 * @return array
+	 */
+	public function get_test_allowed_field_keys() {
+		return $this->get_options_page_allowed_field_keys();
+	}
+
+	/**
+	 * Exposes filter_options_page_field_values().
+	 *
+	 * @param array $values Submitted ACF values.
+	 * @return array
+	 */
+	public function filter_test_field_values( array $values ): array {
+		return $this->filter_options_page_field_values( $values );
+	}
+}
+
+/**
+ * Tests for the administrative Options Page save scope.
+ */
+class Test_ACF_Admin_Options_Page extends BaseTestCase {
+
+	/**
+	 * Menu slug for the lower-capability test page.
+	 *
+	 * @var string
+	 */
+	private const LOW_PAGE_SLUG = 'scf-test-low-options';
+
+	/**
+	 * Menu slug for the protected test page.
+	 *
+	 * @var string
+	 */
+	private const PROTECTED_PAGE_SLUG = 'scf-test-protected-options';
+
+	/**
+	 * Options Page instance under test.
+	 *
+	 * @var Testable_ACF_Admin_Options_Page
+	 */
+	private $options_page;
+
+	/**
+	 * Test filters that must be removed during cleanup.
+	 *
+	 * @var array
+	 */
+	private $test_filters = array();
+
+	/**
+	 * Sets up isolated local field groups and the required field-type hooks.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		acf_reset_local();
+		acf_enable_local();
+		acf_enable_filter( 'clone' );
+		acf_reset_validation_errors();
+
+		foreach ( array( 'local-empty', 'fields', 'field-groups', 'values' ) as $store_name ) {
+			$store = acf_get_store( $store_name );
+			if ( $store ) {
+				$store->reset();
+			}
+		}
+
+		$this->ensure_field_types();
+		$this->ensure_options_page_location();
+
+		if ( ! has_filter( 'acf/load_field_groups', '_acf_apply_get_local_internal_posts' ) ) {
+			add_filter( 'acf/load_field_groups', '_acf_apply_get_local_internal_posts', 20, 2 );
+		}
+
+		$this->options_page       = new Testable_ACF_Admin_Options_Page();
+		$this->options_page->page = $this->make_page( self::LOW_PAGE_SLUG );
+
+		$_POST    = array();
+		$_REQUEST = array();
+	}
+
+	/**
+	 * Removes local fields, request data, filters, and validation state.
+	 */
+	public function tear_down() {
+		foreach ( $this->test_filters as $filter ) {
+			remove_filter( $filter['hook'], $filter['callback'], $filter['priority'] );
+		}
+
+		$this->test_filters = array();
+
+		acf_reset_validation_errors();
+		acf_reset_local();
+		acf_enable_local();
+		acf_enable_filter( 'clone' );
+
+		foreach ( array( 'local-empty', 'fields', 'field-groups', 'values' ) as $store_name ) {
+			$store = acf_get_store( $store_name );
+			if ( $store ) {
+				$store->reset();
+			}
+		}
+
+		$_POST    = array();
+		$_REQUEST = array();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Foreign required fields are removed before validation, while an allowed
+	 * required field continues to produce its normal validation error.
+	 */
+	public function test_filtered_values_validate_only_required_fields_on_current_page() {
+		$this->add_page_group(
+			'group_low_required',
+			self::LOW_PAGE_SLUG,
+			array( $this->make_text_field( 'field_low_required', array( 'required' => 1 ) ) )
+		);
+		$this->add_page_group(
+			'group_protected_required',
+			self::PROTECTED_PAGE_SLUG,
+			array( $this->make_text_field( 'field_protected_required', array( 'required' => 1 ) ) )
+		);
+
+		$_POST['acf'] = $this->options_page->filter_test_field_values(
+			array(
+				'field_low_required'       => 'low-updated',
+				'field_protected_required' => '',
+			)
+		);
+
+		$this->assertTrue( acf_validate_save_post() );
+		$this->assertFalse( acf_get_validation_error( 'acf[field_protected_required]' ) );
+
+		acf_reset_validation_errors();
+		$_POST['acf'] = $this->options_page->filter_test_field_values(
+			array(
+				'field_low_required'       => '',
+				'field_protected_required' => 'protected-original',
+			)
+		);
+
+		$this->assertFalse( acf_validate_save_post() );
+		$this->assertIsArray( acf_get_validation_error( 'acf[field_low_required]' ) );
+		$this->assertFalse( acf_get_validation_error( 'acf[field_protected_required]' ) );
+	}
+
+	/**
+	 * All groups assigned to the current page contribute roots to the allowlist.
+	 */
+	public function test_get_field_groups_and_allowed_keys_include_multiple_current_page_groups() {
+		$this->add_page_group(
+			'group_low_first',
+			self::LOW_PAGE_SLUG,
+			array( $this->make_text_field( 'field_low_first' ) ),
+			'Low First'
+		);
+		$this->add_page_group(
+			'group_low_second',
+			self::LOW_PAGE_SLUG,
+			array( $this->make_text_field( 'field_low_second' ) ),
+			'Low Second'
+		);
+		$this->add_page_group(
+			'group_protected_multiple',
+			self::PROTECTED_PAGE_SLUG,
+			array( $this->make_text_field( 'field_protected_multiple' ) )
+		);
+
+		$group_keys = wp_list_pluck( $this->options_page->get_test_field_groups(), 'key' );
+		$allowed    = $this->options_page->get_test_allowed_field_keys();
+
+		$this->assertSame( array( 'group_low_first', 'group_low_second' ), array_values( $group_keys ) );
+		$this->assertSame( array( 'field_low_first', 'field_low_second' ), $allowed );
+	}
+
+	/**
+	 * Group, repeater, and flexible-content payloads remain intact below their
+	 * allowed top-level roots.
+	 */
+	public function test_filter_field_values_preserves_nested_field_payloads() {
+		$this->add_page_group(
+			'group_low_nested',
+			self::LOW_PAGE_SLUG,
+			array(
+				array(
+					'key'        => 'field_low_group',
+					'name'       => 'low_group',
+					'label'      => 'Low Group',
+					'type'       => 'group',
+					'sub_fields' => array(
+						$this->make_text_field( 'field_low_group_text' ),
+					),
+				),
+				array(
+					'key'           => 'field_low_repeater',
+					'name'          => 'low_repeater',
+					'label'         => 'Low Repeater',
+					'type'          => 'repeater',
+					'pagination'    => 1,
+					'rows_per_page' => 2,
+					'sub_fields'    => array(
+						$this->make_text_field( 'field_low_repeater_text' ),
+					),
+				),
+				array(
+					'key'     => 'field_low_flexible',
+					'name'    => 'low_flexible',
+					'label'   => 'Low Flexible',
+					'type'    => 'flexible_content',
+					'layouts' => array(
+						array(
+							'key'        => 'layout_low_text',
+							'name'       => 'low_text',
+							'label'      => 'Low Text',
+							'display'    => 'block',
+							'sub_fields' => array(
+								$this->make_text_field( 'field_low_flexible_text' ),
+							),
+						),
+					),
+				),
+			)
+		);
+		$this->add_page_group(
+			'group_protected_nested',
+			self::PROTECTED_PAGE_SLUG,
+			array( $this->make_text_field( 'field_protected_nested' ) )
+		);
+
+		$allowed_values = array(
+			'field_low_group'    => array(
+				'field_low_group_text' => 'group-value',
+			),
+			'field_low_repeater' => array(
+				'row-4' => array(
+					'field_low_repeater_text' => 'repeater-value',
+				),
+				'row-5' => array(
+					'field_low_repeater_text' => 'repeater-second-value',
+				),
+			),
+			'field_low_flexible' => array(
+				'row-0' => array(
+					'acf_fc_layout'           => 'low_text',
+					'field_low_flexible_text' => 'flexible-value',
+				),
+			),
+		);
+
+		$this->assertSame(
+			$allowed_values,
+			$this->options_page->filter_test_field_values(
+				$allowed_values + array( 'field_protected_nested' => 'attempted-overwrite' )
+			)
+		);
+	}
+
+	/**
+	 * Group clones use their field key as the root, while seamless clones use
+	 * the clone key extracted from each expanded field's input prefix.
+	 */
+	public function test_allowed_keys_discover_group_and_seamless_clone_roots() {
+		$this->add_page_group(
+			'group_clone_sources',
+			self::PROTECTED_PAGE_SLUG,
+			array(
+				$this->make_text_field( 'field_clone_group_source' ),
+				$this->make_text_field( 'field_clone_seamless_source' ),
+			)
+		);
+		$this->add_page_group(
+			'group_low_clones',
+			self::LOW_PAGE_SLUG,
+			array(
+				array(
+					'key'          => 'field_low_clone_group',
+					'name'         => 'low_clone_group',
+					'label'        => 'Low Clone Group',
+					'type'         => 'clone',
+					'display'      => 'group',
+					'clone'        => array( 'field_clone_group_source' ),
+					'prefix_label' => 0,
+					'prefix_name'  => 0,
+				),
+				array(
+					'key'          => 'field_low_clone_seamless',
+					'name'         => 'low_clone_seamless',
+					'label'        => 'Low Clone Seamless',
+					'type'         => 'clone',
+					'display'      => 'seamless',
+					'clone'        => array( 'field_clone_seamless_source' ),
+					'prefix_label' => 0,
+					'prefix_name'  => 0,
+				),
+			)
+		);
+
+		$allowed = $this->options_page->get_test_allowed_field_keys();
+
+		$this->assertContains( 'field_low_clone_group', $allowed );
+		$this->assertContains( 'field_low_clone_seamless', $allowed );
+		$this->assertNotContains( 'field_clone_seamless_source', $allowed );
+		$this->assertNotContains( 'field_low_clone_seamless_field_clone_seamless_source', $allowed );
+
+		$clone_values = array(
+			'field_low_clone_group'    => array(
+				'field_clone_group_source' => 'group-clone-value',
+			),
+			'field_low_clone_seamless' => array(
+				'field_clone_seamless_source' => 'seamless-clone-value',
+			),
+		);
+
+		$this->assertSame(
+			$clone_values,
+			$this->options_page->filter_test_field_values(
+				$clone_values + array( 'field_clone_seamless_source' => 'unscoped-root' )
+			)
+		);
+	}
+
+	/**
+	 * A seamless clone of a seamless clone flattens into subfields with a
+	 * single-segment input prefix naming the outer clone, which is the
+	 * submitted top-level root.
+	 */
+	public function test_allowed_keys_discover_nested_seamless_clone_root() {
+		$this->add_page_group(
+			'group_nested_clone_source',
+			self::PROTECTED_PAGE_SLUG,
+			array( $this->make_text_field( 'field_nested_clone_text' ) )
+		);
+		$this->add_page_group(
+			'group_nested_clone_inner',
+			self::PROTECTED_PAGE_SLUG,
+			array(
+				array(
+					'key'          => 'field_nested_inner_clone',
+					'name'         => 'nested_inner_clone',
+					'label'        => 'Nested Inner Clone',
+					'type'         => 'clone',
+					'display'      => 'seamless',
+					'clone'        => array( 'field_nested_clone_text' ),
+					'prefix_label' => 0,
+					'prefix_name'  => 0,
+				),
+			)
+		);
+		$this->add_page_group(
+			'group_low_nested_outer',
+			self::LOW_PAGE_SLUG,
+			array(
+				array(
+					'key'          => 'field_low_nested_outer_clone',
+					'name'         => 'low_nested_outer_clone',
+					'label'        => 'Low Nested Outer Clone',
+					'type'         => 'clone',
+					'display'      => 'seamless',
+					'clone'        => array( 'field_nested_inner_clone' ),
+					'prefix_label' => 0,
+					'prefix_name'  => 0,
+				),
+			)
+		);
+
+		$this->assertSame(
+			array( 'field_low_nested_outer_clone' ),
+			$this->options_page->get_test_allowed_field_keys()
+		);
+	}
+
+	/**
+	 * Each page accepts only its own fields when both pages use the same
+	 * custom post_id.
+	 */
+	public function test_shared_custom_post_id_scopes_each_page_to_its_own_fields() {
+		$shared_post_id = 'shared-options-protected-save';
+
+		$this->add_page_group(
+			'group_low_protected_save',
+			self::LOW_PAGE_SLUG,
+			array( $this->make_text_field( 'field_low_protected_save' ) )
+		);
+		$this->add_page_group(
+			'group_protected_save',
+			self::PROTECTED_PAGE_SLUG,
+			array( $this->make_text_field( 'field_protected_save' ) )
+		);
+
+		$this->options_page->page = $this->make_page( self::LOW_PAGE_SLUG, $shared_post_id );
+
+		$this->assertSame(
+			array( 'field_low_protected_save' => 'low-updated' ),
+			$this->options_page->filter_test_field_values(
+				array(
+					'field_low_protected_save' => 'low-updated',
+					'field_protected_save'     => 'attempted-overwrite',
+				)
+			)
+		);
+
+		$this->options_page->page = $this->make_page( self::PROTECTED_PAGE_SLUG, $shared_post_id );
+
+		$this->assertSame(
+			array( 'field_protected_save' => 'protected-updated' ),
+			$this->options_page->filter_test_field_values(
+				array(
+					'field_low_protected_save' => 'attempted-overwrite',
+					'field_protected_save'     => 'protected-updated',
+				)
+			)
+		);
+	}
+
+	/**
+	 * Fields added by the standard acf/load_fields loader participate in the
+	 * allowlist for the matching page group.
+	 */
+	public function test_allowed_keys_include_fields_added_by_acf_load_fields() {
+		$this->add_page_group(
+			'group_low_load_fields',
+			self::LOW_PAGE_SLUG,
+			array( $this->make_text_field( 'field_low_load_fields' ) )
+		);
+		acf_add_local_field(
+			array(
+				'key'    => 'field_low_loader_injected',
+				'name'   => 'low_loader_injected',
+				'label'  => 'Low Loader Injected',
+				'type'   => 'text',
+				'parent' => 'group_loader_source',
+			)
+		);
+
+		$this->add_test_filter(
+			'acf/load_fields',
+			static function ( $fields, $field_group ) {
+				if ( 'group_low_load_fields' === $field_group['key'] ) {
+					$fields[] = acf_get_field( 'field_low_loader_injected' );
+				}
+
+				return $fields;
+			},
+			10,
+			2
+		);
+
+		$this->assertIsArray( acf_get_field( 'field_low_loader_injected' ) );
+		$this->assertSame(
+			array( 'field_low_load_fields', 'field_low_loader_injected' ),
+			$this->options_page->get_test_allowed_field_keys()
+		);
+		$this->assertSame(
+			array( 'field_low_loader_injected' => 'injected-value' ),
+			$this->options_page->filter_test_field_values(
+				array( 'field_low_loader_injected' => 'injected-value' )
+			)
+		);
+	}
+
+	/**
+	 * Discovering saveable keys does not invoke render-time field filters.
+	 */
+	public function test_allowed_keys_do_not_run_pre_render_fields() {
+		$this->add_page_group(
+			'group_low_without_pre_render',
+			self::LOW_PAGE_SLUG,
+			array( $this->make_text_field( 'field_low_without_pre_render' ) )
+		);
+
+		$pre_render_calls = 0;
+		$this->add_test_filter(
+			'acf/pre_render_fields',
+			static function ( $fields ) use ( &$pre_render_calls ) {
+				++$pre_render_calls;
+				return $fields;
+			}
+		);
+
+		$this->assertSame(
+			array( 'field_low_without_pre_render' ),
+			$this->options_page->get_test_allowed_field_keys()
+		);
+		$this->assertSame( 0, $pre_render_calls );
+	}
+
+	/**
+	 * Ensures field types needed by these fixtures have active hooks.
+	 */
+	private function ensure_field_types() {
+		$field_types = array(
+			'text'             => 'acf_field_text',
+			'group'            => 'acf_field__group',
+			'repeater'         => 'acf_field_repeater',
+			'flexible_content' => 'acf_field_flexible_content',
+			'clone'            => 'acf_field_clone',
+		);
+
+		acf_include( 'includes/fields/class-acf-field-text.php' );
+		acf_include( 'includes/fields/class-acf-field-group.php' );
+		acf_include( 'includes/fields/class-acf-repeater-table.php' );
+		acf_include( 'includes/fields/class-acf-field-repeater.php' );
+		acf_include( 'includes/fields/class-acf-field-flexible-content.php' );
+		acf_include( 'includes/fields/class-acf-field-clone.php' );
+
+		foreach ( $field_types as $type => $class_name ) {
+			$instance = acf_get_field_type( $type );
+
+			if (
+				! $instance ||
+				! has_filter( "acf/load_field/type={$type}", array( $instance, 'load_field' ) ) ||
+				( 'clone' === $type && ! has_filter( 'acf/get_fields', array( $instance, 'acf_get_fields' ) ) )
+			) {
+				acf_register_field_type( $class_name );
+			}
+		}
+	}
+
+	/**
+	 * Ensures the Options Page location type can evaluate local group rules.
+	 */
+	private function ensure_options_page_location() {
+		acf_include( 'includes/locations/class-acf-location-options-page.php' );
+
+		if ( ! acf_get_location_type( 'options_page' ) ) {
+			acf_register_location_type( 'ACF_Location_Options_Page' );
+		}
+	}
+
+	/**
+	 * Builds canonical page data for the class under test.
+	 *
+	 * @param string $menu_slug Page menu slug.
+	 * @param string $post_id   Page storage identifier.
+	 * @return array
+	 */
+	private function make_page( $menu_slug, $post_id = 'options' ) {
+		return array(
+			'menu_slug'  => $menu_slug,
+			'post_id'    => $post_id,
+			'capability' => self::PROTECTED_PAGE_SLUG === $menu_slug ? 'manage_options' : 'edit_posts',
+		);
+	}
+
+	/**
+	 * Registers a local group assigned to a specific Options Page.
+	 *
+	 * @param string $group_key Group key.
+	 * @param string $menu_slug Options Page menu slug.
+	 * @param array  $fields    Group fields.
+	 * @param string $title     Optional group title.
+	 */
+	private function add_page_group( $group_key, $menu_slug, array $fields, $title = '' ) {
+		acf_add_local_field_group(
+			array(
+				'key'      => $group_key,
+				'title'    => $title ? $title : ucwords( str_replace( '_', ' ', $group_key ) ),
+				'fields'   => $fields,
+				'active'   => true,
+				'location' => array(
+					array(
+						array(
+							'param'    => 'options_page',
+							'operator' => '==',
+							'value'    => $menu_slug,
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Builds a text field definition.
+	 *
+	 * @param string $key       Field key.
+	 * @param array  $overrides Optional field overrides.
+	 * @return array
+	 */
+	private function make_text_field( $key, array $overrides = array() ) {
+		$name = preg_replace( '/^field_/', '', $key );
+
+		return array_merge(
+			array(
+				'key'   => $key,
+				'name'  => $name,
+				'label' => ucwords( str_replace( '_', ' ', $name ) ),
+				'type'  => 'text',
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * Adds and tracks a test-specific filter.
+	 *
+	 * @param string   $hook          Filter name.
+	 * @param callable $callback      Filter callback.
+	 * @param int      $priority      Filter priority.
+	 * @param int      $accepted_args Accepted argument count.
+	 */
+	private function add_test_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		add_filter( $hook, $callback, $priority, $accepted_args );
+
+		$this->test_filters[] = array(
+			'hook'     => $hook,
+			'callback' => $callback,
+			'priority' => $priority,
+		);
+	}
+}

--- a/tests/php/includes/blocks/test-blocks.php
+++ b/tests/php/includes/blocks/test-blocks.php
@@ -440,6 +440,7 @@ class Test_Blocks extends BaseTestCase {
 				'name'            => 'prepare-block',
 				'title'           => 'Prepare Block',
 				'render_template' => 'real-template.php',
+				'path'            => '/trusted/block/path',
 			)
 		);
 
@@ -448,6 +449,7 @@ class Test_Blocks extends BaseTestCase {
 				'name'            => 'acf/prepare-block',
 				'id'              => 'abc123',
 				'render_template' => 'evil-template.php',
+				'path'            => 'phar:///tmp/attacker.phar',
 				'align'           => 'wide',
 			)
 		);
@@ -457,11 +459,30 @@ class Test_Blocks extends BaseTestCase {
 
 		// Protected attributes cannot be overridden by block attributes.
 		$this->assertSame( 'real-template.php', $prepared['render_template'] );
+		$this->assertSame( '/trusted/block/path', $prepared['path'] );
 
 		// Attribute defaults are merged in, with provided values winning.
 		$this->assertSame( 'wide', $prepared['align'] );
 		$this->assertSame( array(), $prepared['data'] );
 		$this->assertSame( 'Prepare Block', $prepared['title'] );
+
+		$this->register_block(
+			array(
+				'name'            => 'prepare-block-without-path',
+				'title'           => 'Prepare Block Without Path',
+				'render_template' => 'theme-template.php',
+			)
+		);
+
+		$prepared_without_path = acf_prepare_block(
+			array(
+				'name' => 'acf/prepare-block-without-path',
+				'id'   => 'without-path',
+				'path' => 'phar:///tmp/attacker.phar',
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'path', $prepared_without_path );
 	}
 
 	/**
@@ -847,6 +868,11 @@ class Test_Blocks extends BaseTestCase {
 		);
 		file_put_contents( $dir . '/render.php', '<?php echo "VAL[" . get_field( "jsonfile_text" ) . "]"; ?>' );
 
+		$attacker_dir = sys_get_temp_dir() . '/scf-block-json-attacker-' . uniqid();
+		mkdir( $attacker_dir );
+		$this->temp_paths[] = $attacker_dir;
+		file_put_contents( $attacker_dir . '/render.php', '<?php echo "ATTACKER_TEMPLATE"; ?>' );
+
 		$wp_block_type       = register_block_type( $dir );
 		$this->block_names[] = 'acf/jsonfile-block';
 		$this->track_group( 'group_acf_jsonfile_block', array( 'field_acf_jsonfile_block_jsonfile_text' ) );
@@ -866,8 +892,114 @@ class Test_Blocks extends BaseTestCase {
 		$this->assertTrue( acf_is_local_field_group( 'group_acf_jsonfile_block' ) );
 
 		// Render the block through the real WordPress pipeline.
-		$html = do_blocks( '<!-- wp:acf/jsonfile-block {"name":"acf/jsonfile-block","data":{"jsonfile_text":"FromJson","_jsonfile_text":"field_acf_jsonfile_block_jsonfile_text"}} /-->' );
+		$attributes = array(
+			'name' => 'acf/jsonfile-block',
+			'path' => $attacker_dir,
+			'data' => array(
+				'jsonfile_text'  => 'FromJson',
+				'_jsonfile_text' => 'field_acf_jsonfile_block_jsonfile_text',
+			),
+		);
+		$html       = do_blocks( sprintf( '<!-- wp:acf/jsonfile-block %s /-->', wp_json_encode( $attributes ) ) );
 		$this->assertStringContainsString( 'VAL[FromJson]', $html );
+		$this->assertStringNotContainsString( 'ATTACKER_TEMPLATE', $html );
+	}
+
+	/**
+	 * Test that the template path is resolved from the registered block type
+	 * and never from the passed block array.
+	 */
+	public function test_block_render_template_ignores_path_in_block_array() {
+		$trusted_dir = sys_get_temp_dir() . '/scf-block-trusted-' . uniqid();
+		mkdir( $trusted_dir );
+		$this->temp_paths[] = $trusted_dir;
+		file_put_contents( $trusted_dir . '/render.php', '<?php echo "TRUSTED_TEMPLATE"; ?>' );
+
+		$attacker_dir = sys_get_temp_dir() . '/scf-block-attacker-' . uniqid();
+		mkdir( $attacker_dir );
+		$this->temp_paths[] = $attacker_dir;
+		file_put_contents( $attacker_dir . '/render.php', '<?php echo "ATTACKER_TEMPLATE"; ?>' );
+
+		$this->register_block(
+			array(
+				'name'            => 'render-template-block',
+				'title'           => 'Render Template Block',
+				'render_template' => 'render.php',
+				'path'            => $trusted_dir,
+			)
+		);
+
+		ob_start();
+		acf_block_render_template(
+			array(
+				'name'            => 'acf/render-template-block',
+				'render_template' => 'render.php',
+				'path'            => $attacker_dir,
+			),
+			'',
+			false,
+			0,
+			null,
+			array()
+		);
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'TRUSTED_TEMPLATE', $html );
+		$this->assertStringNotContainsString( 'ATTACKER_TEMPLATE', $html );
+	}
+
+	/**
+	 * Test that a render template using a stream wrapper is never included.
+	 */
+	public function test_block_render_template_rejects_stream_wrappers() {
+		$attacker_dir = sys_get_temp_dir() . '/scf-block-wrapper-' . uniqid();
+		mkdir( $attacker_dir );
+		$this->temp_paths[] = $attacker_dir;
+		file_put_contents( $attacker_dir . '/render.php', '<?php echo "ATTACKER_TEMPLATE"; ?>' );
+
+		$this->register_block(
+			array(
+				'name'            => 'wrapper-template-block',
+				'title'           => 'Wrapper Template Block',
+				'render_template' => 'render.php',
+			)
+		);
+
+		// The file:// wrapper resolves to a real, includable file, so this would
+		// render if the stream wrapper check was missing.
+		ob_start();
+		acf_block_render_template(
+			array(
+				'name'            => 'acf/wrapper-template-block',
+				'render_template' => 'file://' . $attacker_dir . '/render.php',
+			),
+			'',
+			false,
+			0,
+			null,
+			array()
+		);
+		$html = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'ATTACKER_TEMPLATE', $html );
+	}
+
+	/**
+	 * Test stream wrapper detection.
+	 */
+	public function test_path_has_stream_wrapper() {
+		$this->assertTrue( scf_path_has_stream_wrapper( 'phar:///tmp/attacker.phar' ) );
+		$this->assertTrue( scf_path_has_stream_wrapper( 'php://input' ) );
+		$this->assertTrue( scf_path_has_stream_wrapper( 'data://text/plain;base64,AAAA' ) );
+		$this->assertTrue( scf_path_has_stream_wrapper( 'compress.zlib://file.gz' ) );
+		$this->assertTrue( scf_path_has_stream_wrapper( 'HTTPS://example.com/x.php' ) );
+
+		$this->assertFalse( scf_path_has_stream_wrapper( '/var/www/theme/render.php' ) );
+		$this->assertFalse( scf_path_has_stream_wrapper( 'render.php' ) );
+		$this->assertFalse( scf_path_has_stream_wrapper( 'blocks/testimonial/render.php' ) );
+		$this->assertFalse( scf_path_has_stream_wrapper( '' ) );
+		// A wrapper that is not at the start of the path is just a directory name.
+		$this->assertFalse( scf_path_has_stream_wrapper( '/var/www/phar://render.php' ) );
 	}
 
 	/**

--- a/tests/php/includes/fields/test-acf-relational-field-ajax-security.php
+++ b/tests/php/includes/fields/test-acf-relational-field-ajax-security.php
@@ -1,0 +1,583 @@
+<?php
+/**
+ * Tests for relational field AJAX post visibility.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+// Load the field types before WorDBless snapshots the hook state.
+acf_include( 'includes/fields/class-acf-field-post_object.php' );
+acf_include( 'includes/fields/class-acf-field-relationship.php' );
+acf_include( 'includes/fields/class-acf-field-page_link.php' );
+
+/**
+ * Exercises the real relational AJAX handlers with deterministic query results.
+ *
+ * @group fields
+ * @group ajax
+ * @group security
+ */
+class Test_ACF_Relational_Field_Ajax_Security extends BaseTestCase {
+
+	/**
+	 * User IDs.
+	 *
+	 * @var array
+	 */
+	private $users = array();
+
+	/**
+	 * Post IDs.
+	 *
+	 * @var array
+	 */
+	private $posts = array();
+
+	/**
+	 * Queryable post IDs.
+	 *
+	 * @var array
+	 */
+	private $query_post_ids = array();
+
+	/**
+	 * Whether to serve fixture queries.
+	 *
+	 * @var bool
+	 */
+	private $serve_queries = false;
+
+	/**
+	 * Observed query variables.
+	 *
+	 * @var array
+	 */
+	private $observed_queries = array();
+
+	/** Set up deterministic users, fields, posts, and queries. */
+	public function set_up(): void {
+		parent::set_up();
+
+		wp_set_current_user( 0 );
+
+		$this->users['subscriber'] = $this->create_user( 'subscriber', 'relational_subscriber' );
+		$this->users['author']     = $this->create_user( 'author', 'relational_author' );
+		$this->users['other']      = $this->create_user( 'author', 'relational_other' );
+		$this->users['editor']     = $this->create_user( 'editor', 'relational_editor' );
+
+		$this->register_fields();
+		$this->create_base_posts();
+
+		add_filter( 'posts_pre_query', array( $this, 'filter_fixture_posts' ), 10, 2 );
+
+		$_GET     = array();
+		$_POST    = array();
+		$_REQUEST = array();
+	}
+
+	/** Remove fixtures and request state. */
+	public function tear_down(): void {
+		remove_filter( 'posts_pre_query', array( $this, 'filter_fixture_posts' ), 10 );
+
+		foreach ( $this->field_types() as $field_type ) {
+			acf_remove_local_field( $this->field_key( $field_type ) );
+		}
+
+		foreach ( $this->query_post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+
+		wp_set_current_user( 0 );
+		$_GET     = array();
+		$_POST    = array();
+		$_REQUEST = array();
+
+		parent::tear_down();
+	}
+
+	/** Ensure every handler retains its hooks and enforces post visibility. */
+	public function test_handlers_enforce_post_visibility() {
+		foreach ( $this->field_types() as $field_type ) {
+			$action = 'acf/fields/' . $field_type . '/query';
+
+			$this->assertNotFalse( has_action( 'wp_ajax_' . $action ) );
+			$this->assertNotFalse( has_action( 'wp_ajax_nopriv_' . $action ) );
+
+			wp_set_current_user( 0 );
+			$search = $this->invoke_ajax_query( $field_type, array( 's' => 'Alpha' ) );
+			$this->assert_result_ids( array( $this->posts['public_post'], $this->posts['public_page'] ), $search );
+
+			$anonymous = $this->invoke_ajax_query( $field_type, array( 'include' => $this->posts['other_private'] ) );
+			$this->assert_result_ids( array(), $anonymous );
+
+			wp_set_current_user( $this->users['editor'] );
+			$editor = $this->invoke_ajax_query( $field_type, array( 'include' => $this->posts['other_private'] ) );
+			$this->assert_result_ids( array( $this->posts['other_private'] ), $editor );
+		}
+	}
+
+	/** Ensure shared authorization honors the relevant WordPress roles. */
+	public function test_post_object_query_honors_role_permissions() {
+		$public = array( $this->posts['public_post'], $this->posts['public_page'] );
+		$author = array_merge(
+			$public,
+			array( $this->posts['own_draft'], $this->posts['own_pending'], $this->posts['own_private'] )
+		);
+		$editor = array_merge( $author, array( $this->posts['other_private'] ) );
+		$cases  = array(
+			'anonymous'  => array( 0, $public ),
+			'subscriber' => array( $this->users['subscriber'], $public ),
+			'author'     => array( $this->users['author'], $author ),
+			'editor'     => array( $this->users['editor'], $editor ),
+		);
+
+		foreach ( $cases as $case => $values ) {
+			wp_set_current_user( $values[0] );
+			$payload = $this->invoke_ajax_query( 'post_object', array( 's' => 'Alpha' ) );
+			$this->assert_result_ids( $values[1], $payload, $case );
+		}
+	}
+
+	/** Ensure anonymous restrictions apply before pagination. */
+	public function test_anonymous_status_restrictions_apply_before_pagination() {
+		wp_set_current_user( 0 );
+
+		$this->create_post( 'Pagination A Hidden', 'private', $this->users['other'] );
+		$this->create_post( 'Pagination Z Public 01', 'publish', $this->users['other'] );
+		$expected_id = $this->create_post( 'Pagination Z Public 02', 'publish', $this->users['other'] );
+
+		$query_filter = static function ( $args ) {
+			$args['post_status']    = 'any';
+			$args['posts_per_page'] = 1;
+			return $args;
+		};
+		add_filter( 'acf/fields/post_object/query', $query_filter, 100 );
+
+		try {
+			$payload = $this->invoke_ajax_query(
+				'post_object',
+				array(
+					's'     => 'Pagination',
+					'paged' => 2,
+				)
+			);
+		} finally {
+			remove_filter( 'acf/fields/post_object/query', $query_filter, 100 );
+		}
+		$this->assert_result_ids( array( $expected_id ), $payload );
+
+		$queries = array_filter(
+			$this->observed_queries,
+			static function ( $query ) {
+				return 1 === $query['posts_per_page'] && 2 === $query['paged'];
+			}
+		);
+		$this->assertNotEmpty( $queries );
+
+		foreach ( $queries as $query ) {
+			$this->assertEqualsCanonicalizing( array( 'publish' ), (array) $query['post_status'] );
+		}
+	}
+
+	/** Ensure denied groups disappear before result filters run. */
+	public function test_denied_groups_are_removed_before_result_filters() {
+		wp_set_current_user( $this->users['subscriber'] );
+
+		$filtered_ids  = array();
+		$result_filter = static function ( $title, $post ) use ( &$filtered_ids ) {
+			$filtered_ids[] = $post->ID;
+			return $title;
+		};
+		add_filter( 'acf/fields/relationship/result', $result_filter, 10, 2 );
+
+		try {
+			$payload = $this->invoke_ajax_query(
+				'relationship',
+				array(
+					's' => 'Group Sentinel',
+				)
+			);
+		} finally {
+			remove_filter( 'acf/fields/relationship/result', $result_filter, 10 );
+		}
+
+		$this->assert_result_ids( array( $this->posts['sentinel_public'] ), $payload );
+		$this->assertSame( array( $this->posts['sentinel_public'] ), $filtered_ids );
+		$this->assertNotContains(
+			get_post_type_object( 'page' )->labels->name,
+			wp_list_pluck( $payload['results'], 'text' )
+		);
+	}
+
+	/** Ensure public inherited attachments remain available. */
+	public function test_anonymous_public_attachment_remains_available() {
+		wp_set_current_user( 0 );
+
+		$public_attachment_id = $this->create_post(
+			'Public Inherited Attachment',
+			'inherit',
+			$this->users['other'],
+			'attachment',
+			$this->posts['public_post']
+		);
+		$this->create_post(
+			'Private Inherited Attachment',
+			'inherit',
+			$this->users['other'],
+			'attachment',
+			$this->posts['other_private']
+		);
+		$query_filter = static function ( $args ) {
+			$args['post_type']   = array( 'attachment' );
+			$args['post_status'] = 'any';
+			return $args;
+		};
+		add_filter( 'acf/fields/page_link/query', $query_filter, 100 );
+
+		try {
+			$payload = $this->invoke_ajax_query( 'page_link' );
+		} finally {
+			remove_filter( 'acf/fields/page_link/query', $query_filter, 100 );
+		}
+
+		$this->assert_result_ids( array( $public_attachment_id ), $payload );
+		$this->assertContains( 'inherit', (array) $this->observed_queries[0]['post_status'] );
+	}
+
+	/** Ensure anonymous queries discard non-viewable post types before querying. */
+	public function test_anonymous_query_discards_non_viewable_post_types() {
+		register_post_type( 'relational_hidden', array( 'public' => false ) );
+		$this->create_post( 'Hidden Type Post', 'publish', $this->users['other'], 'relational_hidden' );
+		$this->serve_queries = true;
+
+		try {
+			$groups = acf_get_grouped_posts(
+				array(
+					'post_type'      => array( 'relational_hidden' ),
+					'post_status'    => 'any',
+					'posts_per_page' => -1,
+				),
+				true
+			);
+		} finally {
+			$this->serve_queries = false;
+			unregister_post_type( 'relational_hidden' );
+		}
+
+		$this->assertSame( array(), $groups );
+		$this->assertSame( array(), $this->observed_queries );
+	}
+
+	/** Ensure helper consumers remain unfiltered unless they opt in. */
+	public function test_grouped_posts_preserve_existing_behavior_by_default() {
+		wp_set_current_user( 0 );
+		$this->serve_queries = true;
+
+		try {
+			$groups = acf_get_grouped_posts(
+				array(
+					'post_type'      => array( 'post', 'page' ),
+					'post_status'    => 'any',
+					'posts_per_page' => -1,
+					's'              => 'Alpha',
+				)
+			);
+		} finally {
+			$this->serve_queries = false;
+		}
+
+		$post_ids = array();
+		foreach ( $groups as $group ) {
+			$post_ids = array_merge( $post_ids, array_keys( $group ) );
+		}
+
+		$this->assertEqualsCanonicalizing(
+			array(
+				$this->posts['public_post'],
+				$this->posts['public_page'],
+				$this->posts['own_draft'],
+				$this->posts['own_pending'],
+				$this->posts['own_private'],
+				$this->posts['other_private'],
+			),
+			$post_ids
+		);
+	}
+
+	/**
+	 * Create a test user.
+	 *
+	 * @param string $role  WordPress role.
+	 * @param string $login Login and email prefix.
+	 * @return int
+	 */
+	private function create_user( $role, $login ) {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => $login,
+				'user_pass'  => 'password',
+				'user_email' => $login . '@example.com',
+				'role'       => $role,
+			)
+		);
+
+		$this->assertIsInt( $user_id );
+		return $user_id;
+	}
+
+	/** Register fields used to resolve typed nonces. */
+	private function register_fields() {
+		$common = array(
+			'post_type'   => array( 'post', 'page' ),
+			'post_status' => array( 'publish', 'draft', 'pending', 'private' ),
+			'taxonomy'    => array(),
+		);
+
+		foreach ( $this->field_types() as $field_type ) {
+			$field = array_merge(
+				$common,
+				array(
+					'key'  => $this->field_key( $field_type ),
+					'name' => 'test_relational_' . $field_type,
+					'type' => $field_type,
+				)
+			);
+
+			if ( 'relationship' === $field_type ) {
+				$field['elements'] = array();
+				$field['filters']  = array( 'search' );
+			} elseif ( 'page_link' === $field_type ) {
+				$field['allow_archives'] = 0;
+			}
+
+			acf_add_local_field( $field );
+		}
+	}
+
+	/** Create posts shared by the scenarios. */
+	private function create_base_posts() {
+		$fixtures = array(
+			'public_post'     => array( 'Alpha Public Post', 'publish', 'other', 'post' ),
+			'public_page'     => array( 'Alpha Public Page', 'publish', 'other', 'page' ),
+			'own_draft'       => array( 'Alpha Own Draft', 'draft', 'author', 'post' ),
+			'own_pending'     => array( 'Alpha Own Pending', 'pending', 'author', 'post' ),
+			'own_private'     => array( 'Alpha Own Private', 'private', 'author', 'post' ),
+			'other_private'   => array( 'Alpha Other Private', 'private', 'other', 'post' ),
+			'sentinel_public' => array( 'Group Sentinel Public', 'publish', 'other', 'post' ),
+			'sentinel_hidden' => array( 'Group Sentinel Hidden', 'private', 'other', 'page' ),
+		);
+
+		foreach ( $fixtures as $key => $fixture ) {
+			$this->posts[ $key ] = $this->create_post(
+				$fixture[0],
+				$fixture[1],
+				$this->users[ $fixture[2] ],
+				$fixture[3]
+			);
+		}
+	}
+
+	/**
+	 * Create a post and expose it to the query shim.
+	 *
+	 * @param string $title     Post title.
+	 * @param string $status    Post status.
+	 * @param int    $author    Post author ID.
+	 * @param string $type      Post type.
+	 * @param int    $parent_id Parent post ID.
+	 * @return int
+	 */
+	private function create_post( $title, $status, $author, $type = 'post', $parent_id = 0 ) {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => $title,
+				'post_status' => $status,
+				'post_type'   => $type,
+				'post_author' => $author,
+				'post_parent' => $parent_id,
+			)
+		);
+
+		$this->assertIsInt( $post_id );
+		$this->query_post_ids[] = $post_id;
+		return $post_id;
+	}
+
+	/**
+	 * Invoke a real relational AJAX handler and decode its JSON.
+	 *
+	 * @param string $field_type   Relational field type.
+	 * @param array  $request_args Request overrides.
+	 * @return array
+	 * @throws RuntimeException When the handler throws unexpectedly.
+	 */
+	private function invoke_ajax_query( $field_type, $request_args = array() ) {
+		$field_key = $this->field_key( $field_type );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Real handler test request.
+		$_POST = array_merge(
+			array(
+				'nonce'     => wp_create_nonce( 'acf_field_' . $field_type . '_' . $field_key ),
+				'field_key' => $field_key,
+				'post_id'   => 0,
+				's'         => '',
+				'paged'     => 1,
+				'include'   => '',
+			),
+			$request_args
+		);
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Mirrors acf_request_arg().
+		$_REQUEST = $_POST;
+
+		$halt_marker  = 'acf_relational_ajax_halt';
+		$force_ajax   = static function () {
+			return true;
+		};
+		$halt_handler = static function () use ( $halt_marker ) {
+			return static function () use ( $halt_marker ) {
+				throw new RuntimeException( esc_html( $halt_marker ) );
+			};
+		};
+
+		add_filter( 'wp_doing_ajax', $force_ajax );
+		add_filter( 'wp_die_ajax_handler', $halt_handler, 100 );
+		add_filter( 'wp_die_json_handler', $halt_handler, 100 );
+
+		$output                 = '';
+		$unrelated_exception    = null;
+		$this->observed_queries = array();
+		$this->serve_queries    = true;
+
+		ob_start();
+		try {
+			acf_get_field_type( $field_type )->ajax_query();
+		} catch ( RuntimeException $exception ) {
+			if ( $halt_marker !== $exception->getMessage() ) {
+				$unrelated_exception = $exception;
+			}
+		} finally {
+			$output              = ob_get_clean();
+			$this->serve_queries = false;
+
+			remove_filter( 'wp_die_json_handler', $halt_handler, 100 );
+			remove_filter( 'wp_die_ajax_handler', $halt_handler, 100 );
+			remove_filter( 'wp_doing_ajax', $force_ajax );
+		}
+
+		if ( $unrelated_exception ) {
+			throw $unrelated_exception;
+		}
+
+		$payload = json_decode( $output, true );
+		$this->assertIsArray( $payload );
+		return $payload;
+	}
+
+	/**
+	 * Preempt relational queries with seeded posts.
+	 *
+	 * @param array|null $preempt Existing short-circuit value.
+	 * @param WP_Query   $query   Query being executed.
+	 * @return array|null
+	 */
+	public function filter_fixture_posts( $preempt, $query ) {
+		if ( ! $this->serve_queries ) {
+			return $preempt;
+		}
+
+		$post_types = (array) $query->get( 'post_type' );
+		if ( ! array_intersect( array( 'post', 'page', 'attachment', 'relational_hidden' ), $post_types ) ) {
+			return $preempt;
+		}
+
+		$this->observed_queries[] = array(
+			'post_status'    => $query->get( 'post_status' ),
+			'posts_per_page' => (int) $query->get( 'posts_per_page' ),
+			'paged'          => (int) $query->get( 'paged' ),
+		);
+
+		$statuses = (array) $query->get( 'post_status' );
+		$included = array_map( 'intval', (array) $query->get( 'post__in' ) );
+		$search   = (string) $query->get( 's' );
+		$posts    = array();
+
+		foreach ( $this->query_post_ids as $post_id ) {
+			$post = get_post( $post_id );
+
+			if (
+				! $post instanceof WP_Post
+				|| ( ! in_array( 'any', $post_types, true ) && ! in_array( $post->post_type, $post_types, true ) )
+				|| ( $statuses && ! in_array( 'any', $statuses, true ) && ! in_array( $post->post_status, $statuses, true ) )
+				|| ( $included && ! in_array( $post->ID, $included, true ) )
+				|| ( '' !== $search && false === stripos( $post->post_title, $search ) )
+			) {
+				continue;
+			}
+
+			$posts[] = $post;
+		}
+
+		usort(
+			$posts,
+			static function ( $left, $right ) use ( $post_types ) {
+				$left_type  = array_search( $left->post_type, $post_types, true );
+				$right_type = array_search( $right->post_type, $post_types, true );
+
+				if ( $left_type !== $right_type ) {
+					return $left_type <=> $right_type;
+				}
+
+				return strnatcasecmp( $left->post_title, $right->post_title );
+			}
+		);
+
+		$per_page = (int) $query->get( 'posts_per_page' );
+		if ( -1 !== $per_page ) {
+			$page  = max( 1, (int) $query->get( 'paged' ) );
+			$posts = array_slice( $posts, ( $page - 1 ) * $per_page, $per_page );
+		}
+
+		return array_values( $posts );
+	}
+
+	/**
+	 * Assert that a payload contains exactly the expected IDs.
+	 *
+	 * @param array  $expected Expected post IDs.
+	 * @param array  $payload  AJAX payload.
+	 * @param string $message  Optional failure context.
+	 * @return void
+	 */
+	private function assert_result_ids( $expected, $payload, $message = '' ) {
+		$post_ids = array();
+
+		foreach ( $payload['results'] as $result ) {
+			$items = isset( $result['children'] ) ? $result['children'] : array( $result );
+
+			foreach ( $items as $item ) {
+				if ( isset( $item['id'] ) && is_numeric( $item['id'] ) ) {
+					$post_ids[] = (int) $item['id'];
+				}
+			}
+		}
+
+		$this->assertEqualsCanonicalizing( $expected, $post_ids, $message );
+	}
+
+	/** Return relational field types. */
+	private function field_types() {
+		return array( 'post_object', 'relationship', 'page_link' );
+	}
+
+	/**
+	 * Return a local field key.
+	 *
+	 * @param string $field_type Relational field type.
+	 * @return string
+	 */
+	private function field_key( $field_type ) {
+		return 'field_test_relational_' . $field_type;
+	}
+}

--- a/tests/php/includes/rest-api/test-acf-rest-api-functions.php
+++ b/tests/php/includes/rest-api/test-acf-rest-api-functions.php
@@ -69,6 +69,18 @@ class Test_ACF_Rest_Api_Functions extends BaseTestCase {
 		if ( ! class_exists( 'acf_field_radio' ) ) {
 			acf_include( 'includes/fields/class-acf-field-radio.php' );
 		}
+		if ( ! class_exists( 'acf_field__group' ) ) {
+			acf_include( 'includes/fields/class-acf-field-group.php' );
+		}
+		if ( ! class_exists( 'acf_field_user' ) ) {
+			acf_include( 'includes/fields/class-acf-field-user.php' );
+		}
+		if ( ! has_filter( 'acf/format_value/type=group' ) ) {
+			acf_register_field_type( 'acf_field__group' );
+		}
+		if ( ! has_filter( 'acf/format_value/type=user' ) ) {
+			acf_register_field_type( 'acf_field_user' );
+		}
 
 		// Create a test post.
 		$this->test_post_id = wp_insert_post(
@@ -359,6 +371,267 @@ class Test_ACF_Rest_Api_Functions extends BaseTestCase {
 		$result = acf_format_value_for_rest( 'test value', $this->test_post_id, $field, 'standard' );
 
 		$this->assertEquals( 'test value', $result );
+	}
+
+	/**
+	 * Test standard REST formatting uses REST-safe output for nested User fields.
+	 */
+	public function test_format_value_for_rest_standard_format_uses_safe_nested_user_format() {
+		$user_login = uniqid( 'rest_safe_nested_user_', false );
+		$user_email = "{$user_login}@example.invalid";
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => $user_login,
+				'user_pass'  => 'password',
+				'user_email' => $user_email,
+			)
+		);
+
+		global $wpdb;
+		$activation_key = "{$user_login}-activation-key";
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test fixture needs a controlled activation key marker.
+		$wpdb->update(
+			$wpdb->users,
+			array( 'user_activation_key' => $activation_key ),
+			array( 'ID' => $user_id )
+		);
+		clean_user_cache( $user_id );
+
+		$user_field = acf_validate_field(
+			array(
+				'key'           => 'field_test_nested_user',
+				'name'          => 'nested_user',
+				'type'          => 'user',
+				'required'      => 0,
+				'multiple'      => 0,
+				'return_format' => 'array',
+				'role'          => array(),
+				'allow_null'    => 0,
+			)
+		);
+
+		$metadata_field = acf_validate_field(
+			array(
+				'key'  => 'field_test_nested_metadata',
+				'name' => 'metadata',
+				'type' => 'text',
+			)
+		);
+
+		$field = acf_validate_field(
+			array(
+				'key'        => 'field_test_group_with_user',
+				'name'       => 'test_group_with_user',
+				'type'       => 'group',
+				'sub_fields' => array( $user_field, $metadata_field ),
+			)
+		);
+
+		$metadata = array(
+			'ID'              => 777,
+			'user_email'      => 'public-metadata@example.invalid',
+			'user_nicename'   => 'public-metadata',
+			'user_registered' => '2026-07-24 00:00:00',
+			'user_avatar'     => 'avatar',
+			'description'     => 'Keep this sibling value intact.',
+		);
+		$value    = array(
+			$user_field['key']     => $user_id,
+			$metadata_field['key'] => $metadata,
+		);
+
+		$shim_user_query = static function ( $results, $query ) use ( $user_id ) {
+			$query->total_users = 1;
+			return array( $user_id );
+		};
+		add_filter( 'users_pre_query', $shim_user_query, 10, 2 );
+
+		$remove_user_avatar = static function ( $formatted_value ) {
+			if ( is_array( $formatted_value ) ) {
+				unset( $formatted_value['user_avatar'] );
+			}
+			return $formatted_value;
+		};
+		add_filter( 'acf/format_value/type=user', $remove_user_avatar, 20 );
+
+		$results = array();
+		foreach ( array( 'array', 'object' ) as $return_format ) {
+			$field['sub_fields'][0]['return_format'] = $return_format;
+			acf_get_store( 'values' )->reset();
+
+			$results[ $return_format ] = acf_format_value_for_rest( $value, $this->test_post_id, $field, 'standard' );
+		}
+
+		remove_filter( 'acf/format_value/type=user', $remove_user_avatar, 20 );
+		remove_filter( 'users_pre_query', $shim_user_query, 10 );
+		wp_delete_user( $user_id );
+
+		foreach ( $results as $result ) {
+			$json = wp_json_encode( $result );
+
+			$this->assertArrayHasKey( 'nested_user', $result );
+			$this->assertSame( $user_id, $result['nested_user'] );
+			$this->assertSame( $metadata, $result['metadata'] );
+			$this->assertStringNotContainsString( $user_email, $json );
+			$this->assertStringNotContainsString( 'user_pass', $json );
+			$this->assertStringNotContainsString( $activation_key, $json );
+			$this->assertStringNotContainsString( 'user_activation_key', $json );
+		}
+	}
+
+	/**
+	 * Test nested User sanitization follows field definitions across layout field types.
+	 */
+	public function test_rest_user_sanitization_follows_nested_field_definitions() {
+		$user_id               = 321;
+		$second_user_id        = 654;
+		$formatted_user        = array(
+			'ID'              => $user_id,
+			'user_email'      => 'private-user@example.invalid',
+			'user_nicename'   => 'private-user',
+			'user_registered' => '2026-07-24 00:00:00',
+		);
+		$formatted_second_user = array(
+			'ID'              => $second_user_id,
+			'user_email'      => 'second-private-user@example.invalid',
+			'user_nicename'   => 'second-private-user',
+			'user_registered' => '2026-07-24 00:00:00',
+		);
+		$formatted_lookalike   = array(
+			'ID'              => 777,
+			'user_email'      => 'public-metadata@example.invalid',
+			'user_nicename'   => 'public-metadata',
+			'user_registered' => '2026-07-24 00:00:00',
+			'user_avatar'     => 'avatar',
+		);
+		$user_field            = array(
+			'key'      => 'field_nested_user',
+			'name'     => 'nested_user',
+			'_name'    => 'nested_user',
+			'__name'   => 'cloned_user',
+			'type'     => 'user',
+			'multiple' => 0,
+		);
+
+		$cases = array(
+			'group'            => array(
+				'field'     => array(
+					'type'       => 'group',
+					'sub_fields' => array( $user_field ),
+				),
+				'formatted' => array( 'nested_user' => $formatted_user ),
+				'raw'       => array( 'field_nested_user' => $user_id ),
+				'expected'  => array( 'nested_user' => $user_id ),
+			),
+			'clone'            => array(
+				'field'     => array(
+					'type'       => 'clone',
+					'sub_fields' => array( $user_field ),
+				),
+				'formatted' => array( 'cloned_user' => $formatted_user ),
+				'raw'       => array( 'field_nested_user' => $user_id ),
+				'expected'  => array( 'cloned_user' => $user_id ),
+			),
+			'repeater'         => array(
+				'field'     => array(
+					'type'       => 'repeater',
+					'sub_fields' => array( $user_field ),
+				),
+				'formatted' => array(
+					array(
+						'nested_user' => $formatted_second_user,
+						'label'       => 'Second row',
+					),
+					array(
+						'nested_user' => $formatted_user,
+						'label'       => 'First row',
+					),
+				),
+				'raw'       => array(
+					array(
+						'field_nested_user' => $user_id,
+						'field_label'       => 'First row',
+					),
+					array(
+						'field_nested_user' => $second_user_id,
+						'field_label'       => 'Second row',
+					),
+				),
+				'expected'  => array(
+					array(
+						'nested_user' => $second_user_id,
+						'label'       => 'Second row',
+					),
+					array(
+						'nested_user' => $user_id,
+						'label'       => 'First row',
+					),
+				),
+			),
+			'flexible_content' => array(
+				'field'     => array(
+					'type'    => 'flexible_content',
+					'layouts' => array(
+						array(
+							'name'       => 'user_layout',
+							'sub_fields' => array( $user_field ),
+						),
+						array(
+							'name'       => 'metadata_layout',
+							'sub_fields' => array(
+								array(
+									'key'   => 'field_nested_metadata',
+									'name'  => 'nested_user',
+									'_name' => 'nested_user',
+									'type'  => 'text',
+								),
+							),
+						),
+					),
+				),
+				'formatted' => array(
+					2 => array(
+						'acf_fc_layout' => 'metadata_layout',
+						'nested_user'   => $formatted_lookalike,
+					),
+					7 => array(
+						'acf_fc_layout' => 'user_layout',
+						'nested_user'   => $formatted_user,
+					),
+				),
+				'raw'       => array(
+					2 => array(
+						'acf_fc_layout'     => 'user_layout',
+						'field_nested_user' => $user_id,
+					),
+					7 => array(
+						'acf_fc_layout'         => 'metadata_layout',
+						'field_nested_metadata' => $formatted_lookalike,
+					),
+				),
+				'expected'  => array(
+					2 => array(
+						'acf_fc_layout' => 'metadata_layout',
+						'nested_user'   => $formatted_lookalike,
+					),
+					7 => array(
+						'acf_fc_layout' => 'user_layout',
+						'nested_user'   => $user_id,
+					),
+				),
+			),
+		);
+
+		foreach ( $cases as $field_type => $case ) {
+			$result = scf_rest_sanitize_user_data(
+				$case['formatted'],
+				$case['raw'],
+				$case['field']
+			);
+
+			$this->assertSame( $case['expected'], $result, "Failed sanitizing {$field_type} field values." );
+		}
 	}
 
 	/**

--- a/tests/php/includes/rest-api/test-acf-rest-api.php
+++ b/tests/php/includes/rest-api/test-acf-rest-api.php
@@ -94,6 +94,18 @@ class Test_ACF_Rest_Api extends BaseTestCase {
 		if ( ! class_exists( 'ACF_Location_Taxonomy' ) ) {
 			acf_include( 'includes/locations/class-acf-location-taxonomy.php' );
 		}
+		if ( ! class_exists( 'acf_field_user' ) ) {
+			acf_include( 'includes/fields/class-acf-field-user.php' );
+		}
+		if ( ! class_exists( 'acf_field__group' ) ) {
+			acf_include( 'includes/fields/class-acf-field-group.php' );
+		}
+		if ( ! has_filter( 'acf/format_value/type=user' ) ) {
+			acf_register_field_type( 'acf_field_user' );
+		}
+		if ( ! has_filter( 'acf/format_value/type=group' ) ) {
+			acf_register_field_type( 'acf_field__group' );
+		}
 
 		// Store original settings.
 		$this->original_rest_api_enabled     = acf_get_setting( 'rest_api_enabled' );
@@ -363,6 +375,291 @@ class Test_ACF_Rest_Api extends BaseTestCase {
 		$result = $this->rest_api->load_fields( $object, 'acf', new WP_REST_Request(), 'post' );
 
 		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Test load_fields uses REST-safe formatted values for User fields.
+	 */
+	public function test_load_fields_uses_rest_safe_user_formatted_values() {
+		wp_set_current_user( 0 );
+
+		$user_login = uniqid( 'rest_loaded_user_', false );
+		$user_email = "{$user_login}@example.invalid";
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => $user_login,
+				'user_pass'  => 'password',
+				'user_email' => $user_email,
+			)
+		);
+
+		$second_user_login = uniqid( 'rest_loaded_second_user_', false );
+		$second_user_email = "{$second_user_login}@example.invalid";
+		$second_user_id    = wp_insert_user(
+			array(
+				'user_login' => $second_user_login,
+				'user_pass'  => 'password',
+				'user_email' => $second_user_email,
+			)
+		);
+
+		global $wpdb;
+		$activation_key        = "{$user_login}-activation-key";
+		$second_activation_key = "{$second_user_login}-activation-key";
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test fixture needs a controlled activation key marker.
+		$wpdb->update(
+			$wpdb->users,
+			array( 'user_activation_key' => $activation_key ),
+			array( 'ID' => $user_id )
+		);
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test fixture needs a controlled activation key marker.
+		$wpdb->update(
+			$wpdb->users,
+			array( 'user_activation_key' => $second_activation_key ),
+			array( 'ID' => $second_user_id )
+		);
+		clean_user_cache( $user_id );
+		clean_user_cache( $second_user_id );
+
+		acf_add_local_field_group(
+			array_merge(
+				$this->test_field_group,
+				array(
+					'key'    => 'group_test_rest_user_source_values',
+					'title'  => 'Test REST User Source Values',
+					'fields' => array(
+						array(
+							'key'           => 'field_test_rest_user_array',
+							'label'         => 'Test REST User Array',
+							'name'          => 'test_rest_user_array',
+							'type'          => 'user',
+							'required'      => 0,
+							'multiple'      => 0,
+							'return_format' => 'array',
+							'role'          => array(),
+							'allow_null'    => 0,
+						),
+						array(
+							'key'           => 'field_test_rest_user_object',
+							'label'         => 'Test REST User Object',
+							'name'          => 'test_rest_user_object',
+							'type'          => 'user',
+							'required'      => 0,
+							'multiple'      => 0,
+							'return_format' => 'object',
+							'role'          => array(),
+							'allow_null'    => 0,
+						),
+						array(
+							'key'        => 'field_test_rest_user_group',
+							'label'      => 'Test REST User Group',
+							'name'       => 'test_rest_user_group',
+							'type'       => 'group',
+							'sub_fields' => array(
+								array(
+									'key'           => 'field_test_rest_nested_user_array',
+									'label'         => 'Test REST Nested User Array',
+									'name'          => 'nested_user_array',
+									'type'          => 'user',
+									'required'      => 0,
+									'multiple'      => 1,
+									'return_format' => 'array',
+									'role'          => array(),
+									'allow_null'    => 0,
+								),
+								array(
+									'key'           => 'field_test_rest_nested_user_object',
+									'label'         => 'Test REST Nested User Object',
+									'name'          => 'nested_user_object',
+									'type'          => 'user',
+									'required'      => 0,
+									'multiple'      => 1,
+									'return_format' => 'object',
+									'role'          => array(),
+									'allow_null'    => 0,
+								),
+							),
+						),
+					),
+				)
+			)
+		);
+
+		update_field( 'field_test_rest_user_array', $user_id, $this->test_post_id );
+		update_field( 'field_test_rest_user_object', $user_id, $this->test_post_id );
+		update_field(
+			'field_test_rest_user_group',
+			array(
+				'field_test_rest_nested_user_array'  => array( $user_id, $second_user_id ),
+				'field_test_rest_nested_user_object' => array( $user_id, $second_user_id ),
+			),
+			$this->test_post_id
+		);
+		acf_get_store( 'fields' )->reset();
+
+		$request_prop = $this->reflection->getProperty( 'request' );
+		$request_prop->setAccessible( true );
+
+		$mock_request = new class() {
+			/**
+			 * The REST object type.
+			 *
+			 * @var string
+			 */
+			public $object_type = 'post';
+
+			/**
+			 * The REST object subtype.
+			 *
+			 * @var string
+			 */
+			public $object_sub_type = 'post';
+
+			/**
+			 * The REST request method.
+			 *
+			 * @var string
+			 */
+			public $http_method = 'GET';
+
+			/**
+			 * Get a URL parameter value.
+			 *
+			 * @param string $param The URL parameter name.
+			 * @return null
+			 */
+			public function get_url_param( $param ) {
+				return null;
+			}
+		};
+		$request_prop->setValue( $this->rest_api, $mock_request );
+
+		$shim_user_query = static function ( $results, $query ) {
+			$user_ids           = array_map( 'intval', (array) ( $query->query_vars['include'] ?? array() ) );
+			$query->total_users = count( $user_ids );
+			return $user_ids;
+		};
+		add_filter( 'users_pre_query', $shim_user_query, 10, 2 );
+
+		$remove_user_avatar = static function ( $formatted_value ) {
+			if ( is_array( $formatted_value ) && isset( $formatted_value['ID'] ) ) {
+				unset( $formatted_value['user_avatar'] );
+				return $formatted_value;
+			}
+
+			if ( is_array( $formatted_value ) ) {
+				foreach ( $formatted_value as &$user ) {
+					if ( is_array( $user ) ) {
+						unset( $user['user_avatar'] );
+					}
+				}
+			}
+
+			return $formatted_value;
+		};
+		add_filter( 'acf/format_value/type=user', $remove_user_avatar, 20 );
+
+		$rest_filter_calls = 0;
+		$count_rest_filter = static function ( $formatted_value, $post_id, $field ) use ( &$rest_filter_calls ) {
+			if ( ! in_array( $field['name'], array( 'test_rest_user_array', 'test_rest_user_object' ), true ) ) {
+				return $formatted_value;
+			}
+
+			++$rest_filter_calls;
+			return "rest-filtered-{$formatted_value}";
+		};
+		add_filter( 'acf/rest/format_value_for_rest', $count_rest_filter, 10, 3 );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $this->test_post_id );
+
+		$result               = $this->rest_api->load_fields( array( 'id' => $this->test_post_id ), 'acf', $request, 'post' );
+		$default_filter_calls = $rest_filter_calls;
+
+		$standard_request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $this->test_post_id );
+		$standard_request->set_param( 'acf_format', 'standard' );
+
+		$standard_result = $this->rest_api->load_fields( array( 'id' => $this->test_post_id ), 'acf', $standard_request, 'post' );
+		remove_filter( 'acf/rest/format_value_for_rest', $count_rest_filter, 10 );
+		remove_filter( 'acf/format_value/type=user', $remove_user_avatar, 20 );
+		remove_filter( 'users_pre_query', $shim_user_query, 10 );
+
+		$this->assertSame( 2, $default_filter_calls );
+		$this->assertSame( 4, $rest_filter_calls );
+		$this->assertSame( "rest-filtered-{$user_id}", $result['test_rest_user_array'] );
+		$this->assertSame( "rest-filtered-{$user_id}", $result['test_rest_user_object'] );
+		$this->assertSame( $user_id, $result['test_rest_user_array_source']['formatted_value'] );
+		$this->assertSame( $user_id, $result['test_rest_user_object_source']['formatted_value'] );
+		$this->assertSame(
+			array( $user_id, $second_user_id ),
+			$result['test_rest_user_group']['nested_user_array']
+		);
+		$this->assertSame(
+			array( $user_id, $second_user_id ),
+			$result['test_rest_user_group']['nested_user_object']
+		);
+		$this->assertSame(
+			array( $user_id, $second_user_id ),
+			$result['test_rest_user_group_source']['formatted_value']['nested_user_array']
+		);
+		$this->assertSame(
+			array( $user_id, $second_user_id ),
+			$result['test_rest_user_group_source']['formatted_value']['nested_user_object']
+		);
+		$this->assertRestUserResponseDoesNotExposePrivateData( $result, $user_email, $activation_key );
+		$this->assertRestUserResponseDoesNotExposePrivateData( $result, $second_user_email, $second_activation_key );
+
+		$this->assertSame( "rest-filtered-{$user_id}", $standard_result['test_rest_user_array'] );
+		$this->assertSame( "rest-filtered-{$user_id}", $standard_result['test_rest_user_object'] );
+		$this->assertSame( $user_id, $standard_result['test_rest_user_array_source']['formatted_value'] );
+		$this->assertSame( $user_id, $standard_result['test_rest_user_object_source']['formatted_value'] );
+		$this->assertSame(
+			array( $user_id, $second_user_id ),
+			$standard_result['test_rest_user_group']['nested_user_array']
+		);
+		$this->assertSame(
+			array( $user_id, $second_user_id ),
+			$standard_result['test_rest_user_group']['nested_user_object']
+		);
+		$this->assertSame(
+			array( $user_id, $second_user_id ),
+			$standard_result['test_rest_user_group_source']['formatted_value']['nested_user_array']
+		);
+		$this->assertSame(
+			array( $user_id, $second_user_id ),
+			$standard_result['test_rest_user_group_source']['formatted_value']['nested_user_object']
+		);
+		$this->assertRestUserResponseDoesNotExposePrivateData( $standard_result, $user_email, $activation_key );
+		$this->assertRestUserResponseDoesNotExposePrivateData(
+			$standard_result,
+			$second_user_email,
+			$second_activation_key
+		);
+
+		wp_delete_user( $user_id );
+		wp_delete_user( $second_user_id );
+		acf_remove_local_field_group( 'group_test_rest_user_source_values' );
+		acf_remove_local_field( 'field_test_rest_user_array' );
+		acf_remove_local_field( 'field_test_rest_user_object' );
+		acf_remove_local_field( 'field_test_rest_user_group' );
+		acf_remove_local_field( 'field_test_rest_nested_user_array' );
+		acf_remove_local_field( 'field_test_rest_nested_user_object' );
+	}
+
+	/**
+	 * Assert REST User field output does not expose private user data.
+	 *
+	 * @param array  $response       The REST field response.
+	 * @param string $user_email     The private user email marker.
+	 * @param string $activation_key The private user activation key marker.
+	 */
+	protected function assertRestUserResponseDoesNotExposePrivateData( $response, $user_email, $activation_key ) {
+		$json = wp_json_encode( $response );
+
+		$this->assertStringNotContainsString( $user_email, $json );
+		$this->assertStringNotContainsString( 'user_pass', $json );
+		$this->assertStringNotContainsString( $activation_key, $json );
+		$this->assertStringNotContainsString( 'user_activation_key', $json );
 	}
 
 	// =========================================================================

--- a/tests/php/includes/test-local-json.php
+++ b/tests/php/includes/test-local-json.php
@@ -136,7 +136,7 @@ class Test_Local_JSON extends BaseTestCase {
 
 			$path = $dir . '/' . $entry;
 
-			if ( is_dir( $path ) ) {
+			if ( is_dir( $path ) && ! is_link( $path ) ) {
 				$this->delete_dir( $path );
 			} else {
 				unlink( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test fixture cleanup.
@@ -161,6 +161,51 @@ class Test_Local_JSON extends BaseTestCase {
 		if ( ! has_filter( 'acf/prepare_field_for_import/type=text' ) ) {
 			acf_register_field_type( 'acf_field_text' );
 		}
+	}
+
+	/**
+	 * Creates a Local JSON instance that enforces multisite write restrictions.
+	 *
+	 * @return ACF_Local_JSON
+	 */
+	private function get_restricted_json_instance() {
+		return new class() extends ACF_Local_JSON {
+
+			/**
+			 * Avoids registering a duplicate set of hooks.
+			 */
+			public function __construct() {}
+
+			/**
+			 * Forces multisite write restrictions under WorDBless.
+			 *
+			 * WorDBless defines MULTISITE as false during bootstrap, so only the
+			 * environment decision is overridden.
+			 *
+			 * @return boolean
+			 */
+			protected function should_restrict_multisite_writes() {
+				return true;
+			}
+		};
+	}
+
+	/**
+	 * Reports a directory inside the temp dir as the site's uploads directory.
+	 *
+	 * @param string $basedir The uploads base directory to report.
+	 * @return callable The registered filter callback, for removal by the test.
+	 */
+	private function use_uploads_basedir( $basedir ) {
+		$filter = function ( $uploads ) use ( $basedir ) {
+			$uploads['basedir'] = $basedir;
+			$uploads['path']    = $basedir;
+
+			return $uploads;
+		};
+		add_filter( 'upload_dir', $filter );
+
+		return $filter;
 	}
 
 	/**
@@ -423,6 +468,153 @@ class Test_Local_JSON extends BaseTestCase {
 		$this->assertFileExists( $this->temp_dir . '/' . $key . '.json', 'Wrapper should write the file' );
 	}
 
+	/**
+	 * Test a restricted multisite save is denied by default without recording a filesystem failure.
+	 */
+	public function test_multisite_save_is_denied_by_default_without_failure_notice_state() {
+		$key = 'group_multisite_default_deny';
+		$this->write_json_file(
+			$key . '.json',
+			array(
+				'key'    => $key,
+				'title'  => 'Canary',
+				'fields' => array(),
+			)
+		);
+
+		$json = $this->get_restricted_json_instance();
+		$json->scan_files();
+
+		$result = $json->save_file(
+			$key,
+			array(
+				'ID'     => 0,
+				'key'    => $key,
+				'title'  => 'Attempted Overwrite',
+				'fields' => array(),
+			)
+		);
+		$data   = json_decode( file_get_contents( $this->temp_dir . '/' . $key . '.json' ), true );
+
+		$this->assertFalse( $result, 'Restricted multisite saves should be denied without an opt-in' );
+		$this->assertSame( 'Canary', $data['title'], 'The existing JSON file should not be overwritten' );
+		$this->assertFalse( $json->has_save_file_failure(), 'An authorization denial should not trigger the filesystem warning' );
+	}
+
+	/**
+	 * Test a restricted multisite save succeeds inside the site's uploads directory.
+	 */
+	public function test_multisite_save_allows_directory_inside_site_uploads() {
+		$key         = 'group_multisite_uploads_allowed';
+		$uploads_dir = $this->temp_dir . '/uploads';
+		$json_dir    = $uploads_dir . '/scf-json';
+		mkdir( $uploads_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		mkdir( $json_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+
+		$uploads_filter = $this->use_uploads_basedir( $uploads_dir );
+		$save_paths     = function () use ( $json_dir ) {
+			return array( $json_dir );
+		};
+		add_filter( 'acf/json/save_paths', $save_paths, 100 );
+
+		$result = $this->get_restricted_json_instance()->save_file(
+			$key,
+			array(
+				'ID'     => 0,
+				'key'    => $key,
+				'title'  => 'Uploads Allowed',
+				'fields' => array(),
+			)
+		);
+
+		remove_filter( 'acf/json/save_paths', $save_paths, 100 );
+		remove_filter( 'upload_dir', $uploads_filter );
+
+		$this->assertTrue( $result, 'A save path inside the site uploads directory should be writable' );
+		$this->assertFileExists( $json_dir . '/' . $key . '.json', 'The JSON file should be written inside the uploads directory' );
+	}
+
+	/**
+	 * Test a restricted multisite save is denied inside the sites subdirectory of the uploads directory.
+	 *
+	 * On the main site of a subdirectory multisite, uploads/sites/{id} holds the
+	 * other sites' files, so it must never satisfy the containment policy.
+	 */
+	public function test_multisite_save_denies_other_site_uploads_subtree() {
+		$key         = 'group_multisite_other_site';
+		$uploads_dir = $this->temp_dir . '/uploads';
+		$other_site  = $uploads_dir . '/sites/2';
+		mkdir( $other_site, 0777, true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+
+		$uploads_filter = $this->use_uploads_basedir( $uploads_dir );
+		$save_paths     = function () use ( $other_site ) {
+			return array( $other_site );
+		};
+		add_filter( 'acf/json/save_paths', $save_paths, 100 );
+
+		$result = $this->get_restricted_json_instance()->save_file(
+			$key,
+			array(
+				'ID'     => 0,
+				'key'    => $key,
+				'title'  => 'Cross Site Escape',
+				'fields' => array(),
+			)
+		);
+
+		remove_filter( 'acf/json/save_paths', $save_paths, 100 );
+		remove_filter( 'upload_dir', $uploads_filter );
+
+		$this->assertFalse( $result, 'The sites subtree of the uploads directory should never be writable' );
+		$this->assertFileDoesNotExist( $other_site . '/' . $key . '.json', 'No file should be written into another site\'s uploads directory' );
+	}
+
+	/**
+	 * Test only save paths inside the site's uploads directory participate in multisite save routing.
+	 */
+	public function test_multisite_save_routes_among_authorized_paths_only() {
+		$key         = 'group_multisite_routing';
+		$uploads_dir = $this->temp_dir . '/uploads';
+		$first_dir   = $uploads_dir . '/first';
+		$last_dir    = $uploads_dir . '/last';
+		$blocked_dir = $uploads_dir . '-other';
+		mkdir( $uploads_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		mkdir( $blocked_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		mkdir( $first_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		mkdir( $last_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+
+		file_put_contents( $blocked_dir . '/' . $key . '.json', acf_json_encode( array( 'title' => 'Blocked Canary' ) ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture.
+		file_put_contents( $last_dir . '/' . $key . '.json', acf_json_encode( array( 'title' => 'Authorized Existing' ) ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture.
+
+		$uploads_filter = $this->use_uploads_basedir( $uploads_dir );
+		$save_paths     = function () use ( $blocked_dir, $first_dir, $last_dir ) {
+			// Non-canonical entries must still resolve to their authorized directories.
+			return array( $first_dir . '/.', $last_dir . '/../last', $blocked_dir );
+		};
+		add_filter( 'acf/json/save_paths', $save_paths, 100 );
+
+		$result = $this->get_restricted_json_instance()->save_file(
+			$key,
+			array(
+				'ID'     => 0,
+				'key'    => $key,
+				'title'  => 'Updated',
+				'fields' => array(),
+			)
+		);
+
+		remove_filter( 'acf/json/save_paths', $save_paths, 100 );
+		remove_filter( 'upload_dir', $uploads_filter );
+
+		$blocked_data = json_decode( file_get_contents( $blocked_dir . '/' . $key . '.json' ), true );
+		$last_data    = json_decode( file_get_contents( $last_dir . '/' . $key . '.json' ), true );
+
+		$this->assertTrue( $result, 'The save should succeed through an authorized path' );
+		$this->assertSame( 'Blocked Canary', $blocked_data['title'], 'A prefix-matching sibling of the uploads directory should not be overwritten' );
+		$this->assertFileDoesNotExist( $first_dir . '/' . $key . '.json', 'The existing authorized destination should retain the current routing precedence' );
+		$this->assertSame( 'Updated', $last_data['title'], 'The last existing authorized destination should be updated' );
+	}
+
 	// =========================================================================
 	// Deleting field groups
 	// =========================================================================
@@ -507,6 +699,210 @@ class Test_Local_JSON extends BaseTestCase {
 
 		$this->assertTrue( $result, 'Wrapper should return true' );
 		$this->assertFileDoesNotExist( $this->temp_dir . '/' . $key . '.json', 'Wrapper should delete the file' );
+	}
+
+	/**
+	 * Test multisite delete authorization is evaluated for each save path.
+	 */
+	public function test_multisite_delete_only_removes_files_from_allowed_paths() {
+		$key         = 'group_multisite_delete_paths';
+		$uploads_dir = $this->temp_dir . '/uploads';
+		$allowed_dir = $uploads_dir . '/allowed-delete';
+		$blocked_dir = $this->temp_dir . '/blocked-delete';
+		mkdir( $uploads_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		mkdir( $allowed_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		mkdir( $blocked_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		file_put_contents( $allowed_dir . '/' . $key . '.json', '{}' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture.
+		file_put_contents( $blocked_dir . '/' . $key . '.json', '{}' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture.
+
+		$uploads_filter = $this->use_uploads_basedir( $uploads_dir );
+		$save_paths     = function () use ( $blocked_dir, $allowed_dir ) {
+			return array( $blocked_dir, $allowed_dir );
+		};
+		add_filter( 'acf/json/save_paths', $save_paths, 100 );
+
+		$result = $this->get_restricted_json_instance()->delete_file( $key );
+
+		remove_filter( 'acf/json/save_paths', $save_paths, 100 );
+		remove_filter( 'upload_dir', $uploads_filter );
+
+		$this->assertTrue( $result, 'Delete should preserve its existing return contract' );
+		$this->assertFileExists( $blocked_dir . '/' . $key . '.json', 'The file outside the uploads directory should remain' );
+		$this->assertFileDoesNotExist( $allowed_dir . '/' . $key . '.json', 'The file inside the uploads directory should be deleted' );
+	}
+
+	/**
+	 * Test the final path from WordPress's delete filter is also authorized.
+	 */
+	public function test_multisite_delete_authorizes_final_filtered_destination() {
+		$allowed_key         = 'group_multisite_allowed_filtered_delete';
+		$blocked_key         = 'group_multisite_blocked_filtered_delete';
+		$uploads_dir         = $this->temp_dir . '/uploads';
+		$allowed_dir         = $uploads_dir . '/allowed-filtered-delete';
+		$blocked_dir         = $this->temp_dir . '/blocked-filtered-delete';
+		$allowed_source      = $allowed_dir . '/' . $allowed_key . '.json';
+		$blocked_source      = $allowed_dir . '/' . $blocked_key . '.json';
+		$allowed_destination = $allowed_dir . '/allowed-destination.json';
+		$blocked_destination = $blocked_dir . '/blocked-destination.json';
+		mkdir( $uploads_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		mkdir( $allowed_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		mkdir( $blocked_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		file_put_contents( $allowed_source, '{}' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture.
+		file_put_contents( $blocked_source, '{}' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture.
+		file_put_contents( $allowed_destination, '{}' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture.
+		file_put_contents( $blocked_destination, '{}' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture.
+
+		$uploads_filter  = $this->use_uploads_basedir( $uploads_dir );
+		$save_paths      = function () use ( $allowed_dir ) {
+			return array( $allowed_dir );
+		};
+		$destinations    = array( $allowed_destination, $blocked_destination );
+		$redirect_delete = function () use ( &$destinations ) {
+			return array_shift( $destinations );
+		};
+		add_filter( 'acf/json/save_paths', $save_paths, 100 );
+		add_filter( 'wp_delete_file', $redirect_delete, 10, 0 );
+
+		$json = $this->get_restricted_json_instance();
+		$json->delete_file( $allowed_key );
+		$json->delete_file( $blocked_key );
+
+		remove_filter( 'acf/json/save_paths', $save_paths, 100 );
+		remove_filter( 'wp_delete_file', $redirect_delete );
+		remove_filter( 'upload_dir', $uploads_filter );
+
+		$this->assertFileExists( $allowed_source, 'The first original file should remain after an allowed redirect' );
+		$this->assertFileDoesNotExist( $allowed_destination, 'A filtered destination in the allowed directory should be deleted' );
+		$this->assertFileExists( $blocked_source, 'The second original file should remain after a denied redirect' );
+		$this->assertFileExists( $blocked_destination, 'A filtered destination outside the allowlist should not be deleted' );
+	}
+
+	/**
+	 * Test save and delete authorization handle symlink targets according to the mutation.
+	 */
+	public function test_multisite_authorization_handles_symlinks_safely() {
+		if ( ! function_exists( 'symlink' ) ) {
+			$this->markTestSkipped( 'Symlinks are not supported in this environment.' );
+		}
+
+		$key                  = 'group_multisite_symlink';
+		$directory_escape_key = 'group_multisite_directory_symlink';
+		$uploads_dir          = $this->temp_dir . '/uploads';
+		$allowed_dir          = $uploads_dir . '/allowed-symlink';
+		$blocked_dir          = $this->temp_dir . '/blocked-symlink';
+		$target_dir           = $this->temp_dir . '/symlink-targets';
+		$directory_link       = $allowed_dir . '/directory-link';
+		mkdir( $uploads_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		mkdir( $allowed_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		mkdir( $blocked_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		mkdir( $target_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+
+		$outside_target = $target_dir . '/outside.json';
+		$allowed_target = $allowed_dir . '/allowed-target.json';
+		file_put_contents( $outside_target, 'outside-canary' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture.
+		file_put_contents( $allowed_target, 'allowed-canary' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture.
+		symlink( $outside_target, $allowed_dir . '/' . $key . '.json' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_symlink -- test fixture.
+		symlink( $allowed_target, $blocked_dir . '/' . $key . '.json' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_symlink -- test fixture.
+		$this->assertTrue(
+			symlink( $target_dir, $directory_link ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_symlink -- test fixture.
+			'Could not create the directory symlink fixture'
+		);
+
+		$uploads_filter      = $this->use_uploads_basedir( $uploads_dir );
+		$allowed_save_path   = function () use ( $allowed_dir ) {
+			return array( $allowed_dir );
+		};
+		$directory_save_path = function () use ( $directory_link ) {
+			return array( $directory_link );
+		};
+		$all_delete_paths    = function () use ( $blocked_dir, $allowed_dir ) {
+			return array( $blocked_dir, $allowed_dir );
+		};
+		add_filter( 'acf/json/save_paths', $allowed_save_path, 100 );
+
+		$save_result = $this->get_restricted_json_instance()->save_file(
+			$key,
+			array(
+				'ID'     => 0,
+				'key'    => $key,
+				'title'  => 'Symlink Escape',
+				'fields' => array(),
+			)
+		);
+
+		remove_filter( 'acf/json/save_paths', $allowed_save_path, 100 );
+		add_filter( 'acf/json/save_paths', $directory_save_path, 100 );
+
+		$directory_save_result = $this->get_restricted_json_instance()->save_file(
+			$directory_escape_key,
+			array(
+				'ID'     => 0,
+				'key'    => $directory_escape_key,
+				'title'  => 'Directory Symlink Escape',
+				'fields' => array(),
+			)
+		);
+
+		remove_filter( 'acf/json/save_paths', $directory_save_path, 100 );
+		add_filter( 'acf/json/save_paths', $all_delete_paths, 100 );
+
+		$delete_result = $this->get_restricted_json_instance()->delete_file( $key );
+
+		remove_filter( 'acf/json/save_paths', $all_delete_paths, 100 );
+		remove_filter( 'upload_dir', $uploads_filter );
+
+		$this->assertFalse( $save_result, 'A save symlinked outside the allowed directory should be denied' );
+		$this->assertSame( 'outside-canary', file_get_contents( $outside_target ), 'The external save target should not be overwritten' );
+		$this->assertFalse( $directory_save_result, 'A save through a symlinked directory should be denied' );
+		$this->assertFileDoesNotExist( $target_dir . '/' . $directory_escape_key . '.json', 'A symlinked directory should not create a file outside the allowlist' );
+		$this->assertTrue( $delete_result, 'Delete should preserve its existing return contract' );
+		$this->assertFalse( is_link( $allowed_dir . '/' . $key . '.json' ), 'A symlink located in an allowed directory may be unlinked' );
+		$this->assertFileExists( $outside_target, 'Deleting an allowed symlink should not delete its target' );
+		$this->assertTrue( is_link( $blocked_dir . '/' . $key . '.json' ), 'A symlink located in an unauthorized directory should remain' );
+		$this->assertSame( 'allowed-canary', file_get_contents( $allowed_target ), 'The unauthorized delete target should remain unchanged' );
+	}
+
+	/**
+	 * Test a broken file symlink cannot redirect a save outside the allowed directory.
+	 */
+	public function test_multisite_save_denies_broken_file_symlink() {
+		if ( ! function_exists( 'symlink' ) ) {
+			$this->markTestSkipped( 'Symlinks are not supported in this environment.' );
+		}
+
+		$key            = 'group_multisite_broken_symlink';
+		$uploads_dir    = $this->temp_dir . '/uploads';
+		$allowed_dir    = $uploads_dir . '/allowed-broken-symlink';
+		$outside_dir    = $this->temp_dir . '/outside-broken-symlink';
+		$outside_target = $outside_dir . '/created-through-link.json';
+		mkdir( $uploads_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		mkdir( $allowed_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		mkdir( $outside_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		$file = $allowed_dir . '/' . $key . '.json';
+		symlink( $outside_target, $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_symlink -- test fixture.
+
+		$uploads_filter = $this->use_uploads_basedir( $uploads_dir );
+		$save_paths     = function () use ( $allowed_dir ) {
+			return array( $allowed_dir );
+		};
+		add_filter( 'acf/json/save_paths', $save_paths, 100 );
+
+		$result = $this->get_restricted_json_instance()->save_file(
+			$key,
+			array(
+				'ID'     => 0,
+				'key'    => $key,
+				'title'  => 'Broken Symlink Escape',
+				'fields' => array(),
+			)
+		);
+
+		remove_filter( 'acf/json/save_paths', $save_paths, 100 );
+		remove_filter( 'upload_dir', $uploads_filter );
+
+		$this->assertFalse( $result, 'A broken file symlink should not be authorized for saving' );
+		$this->assertTrue( is_link( $file ), 'The broken symlink should remain untouched' );
+		$this->assertFileDoesNotExist( $outside_target, 'The broken symlink should not create its external target' );
 	}
 
 	// =========================================================================


### PR DESCRIPTION
This PR brings trunk in sync with the defensive hardening improvements released in SCF 6.9.3.

- Harden REST field value formatting
- Harden block template resolution
- Harden relational field query results
- Harden Options Page save scoping
- Harden multisite Local JSON write scoping
- Sync the 6.9.3 changelog, generated documentation, and version metadata

## Use of AI Tools

Codex and Claude were used to implement these changes, guided and reviewed by @ockham and me.
