### PR TITLE
Update props-bot-action to the latest trunk commit

### DIFF
--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Gather a list of contributors
-        uses: WordPress/props-bot-action@496473a3d11a263c17653aa9a00a98b8ed1479f8 # pinned 2026-04-24, no releases upstream
+        uses: WordPress/props-bot-action@8506b2615cdaaf57e4f3364eff8a38d0fbd16e1a # pinned 2026-08-26, no releases upstream
         with:
           format: 'svn'
 


### PR DESCRIPTION
Bumps the pinned `props-bot-action` reference to the current `trunk` HEAD (`8506b26`). The pin was on `496473a` (2026-04-24); this picks up the changes merged since, keeping the props workflow current with upstream.