### PR TITLE
Add beta feature settings for datastore, ACF AI, schema

### DIFF
--- a/includes/admin/beta-features.php
+++ b/includes/admin/beta-features.php
@@ -139,6 +139,10 @@ if ( ! class_exists( 'SCF_Admin_Beta_Features' ) ) :
 		private function include_beta_features() {
 			acf_include( 'includes/admin/beta-features/class-scf-beta-feature.php' );
 			acf_include( 'includes/admin/beta-features/class-scf-beta-feature-connect-fields.php' );
+			acf_include( 'includes/admin/beta-features/class-scf-beta-feature-editor-sidebar.php' );
+			acf_include( 'includes/admin/beta-features/class-scf-beta-feature-datastore.php' );
+			acf_include( 'includes/admin/beta-features/class-scf-beta-feature-acf-ai.php' );
+			acf_include( 'includes/admin/beta-features/class-scf-beta-feature-schema.php' );
 
 			add_action( 'scf/include_admin_beta_features', array( $this, 'register_beta_features' ) );
 
@@ -153,6 +157,10 @@ if ( ! class_exists( 'SCF_Admin_Beta_Features' ) ) :
 		 * @return  void
 		 */
 		public function register_beta_features() {
+			$this->register_beta_feature( 'SCF_Admin_Beta_Feature_Editor_Sidebar' );
+			$this->register_beta_feature( 'SCF_Admin_Beta_Feature_Datastore' );
+			$this->register_beta_feature( 'SCF_Admin_Beta_Feature_ACF_AI' );
+			$this->register_beta_feature( 'SCF_Admin_Beta_Feature_Schema' );
 		}
 
 		/**

--- a/includes/admin/beta-features/class-scf-beta-feature-acf-ai.php
+++ b/includes/admin/beta-features/class-scf-beta-feature-acf-ai.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * ACF AI Beta Feature
+ *
+ * This beta feature enables ACF AI support.
+ *
+ * @package    Secure Custom Fields
+ * @since      SCF 6.9.5
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+if ( ! class_exists( 'SCF_Admin_Beta_Feature_ACF_AI' ) ) :
+	/**
+	 * Class SCF_Admin_Beta_Feature_ACF_AI
+	 *
+	 * Implements a beta feature to enable ACF AI support.
+	 *
+	 * @package    Secure Custom Fields
+	 * @since      SCF 6.9.5
+	 */
+	class SCF_Admin_Beta_Feature_ACF_AI extends SCF_Admin_Beta_Feature {
+
+		/**
+		 * Initialize the beta feature.
+		 *
+		 * @return void
+		 */
+		protected function initialize() {
+			$this->name        = 'enable_acf_ai';
+			$this->title       = __( 'Enable ACF AI', 'secure-custom-fields' );
+			$this->description = __( 'Enables ACF AI support.', 'secure-custom-fields' );
+		}
+	}
+endif;

--- a/includes/admin/beta-features/class-scf-beta-feature-datastore.php
+++ b/includes/admin/beta-features/class-scf-beta-feature-datastore.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Datastore Beta Feature
+ *
+ * This beta feature enables the SCF datastore.
+ *
+ * @package    Secure Custom Fields
+ * @since      SCF 6.9.5
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+if ( ! class_exists( 'SCF_Admin_Beta_Feature_Datastore' ) ) :
+	/**
+	 * Class SCF_Admin_Beta_Feature_Datastore
+	 *
+	 * Implements a beta feature to enable the SCF datastore.
+	 *
+	 * @package    Secure Custom Fields
+	 * @since      SCF 6.9.5
+	 */
+	class SCF_Admin_Beta_Feature_Datastore extends SCF_Admin_Beta_Feature {
+
+		/**
+		 * Initialize the beta feature.
+		 *
+		 * @return void
+		 */
+		protected function initialize() {
+			$this->name        = 'enable_datastore';
+			$this->title       = __( 'Enable Datastore', 'secure-custom-fields' );
+			$this->description = __( 'Enables the SCF datastore for supported WordPress versions.', 'secure-custom-fields' );
+		}
+	}
+endif;

--- a/includes/admin/beta-features/class-scf-beta-feature-schema.php
+++ b/includes/admin/beta-features/class-scf-beta-feature-schema.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Schema Beta Feature
+ *
+ * This beta feature enables schema support.
+ *
+ * @package    Secure Custom Fields
+ * @since      SCF 6.9.5
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+if ( ! class_exists( 'SCF_Admin_Beta_Feature_Schema' ) ) :
+	/**
+	 * Class SCF_Admin_Beta_Feature_Schema
+	 *
+	 * Implements a beta feature to enable schema support.
+	 *
+	 * @package    Secure Custom Fields
+	 * @since      SCF 6.9.5
+	 */
+	class SCF_Admin_Beta_Feature_Schema extends SCF_Admin_Beta_Feature {
+
+		/**
+		 * Initialize the beta feature.
+		 *
+		 * @return void
+		 */
+		protected function initialize() {
+			$this->name        = 'enable_schema';
+			$this->title       = __( 'Enable Schema Support', 'secure-custom-fields' );
+			$this->description = __( 'Enables schema support.', 'secure-custom-fields' );
+		}
+	}
+endif;

--- a/includes/beta-features.php
+++ b/includes/beta-features.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Beta feature runtime settings.
+ *
+ * Bridges each stored beta-feature option to its runtime filter so the toggle
+ * in wp-admin works alongside the existing PHP filters.
+ *
+ * @package wordpress/secure-custom-fields
+ * @since SCF 6.9.5
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Enable a setting when its beta feature is enabled.
+ *
+ * Existing filter callbacks remain in the filter chain, so this adds the
+ * beta-feature option as another way to enable the setting.
+ *
+ * @since SCF 6.9.5
+ *
+ * @param bool   $enabled The current setting value.
+ * @param string $name    The beta feature name.
+ * @return bool
+ */
+function scf_enable_beta_feature_setting( $enabled, $name ) {
+	return (bool) $enabled || (bool) get_option( 'scf_beta_feature_' . $name . '_enabled', false );
+}
+
+add_filter(
+	'acf/settings/enable_datastore',
+	function ( $enabled ) {
+		return scf_enable_beta_feature_setting( $enabled, 'enable_datastore' );
+	}
+);
+add_filter(
+	'acf/settings/enable_acf_ai',
+	function ( $enabled ) {
+		return scf_enable_beta_feature_setting( $enabled, 'enable_acf_ai' );
+	}
+);
+add_filter(
+	'acf/settings/enable_schema',
+	function ( $enabled ) {
+		return scf_enable_beta_feature_setting( $enabled, 'enable_schema' );
+	}
+);

--- a/secure-custom-fields.php
+++ b/secure-custom-fields.php
@@ -259,6 +259,7 @@ if ( ! class_exists( 'ACF' ) ) {
 			acf_include( 'includes/validation.php' );
 			acf_include( 'includes/rest-api.php' );
 			acf_include( 'includes/datastore.php' );
+			acf_include( 'includes/beta-features.php' );
 			acf_include( 'includes/blocks.php' );
 			acf_include( 'includes/class-acf-options-page.php' );
 
@@ -970,6 +971,9 @@ function scf_plugin_uninstall() {
 	// List of known beta features.
 	$beta_features = array(
 		'editor_sidebar',
+		'enable_datastore',
+		'enable_acf_ai',
+		'enable_schema',
 	);
 
 	foreach ( $beta_features as $beta_feature ) {

--- a/tests/php/includes/SCFBetaFeaturesTest.php
+++ b/tests/php/includes/SCFBetaFeaturesTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Tests for the beta feature runtime bridge.
+ *
+ * @package wordpress/secure-custom-fields
+ */
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for includes/beta-features.php.
+ */
+class SCFBetaFeaturesTest extends BaseTestCase {
+
+	/**
+	 * Beta feature settings to exercise.
+	 *
+	 * @var array
+	 */
+	private $settings = array(
+		'enable_datastore',
+		'enable_acf_ai',
+		'enable_schema',
+	);
+
+	/**
+	 * Set up the test case.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		acf_init();
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		foreach ( $this->settings as $name ) {
+			delete_option( 'scf_beta_feature_' . $name . '_enabled' );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test the runtime flags default to disabled.
+	 */
+	public function test_runtime_filters_registered_by_plugin_bootstrap() {
+		$this->assertNotFalse( has_filter( 'acf/settings/enable_datastore' ) );
+		$this->assertNotFalse( has_filter( 'acf/settings/enable_acf_ai' ) );
+		$this->assertNotFalse( has_filter( 'acf/settings/enable_schema' ) );
+	}
+
+	/**
+	 * Test the runtime flags default to disabled.
+	 */
+	public function test_runtime_flags_default_disabled() {
+		$this->assertFalse( acf_get_setting( 'enable_acf_ai' ) );
+		$this->assertFalse( acf_get_setting( 'enable_schema' ) );
+		$this->assertFalse( acf_is_using_datastore() );
+	}
+
+	/**
+	 * Test an enabled beta feature enables its runtime setting.
+	 */
+	public function test_enabled_beta_feature_enables_runtime_setting() {
+		update_option( 'scf_beta_feature_enable_acf_ai_enabled', true );
+		update_option( 'scf_beta_feature_enable_schema_enabled', true );
+		update_option( 'scf_beta_feature_enable_datastore_enabled', true );
+
+		$this->assertTrue( acf_get_setting( 'enable_acf_ai' ) );
+		$this->assertTrue( acf_get_setting( 'enable_schema' ) );
+		$this->assertTrue( acf_is_using_datastore() );
+	}
+
+	/**
+	 * Test an existing filter can enable a setting regardless of the beta option.
+	 */
+	public function test_existing_filter_can_enable_setting() {
+		add_filter( 'acf/settings/enable_schema', '__return_true' );
+
+		try {
+			$this->assertTrue( acf_get_setting( 'enable_schema' ) );
+		} finally {
+			remove_filter( 'acf/settings/enable_schema', '__return_true' );
+		}
+	}
+
+	/**
+	 * Test a later filter can override an enabled beta feature.
+	 */
+	public function test_beta_feature_setting_coerces_string_values() {
+		foreach ( $this->settings as $name ) {
+			update_option( 'scf_beta_feature_' . $name . '_enabled', '1' );
+			$this->assertTrue( apply_filters( 'acf/settings/' . $name, false ) );
+
+			update_option( 'scf_beta_feature_' . $name . '_enabled', '0' );
+			$this->assertFalse( apply_filters( 'acf/settings/' . $name, false ) );
+		}
+	}
+
+	/**
+	 * Test a later filter can override an enabled beta feature.
+	 */
+	public function test_later_filter_can_override_beta_feature() {
+		update_option( 'scf_beta_feature_enable_acf_ai_enabled', true );
+
+		add_filter(
+			'acf/settings/enable_acf_ai',
+			static function () {
+				return false;
+			},
+			20
+		);
+
+		$this->assertFalse( acf_get_setting( 'enable_acf_ai' ) );
+	}
+
+	/**
+	 * Test uninstall cleanup removes all beta feature options.
+	 */
+	public function test_uninstall_cleanup_removes_beta_feature_options() {
+		foreach ( array_merge( $this->settings, array( 'editor_sidebar' ) ) as $name ) {
+			update_option( 'scf_beta_feature_' . $name . '_enabled', true );
+		}
+
+		scf_plugin_uninstall();
+
+		foreach ( array_merge( $this->settings, array( 'editor_sidebar' ) ) as $name ) {
+			$this->assertFalse( get_option( 'scf_beta_feature_' . $name . '_enabled' ) );
+		}
+	}
+}

--- a/tests/php/test-admin-beta-features.php
+++ b/tests/php/test-admin-beta-features.php
@@ -27,8 +27,6 @@ class SCF_Admin_Beta_Features_Test extends BaseTestCase {
 		parent::set_up();
 
 		acf_include( 'includes/admin/beta-features.php' );
-		acf_include( 'includes/admin/beta-features/class-scf-beta-feature.php' );
-		acf_include( 'includes/admin/beta-features/class-scf-beta-feature-editor-sidebar.php' );
 
 		$this->beta_features = new SCF_Admin_Beta_Features();
 	}
@@ -37,7 +35,11 @@ class SCF_Admin_Beta_Features_Test extends BaseTestCase {
 	 * Clean up after each test.
 	 */
 	public function tear_down() {
-		delete_option( 'scf_beta_feature_editor_sidebar_enabled' );
+		foreach ( array( 'editor_sidebar', 'enable_datastore', 'enable_acf_ai', 'enable_schema' ) as $name ) {
+			delete_option( 'scf_beta_feature_' . $name . '_enabled' );
+		}
+
+		unset( $_POST['scf_beta_features_nonce'], $_POST['scf_beta_features'] );
 		parent::tear_down();
 	}
 
@@ -49,6 +51,35 @@ class SCF_Admin_Beta_Features_Test extends BaseTestCase {
 		$beta_features = $this->beta_features->get_beta_features();
 		$this->assertArrayHasKey( 'editor_sidebar', $beta_features );
 		$this->assertInstanceOf( 'SCF_Admin_Beta_Feature_Editor_Sidebar', $beta_features['editor_sidebar'] );
+	}
+
+	/**
+	 * Test default beta feature registration.
+	 */
+	public function test_register_default_beta_features() {
+		$beta_features = $this->beta_features->get_beta_features();
+
+		$this->assertCount( 4, $beta_features );
+		$this->assertArrayHasKey( 'editor_sidebar', $beta_features );
+		$this->assertArrayHasKey( 'enable_datastore', $beta_features );
+		$this->assertArrayHasKey( 'enable_acf_ai', $beta_features );
+		$this->assertArrayHasKey( 'enable_schema', $beta_features );
+
+		$expected_classes = array(
+			'editor_sidebar'   => 'SCF_Admin_Beta_Feature_Editor_Sidebar',
+			'enable_datastore' => 'SCF_Admin_Beta_Feature_Datastore',
+			'enable_acf_ai'    => 'SCF_Admin_Beta_Feature_ACF_AI',
+			'enable_schema'    => 'SCF_Admin_Beta_Feature_Schema',
+		);
+
+		foreach ( $expected_classes as $name => $class_name ) {
+			$this->assertInstanceOf( $class_name, $beta_features[ $name ] );
+			$this->assertSame( $name, $beta_features[ $name ]->name );
+		}
+
+		$this->assertNotEmpty( $beta_features['enable_datastore']->title );
+		$this->assertNotEmpty( $beta_features['enable_acf_ai']->description );
+		$this->assertNotEmpty( $beta_features['enable_schema']->description );
 	}
 
 	/**
@@ -116,6 +147,59 @@ class SCF_Admin_Beta_Features_Test extends BaseTestCase {
 
 		$this->assertTrue( $beta_feature->is_enabled() );
 		$this->assertTrue( get_option( 'scf_beta_feature_editor_sidebar_enabled' ) );
+	}
+
+	/**
+	 * Test beta feature settings enable runtime flags.
+	 */
+	public function test_beta_feature_settings_enable_runtime_flags() {
+		foreach ( array( 'enable_datastore', 'enable_acf_ai', 'enable_schema' ) as $name ) {
+			$this->assertFalse( apply_filters( 'acf/settings/' . $name, false ) );
+			update_option( 'scf_beta_feature_' . $name . '_enabled', true );
+			$this->assertTrue( apply_filters( 'acf/settings/' . $name, false ) );
+		}
+	}
+
+	/**
+	 * Test submitting beta feature settings updates every registered feature.
+	 */
+	public function test_beta_feature_form_submission_updates_all_features() {
+		$beta_features = $this->beta_features->get_beta_features();
+		$all_names     = array_keys( $beta_features );
+
+		$_POST['scf_beta_features_nonce'] = wp_create_nonce( 'scf_beta_features_update' );
+		$_POST['scf_beta_features']       = array_fill_keys( $all_names, '1' );
+
+		$this->beta_features->check_submit();
+
+		foreach ( $all_names as $name ) {
+			$this->assertTrue( $beta_features[ $name ]->is_enabled() );
+		}
+
+		$_POST['scf_beta_features_nonce'] = wp_create_nonce( 'scf_beta_features_update' );
+		$_POST['scf_beta_features']       = array( 'editor_sidebar' => '1' );
+
+		$this->beta_features->check_submit();
+
+		foreach ( $all_names as $name ) {
+			$expected = 'editor_sidebar' === $name;
+			$this->assertSame( $expected, $beta_features[ $name ]->is_enabled() );
+		}
+	}
+
+	/**
+	 * Test existing filters can enable runtime flags.
+	 */
+	public function test_existing_filters_can_enable_runtime_flags() {
+		foreach ( array( 'enable_datastore', 'enable_acf_ai', 'enable_schema' ) as $name ) {
+			add_filter( 'acf/settings/' . $name, '__return_true' );
+
+			try {
+				$this->assertTrue( apply_filters( 'acf/settings/' . $name, false ) );
+			} finally {
+				remove_filter( 'acf/settings/' . $name, '__return_true' );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Secure Custom Fields (SCF)! Please have a look at the Contributing Guidelines:
https://github.com/WordPress/secure-custom-fields/blob/trunk/docs/contributing/index.md -->

Adds three new entries to the Beta Features admin page so the features that currently require a PHP filter can be enabled by an administrator from wp-admin:

- Enable Datastore (`acf/settings/enable_datastore`)
- Enable ACF AI (`acf/settings/enable_acf_ai`)
- Enable Schema Support (`acf/settings/enable_schema`)

Each feature gets a class under `includes/admin/beta-features/` following the existing editor sidebar pattern, and `register_beta_features()` now registers them. A small globally loaded file, `includes/beta-features.php`, bridges each stored option to its runtime filter with OR semantics, so existing PHP filters keep working alongside the new toggles and a later filter callback can still override the stored option. The bridge is included during normal plugin bootstrap (not admin-only) because these settings also affect frontend and REST execution.

The uninstall routine now deletes all four beta feature options.

Closes #433

## Use of AI Tools

This pull request was written with AI tooling assistance (Claude Code) and reviewed and tested by me.