### PR TITLE
docs: clarify changelog is maintained by hand

### DIFF
--- a/docs/contributing/releases.md
+++ b/docs/contributing/releases.md
@@ -21,7 +21,7 @@ Using SVN for WordPress.org plugin releases is covered in more detail in <https:
 
 ## Changelog
 
-Before running the `prepare-release` script (see below), ensure the changelog entry for the new version exists in `readme.txt`:
+The changelog is maintained by hand. It is a section in `readme.txt`, not a separate `CHANGELOG.md` file, and there is no automated tool that generates it. A maintainer writes the entry for each new version before running the `prepare-release` script (see below). Entries group changes under categories such as `Feature:` and `Fix:`:
 
 ```md
 == Changelog ==
@@ -30,6 +30,8 @@ Before running the `prepare-release` script (see below), ensure the changelog en
 * Feature: Description of new feature
 * Fix: Description of bug fix
 ```
+
+The milestone automation described below only assigns merged pull requests to the next release milestone, which makes it easier to gather changes when writing release notes. It does not produce the changelog text. Generating the changelog automatically is a separate open project.
 
 ## Configure the Next Milestone
 


### PR DESCRIPTION
Clarify the changelog is maintained by hand and not generated by an automated tool.

The Changelog section of the release guide described the entry format ([`== Changelog ==`](./readme.txt) in `readme.txt`) but never stated how the changelog is actually maintained. Contributions to the repo keep asking how the changelog updates automatically, and there is no `CHANGELOG.md` or release automation publishing text to it.

This adds a short note to `docs/contributing/releases.md` stating:

- The changelog lives in `readme.txt` and is written by hand by a maintainer before each release.
- No automated tool generates the changelog text.
- The milestone workflow only assigns merged pull requests to the next milestone to make gathering changes easier; it does not produce release notes.

Closes #497