### PR TITLE
fix: align Option meta backend with MetaLocation base

### DIFF
--- a/includes/Meta/Option.php
+++ b/includes/Meta/Option.php
@@ -41,8 +41,8 @@ class Option extends MetaLocation {
 			}
 		}
 
-		// Return results.
-		return $meta;
+		// Unserialize results and return.
+		return array_map( 'acf_maybe_unserialize', $meta );
 	}
 
 	/**
@@ -84,7 +84,6 @@ class Option extends MetaLocation {
 		$autoload = (bool) acf_get_setting( 'autoload' );
 
 		foreach ( $meta as $name => $value ) {
-			$value = wp_unslash( $value );
 			update_option( $object_id . '_' . $name, $value, $autoload );
 		}
 	}

--- a/tests/php/includes/meta/test-meta-locations.php
+++ b/tests/php/includes/meta/test-meta-locations.php
@@ -786,20 +786,17 @@ class Test_Meta_Locations extends BaseTestCase {
 		$this->assertSame( 'field_color', $meta['_color'] );
 		$this->assertArrayNotHasKey( 'orphan', $meta );
 
-		// NOTE: documents current behavior — possible bug: unlike
-		// MetaLocation::get_meta(), Option::get_meta() does not run values
-		// through acf_maybe_unserialize(), so serialized arrays are returned
-		// as raw serialized strings. Tracked in #454.
-		$this->assertSame( $serialized_array, $meta['list'] );
+		// Serialized values are unserialized on read, matching MetaLocation.
+		$this->assertSame( array( 'a', 'b' ), $meta['list'] );
 
 		// acf_get_meta( 'options' ) routes to the same backend.
 		$this->assertSame( $meta, acf_get_meta( 'options' ) );
 	}
 
 	/**
-	 * Test Option::update_meta() unslashing behavior.
+	 * Test Option::update_meta() preserves backslashes.
 	 */
-	public function test_option_update_meta_unslashes_values() {
+	public function test_option_update_meta_preserves_slashes() {
 		$instance = acf_get_meta_instance( 'option' );
 
 		$instance->update_meta(
@@ -812,12 +809,9 @@ class Test_Meta_Locations extends BaseTestCase {
 
 		$this->assertSame( 'value1', get_option( 'options_plain' ) );
 
-		// NOTE: documents current behavior — possible bug: Option::update_meta()
-		// calls wp_unslash() on the raw values while MetaLocation::update_meta()
-		// wp_slash()es them before update_metadata(), so values containing
-		// backslashes lose them when copied to an option location
-		// (e.g. via acf_copy_metadata() to an options page). Tracked in #454.
-		$this->assertSame( 'C:tempnew', get_option( 'options_slashy' ) );
+		// Unlike MetaLocation::update_meta(), update_option() does not unslash
+		// internally, so values are stored as-is and backslashes are preserved.
+		$this->assertSame( 'C:\\temp\\new', get_option( 'options_slashy' ) );
 	}
 
 	// =========================================================================


### PR DESCRIPTION
<!-- Thanks for contributing to Secure Custom Fields (SCF)! Please have a look at the Contributing Guidelines:
https://github.com/WordPress/secure-custom-fields/blob/trunk/docs/contributing/index.md -->

Aligns the option meta backend with the `MetaLocation` base class so serialized values and backslashes behave consistently across all meta locations.

- `Option::get_meta()` now runs values through `acf_maybe_unserialize()`, matching `MetaLocation::get_meta()`. `acf_get_meta( 'options' )` now returns arrays instead of raw serialized strings.
- `Option::update_meta()` no longer calls `wp_unslash()` on values. `update_metadata()` unslashes internally (which is why the base class `wp_slash()`es first), but `update_option()` does not unslash, so values must be stored as-is. This preserves backslashes during `acf_copy_metadata()` to an options page (`C:\temp\new` no longer becomes `C:tempnew`).

Closes #454

## Use of AI Tools

This implementation was developed with the assistance of an AI coding assistant (OpenCode) to investigate the root cause and write the fix. The code and tests were reviewed and verified by the author.

## Testing

- `composer test:php -- --filter=Test_Meta_Locations` — 27 tests / 151 assertions, all green
- `vendor/bin/phpcs includes/Meta/Option.php tests/php/includes/meta/test-meta-locations.php` — 0 errors
- `vendor/bin/phpstan analyze includes/Meta/Option.php tests/php/includes/meta/test-meta-locations.php` — 0 errors
- `npm run build` — clean build (2 pre-existing Sass deprecation warnings)
