### PR TITLE
e2e tests: Fix E2E selectors for WordPress trunk list tables

### DIFF
--- a/tests/e2e/import-export.spec.ts
+++ b/tests/e2e/import-export.spec.ts
@@ -684,7 +684,7 @@ test.describe( 'Import/Export', () => {
 			} );
 
 			await groupRow
-				.locator( 'th.check-column input[type="checkbox"]' )
+				.locator( '.check-column input[type="checkbox"]' )
 				.check();
 			await page.selectOption( '#bulk-action-selector-bottom', 'trash' );
 			await page.click( '#doaction2' );
@@ -867,7 +867,7 @@ test.describe( 'Import/Export', () => {
 				`#the-list tr:has-text("${ uniqueName }")`
 			);
 			await ptRow
-				.locator( 'th.check-column input[type="checkbox"]' )
+				.locator( '.check-column input[type="checkbox"]' )
 				.check();
 			await page.selectOption( '#bulk-action-selector-bottom', 'trash' );
 			await page.click( '#doaction2' );
@@ -934,7 +934,7 @@ test.describe( 'Import/Export', () => {
 			);
 			if ( await cleanupRow.isVisible().catch( () => false ) ) {
 				await cleanupRow
-					.locator( 'th.check-column input[type="checkbox"]' )
+					.locator( '.check-column input[type="checkbox"]' )
 					.check();
 				await page.selectOption(
 					'#bulk-action-selector-bottom',
@@ -1026,7 +1026,7 @@ test.describe( 'Import/Export', () => {
 				`#the-list tr:has-text("${ uniqueName }")`
 			);
 			await taxRow
-				.locator( 'th.check-column input[type="checkbox"]' )
+				.locator( '.check-column input[type="checkbox"]' )
 				.check();
 			await page.selectOption( '#bulk-action-selector-bottom', 'trash' );
 			await page.click( '#doaction2' );
@@ -1093,7 +1093,7 @@ test.describe( 'Import/Export', () => {
 			);
 			if ( await cleanupRow.isVisible().catch( () => false ) ) {
 				await cleanupRow
-					.locator( 'th.check-column input[type="checkbox"]' )
+					.locator( '.check-column input[type="checkbox"]' )
 					.check();
 				await page.selectOption(
 					'#bulk-action-selector-bottom',
@@ -1190,7 +1190,7 @@ test.describe( 'Import/Export', () => {
 				`#the-list tr:has-text("${ uniqueName }")`
 			);
 			await optRow
-				.locator( 'th.check-column input[type="checkbox"]' )
+				.locator( '.check-column input[type="checkbox"]' )
 				.check();
 			await page.selectOption( '#bulk-action-selector-bottom', 'trash' );
 			await page.click( '#doaction2' );
@@ -1266,7 +1266,7 @@ test.describe( 'Import/Export', () => {
 			);
 			if ( await cleanupRow.isVisible().catch( () => false ) ) {
 				await cleanupRow
-					.locator( 'th.check-column input[type="checkbox"]' )
+					.locator( '.check-column input[type="checkbox"]' )
 					.check();
 				await page.selectOption(
 					'#bulk-action-selector-bottom',
@@ -1404,7 +1404,7 @@ test.describe( 'Import/Export', () => {
 				);
 				if ( await cleanupRow.isVisible().catch( () => false ) ) {
 					await cleanupRow
-						.locator( 'th.check-column input[type="checkbox"]' )
+						.locator( '.check-column input[type="checkbox"]' )
 						.check();
 					await page.selectOption(
 						'#bulk-action-selector-bottom',
@@ -1540,7 +1540,7 @@ test.describe( 'Import/Export', () => {
 				);
 				if ( await cleanupRow.isVisible().catch( () => false ) ) {
 					await cleanupRow
-						.locator( 'th.check-column input[type="checkbox"]' )
+						.locator( '.check-column input[type="checkbox"]' )
 						.check();
 					await page.selectOption(
 						'#bulk-action-selector-bottom',
@@ -1671,7 +1671,7 @@ test.describe( 'Import/Export', () => {
 				);
 				if ( await cleanupRow.isVisible().catch( () => false ) ) {
 					await cleanupRow
-						.locator( 'th.check-column input[type="checkbox"]' )
+						.locator( '.check-column input[type="checkbox"]' )
 						.check();
 					await page.selectOption(
 						'#bulk-action-selector-bottom',
@@ -1743,7 +1743,7 @@ async function cleanupTestEntities( page, admin ) {
 		`#the-list tr:has-text("${ TEST_POST_TYPE_NAME }")`
 	);
 	if ( await ptRow.isVisible().catch( () => false ) ) {
-		await ptRow.locator( 'th.check-column input[type="checkbox"]' ).check();
+		await ptRow.locator( '.check-column input[type="checkbox"]' ).check();
 		await page.selectOption( '#bulk-action-selector-bottom', 'trash' );
 		await page.click( '#doaction2' );
 		await page.waitForLoadState( 'networkidle' );
@@ -1768,9 +1768,7 @@ async function cleanupTestEntities( page, admin ) {
 		`#the-list tr:has-text("${ TEST_TAXONOMY_NAME }")`
 	);
 	if ( await taxRow.isVisible().catch( () => false ) ) {
-		await taxRow
-			.locator( 'th.check-column input[type="checkbox"]' )
-			.check();
+		await taxRow.locator( '.check-column input[type="checkbox"]' ).check();
 		await page.selectOption( '#bulk-action-selector-bottom', 'trash' );
 		await page.click( '#doaction2' );
 		await page.waitForLoadState( 'networkidle' );

--- a/tests/e2e/options-page-admin.spec.ts
+++ b/tests/e2e/options-page-admin.spec.ts
@@ -197,7 +197,7 @@ test.describe( 'Options Page Admin', () => {
 				timeout: DEFAULT_TIMEOUT,
 			} );
 			await optionsPageRow
-				.locator( 'th.check-column input[type="checkbox"]' )
+				.locator( '.check-column input[type="checkbox"]' )
 				.check();
 			await page.selectOption( '#bulk-action-selector-bottom', 'trash' );
 			await page.click( '#doaction2' );

--- a/tests/e2e/post-type-admin.spec.ts
+++ b/tests/e2e/post-type-admin.spec.ts
@@ -453,9 +453,7 @@ async function deletePostType( page, admin, postTypeName = POST_TYPE_NAME ) {
 		`tr.type-acf-post-type:has(a.row-title:text("${ postTypeName }"))`
 	);
 	await expect( postTypeRow ).toBeVisible( { timeout: DEFAULT_TIMEOUT } );
-	await postTypeRow
-		.locator( 'th.check-column input[type="checkbox"]' )
-		.check();
+	await postTypeRow.locator( '.check-column input[type="checkbox"]' ).check();
 
 	// Use bulk actions to trash the post type
 	await page.selectOption( '#bulk-action-selector-bottom', 'trash' );
@@ -482,9 +480,7 @@ async function restorePostType( page, admin, postTypeName = POST_TYPE_NAME ) {
 		hasText: postTypeName,
 	} );
 	await expect( postTypeRow ).toBeVisible( { timeout: DEFAULT_TIMEOUT } );
-	await postTypeRow
-		.locator( 'th.check-column input[type="checkbox"]' )
-		.check();
+	await postTypeRow.locator( '.check-column input[type="checkbox"]' ).check();
 
 	// Use bulk actions to restore
 	await page.selectOption( '#bulk-action-selector-bottom', 'untrash' );
@@ -557,7 +553,7 @@ async function trashEntityByName( page, admin, postType, entityName ) {
 	const entityRow = page.locator( '#the-list tr', { hasText: entityName } );
 	if ( await entityRow.isVisible( { timeout: 1000 } ).catch( () => false ) ) {
 		await entityRow
-			.locator( 'th.check-column input[type="checkbox"]' )
+			.locator( '.check-column input[type="checkbox"]' )
 			.check();
 		await page.selectOption( '#bulk-action-selector-bottom', 'trash' );
 		await page.click( '#doaction2' );


### PR DESCRIPTION
## What

Update the E2E row-checkbox selectors to work with both the `<th>` markup used by released WordPress versions and the `<td>` markup now used by WordPress trunk.

## Why

WordPress Core changed list-table checkbox cells from `<th>` to `<td>` in [ae5d691](https://github.com/WordPress/WordPress/commit/ae5d6915c157c752421fab2f16389c1de455ac92). The existing element-specific selector no longer finds those checkboxes on trunk, which breaks cleanup and allows retries to accumulate duplicate records.

## Testing Instructions

- `git diff --check`
- `npx wp-scripts lint-js tests/e2e/import-export.spec.ts tests/e2e/options-page-admin.spec.ts tests/e2e/post-type-admin.spec.ts`
- E2E tests were not run locally.

## Use of AI Tools

I used OpenAI Codex to update the selectors. I reviewed the diff and test results.
