### PR TITLE
Update tested up to WordPress 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg
 Tags: fields, custom fields, meta, scf
 Requires at least: 6.2
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 6.9.5
 License: GPLv2 or later


### PR DESCRIPTION
Updates the `Tested up to` header in `readme.txt` to WordPress 7.1.

Readme header only — no functional changes.

## Testing instructions

* Verify `readme.txt` shows `Tested up to: 7.1`.

## Use of AI Tools

AI-assistant review of all plugins to bump to the new tested to version. Reviewed by me before submission.
