### PR TITLE
Fix list fields schema for local and extension fields

### DIFF
--- a/includes/class-scf-schema-builder.php
+++ b/includes/class-scf-schema-builder.php
@@ -27,7 +27,8 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 	 * - Base properties (key, label, name, type, parent) are shared across all types
 	 * - oneOf validates "valid text field OR valid number field OR ..."
 	 * - Each variant merges base + type-specific properties with additionalProperties: false
-	 * - Fallback variant allows unknown types until all 35 field types have schemas
+	 * - Fallback variant allows extension field types without weakening known types
+	 * - The fallback pattern excludes known types so oneOf still matches exactly once
 	 *
 	 * Schema structure:
 	 * - schemas/field-fragments/field-base.schema.json: Base properties shared by all types
@@ -224,6 +225,29 @@ if ( ! class_exists( 'SCF_Schema_Builder' ) ) :
 					'additionalProperties' => $type_schema['additionalProperties'] ?? false,
 				);
 			}
+
+			// Preserve fields registered by extensions even when their type does not
+			// have a dedicated schema. Excluding known types prevents those fields
+			// from matching both their strict variant and this fallback.
+			$fallback_props = $base_props;
+			$type_property  = $fallback_props['type'] ?? array();
+			unset( $type_property['enum'] );
+			$escaped_types            = array_map(
+				static function ( $type ) {
+					return preg_quote( $type, '/' );
+				},
+				array_keys( $type_schemas )
+			);
+			$type_property['type']    = 'string';
+			$type_property['pattern'] = '^(?!(?:' . implode( '|', $escaped_types ) . ')$).+$';
+			$fallback_props['type']   = $type_property;
+
+			$variants[] = array(
+				'type'                 => 'object',
+				'required'             => array( 'key', 'label', 'name', 'type', 'parent' ),
+				'properties'           => $fallback_props,
+				'additionalProperties' => true,
+			);
 
 			$this->composed_field_schema = array(
 				'oneOf' => $variants,

--- a/schemas/field.schema.json
+++ b/schemas/field.schema.json
@@ -4619,6 +4619,99 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "label",
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "pattern": "^field_.+$",
+                            "minLength": 1,
+                            "description": "Unique identifier for the field with field_ prefix (e.g. 'field_abc123')"
+                        },
+                        "label": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The label displayed for this field"
+                        },
+                        "name": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9_-]*$",
+                            "description": "The field name/meta_key used to save and load data (empty for layout fields like tab, accordion)"
+                        },
+                        "aria-label": {
+                            "type": "string",
+                            "description": "Accessible label for screen readers"
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "The type of field",
+                            "pattern": "^(?!(?:color_picker|date_picker|date_time_picker|google_map|icon_picker|time_picker|email|number|password|range|text|textarea|url|button_group|checkbox|nav_menu|radio|select|true_false|file|gallery|image|oembed|wysiwyg|accordion|clone|flexible_content|group|message|output|repeater|separator|tab|link|page_link|post_object|relationship|taxonomy|user)$).+$"
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Instructions for content editors"
+                        },
+                        "required": {
+                            "type": [
+                                "boolean",
+                                "integer"
+                            ],
+                            "default": false,
+                            "description": "Whether the field is required"
+                        },
+                        "conditional_logic": {
+                            "type": [
+                                "boolean",
+                                "integer",
+                                "string",
+                                "array"
+                            ],
+                            "default": 0,
+                            "description": "Conditional logic rules for field visibility. False/0/empty string to disable, or array of rule groups."
+                        },
+                        "wrapper": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "width": {
+                                    "type": "string",
+                                    "description": "Width of the field wrapper (e.g. '50' for 50%)"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "description": "CSS class(es) for the field wrapper"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "HTML ID for the field wrapper"
+                                }
+                            },
+                            "description": "Wrapper element settings"
+                        },
+                        "menu_order": {
+                            "type": "integer",
+                            "description": "Order of the field within its parent"
+                        },
+                        "parent": {
+                            "type": [
+                                "string",
+                                "integer"
+                            ],
+                            "description": "Parent field or field group key/ID"
+                        },
+                        "parent_layout": {
+                            "type": "string",
+                            "description": "Parent layout key for flexible content sub-fields"
+                        }
+                    },
+                    "additionalProperties": true
                 }
             ]
         },

--- a/schemas/internal-properties.schema.json
+++ b/schemas/internal-properties.schema.json
@@ -9,6 +9,11 @@
 			"minimum": 1,
 			"description": "WordPress post ID. Present in GET/LIST/CREATE/UPDATE/IMPORT/DUPLICATE outputs."
 		},
+		"fieldID": {
+			"type": "integer",
+			"minimum": 0,
+			"description": "WordPress post ID, or 0 for a code-registered field without a backing post."
+		},
 		"_valid": {
 			"type": [ "boolean", "integer" ],
 			"description": "Validation cache flag. Indicates whether the entity passed validation. Can be boolean or integer (0/1)."
@@ -49,7 +54,7 @@
 			"type": "object",
 			"description": "Internal properties for field entities",
 			"properties": {
-				"ID": { "$ref": "#/definitions/ID" },
+				"ID": { "$ref": "#/definitions/fieldID" },
 				"_valid": { "$ref": "#/definitions/_valid" },
 				"prefix": { "$ref": "#/definitions/prefix" },
 				"value": { "$ref": "#/definitions/value" },

--- a/tests/php/includes/SCFSchemaBuilderTest.php
+++ b/tests/php/includes/SCFSchemaBuilderTest.php
@@ -231,20 +231,26 @@ class SCFSchemaBuilderTest extends BaseTestCase {
 	}
 
 	/**
-	 * Test compose_field_schema only adds fallback when types are missing schemas.
+	 * Test compose_field_schema adds a fallback for extension field types.
 	 *
-	 * With all 39 field types having dedicated schemas, no fallback variant
-	 * should be present. The fallback (with additionalProperties: true) is
-	 * only added when there are field types without schema files.
+	 * The fallback accepts field types without dedicated schemas while excluding
+	 * known types so each known field continues to match exactly one variant.
 	 */
-	public function test_compose_field_schema_no_fallback_when_all_types_have_schemas() {
+	public function test_compose_field_schema_adds_fallback_for_unknown_types() {
 		$result = $this->builder->compose_field_schema();
 
-		// All dedicated schemas have additionalProperties: false.
-		// If a fallback exists, it would have additionalProperties: true.
-		$last_variant = end( $result['oneOf'] );
+		$fallback = end( $result['oneOf'] );
 
-		$this->assertFalse( $last_variant['additionalProperties'] );
+		$this->assertTrue( $fallback['additionalProperties'] );
+		$this->assertArrayHasKey( 'pattern', $fallback['properties']['type'] );
+		$this->assertSame( 0, preg_match( '/' . $fallback['properties']['type']['pattern'] . '/', 'text' ) );
+		$this->assertSame( 1, preg_match( '/' . $fallback['properties']['type']['pattern'] . '/', 'phpunit_unknown_type' ) );
+		$this->assertTrue(
+			rest_validate_value_from_schema( 'phpunit_unknown_type', $fallback['properties']['type'], 'type' )
+		);
+		$this->assertTrue(
+			is_wp_error( rest_validate_value_from_schema( 'text', $fallback['properties']['type'], 'type' ) )
+		);
 	}
 
 	/**

--- a/tests/php/includes/abilities/test-scf-list-fields-schema-robustness.php
+++ b/tests/php/includes/abilities/test-scf-list-fields-schema-robustness.php
@@ -3,15 +3,9 @@
  * Schema robustness repro for the scf/list-fields ability output
  *
  * The scf/list-fields output_schema is `{ type: array, items: { oneOf: [...] } }`
- * where every oneOf variant pins `type` to a known field type enum, sets
- * `additionalProperties: false`, and requires `ID >= 1`. JSON Schema array
- * validation is all-or-nothing: if ANY stored field drifts from its type schema
- * (unknown type, stray property, local field with ID 0), that item matches no
- * oneOf variant and the WHOLE array output is rejected by output-schema
- * validation.
- *
- * NOTE: documents current behavior — possible bug: one invalid field makes the
- * entire listing unusable. Tracked in #453.
+ * with strict variants for built-in field types and a permissive fallback for
+ * extension field types. Local fields legitimately use `ID => 0`, while
+ * database-backed fields use positive post IDs.
  *
  * @package wordpress/secure-custom-fields
  */
@@ -268,10 +262,9 @@ class Test_SCF_List_Fields_Schema_Robustness extends BaseTestCase {
 	}
 
 	/**
-	 * Sanity check: a field stored with an unknown type fails every oneOf
-	 * type variant of the item schema.
+	 * A field stored with an unknown type matches the fallback item schema.
 	 */
-	public function test_drifted_field_alone_fails_item_schema() {
+	public function test_unknown_field_alone_passes_item_schema() {
 		$schema      = $this->get_list_fields_output_schema();
 		$item_schema = $schema['items'];
 
@@ -280,80 +273,46 @@ class Test_SCF_List_Fields_Schema_Robustness extends BaseTestCase {
 
 		$validator = $this->validate_against_schema( $drifted_field, $item_schema );
 
-		$this->assertFalse(
+		$this->assertTrue(
 			$validator->isValid(),
-			'A field with an unknown stored type should match no oneOf variant'
+			'A field with an unknown stored type should match the fallback variant. Errors: '
+				. wp_json_encode( $validator->getErrors() )
 		);
 	}
 
 	/**
-	 * Repro: one drifted field invalidates the ENTIRE list-fields output.
-	 *
-	 * The list output schema is `array` of `oneOf` variants, each pinned to a
-	 * known type enum with additionalProperties: false. Because array schema
-	 * validation rejects the whole array when any single item fails, a single
-	 * stored field that drifted from its type schema (here: an unknown field
-	 * type, e.g. from a third-party or removed field type plugin) makes
-	 * output-schema validation fail for the complete listing - including all
-	 * perfectly valid fields in it.
-	 *
-	 * NOTE: documents current behavior - possible bug: one invalid field makes
-	 * the entire listing unusable. A consumer validating scf/list-fields output
-	 * against its registered output_schema (as the WordPress Abilities API does
-	 * for ability results) receives a validation error instead of the valid
-	 * fields. Tracked in #453.
+	 * A third-party field type does not invalidate the complete list output.
 	 */
-	public function test_single_drifted_field_invalidates_entire_list_output() {
+	public function test_unknown_field_type_keeps_entire_list_output_valid() {
 		$schema        = $this->get_list_fields_output_schema();
 		$drifted_field = acf_get_field( $this->local_drifted_key );
 		$output        = $this->build_list_output( array( $this->db_text_field, $drifted_field ) );
 
 		$this->assertCount( 2, $output, 'The callback itself happily returns both fields' );
 
-		// The valid field on its own passes...
+		// The valid field on its own passes.
 		$valid_only = $this->validate_against_schema( array( $this->db_text_field ), $schema );
 		$this->assertTrue( $valid_only->isValid(), 'The valid field alone passes the output schema' );
 
-		// ...but the combined listing is rejected wholesale.
+		// The fallback keeps the combined listing valid as well.
 		$combined = $this->validate_against_schema( $output, $schema );
-		$this->assertFalse(
+		$this->assertTrue(
 			$combined->isValid(),
-			'One drifted field should (currently) cause the whole list output to fail validation'
-		);
-
-		// The failure is reported against the drifted item, confirming the
-		// rejection is caused by the single bad field poisoning the array.
-		$error_properties    = wp_list_pluck( $combined->getErrors(), 'property' );
-		$drifted_item_errors = array_filter(
-			$error_properties,
-			function ( $property ) {
-				return 0 === strpos( (string) $property, '[1]' );
-			}
-		);
-		$this->assertNotEmpty(
-			$drifted_item_errors,
-			'Validation errors should point at the drifted item ([1]). Errors: '
+			'A third-party field type should not invalidate the list output. Errors: '
 				. wp_json_encode( $combined->getErrors() )
 		);
 	}
 
 	/**
-	 * Repro: ordinary local (code-registered) fields fail the output schema
-	 * because their ID is 0.
+	 * Ordinary local (code-registered) fields pass with an ID of 0.
 	 *
 	 * This run uses the REAL, unmocked list_callback: local field groups are
 	 * aggregated by the production code path. Local fields legitimately have
-	 * `ID => 0` (they have no backing post), but the internal-properties schema
-	 * merged into every oneOf variant requires `ID` with `minimum: 1`, so a
-	 * perfectly ordinary code-registered text field - the most common kind of
-	 * field on real sites - fails the item schema, and with it the whole list.
-	 *
-	 * NOTE: documents current behavior - possible bug: any site registering
-	 * fields in code (acf_add_local_field_group / local JSON) produces
-	 * scf/list-fields output that fails its own output_schema validation.
-	 * Tracked in #453.
+	 * `ID => 0` because they have no backing post. The field-specific internal
+	 * properties schema accepts that value while database-backed entities retain
+	 * the positive-ID constraint.
 	 */
-	public function test_local_text_field_fails_output_schema_due_to_id_zero() {
+	public function test_local_text_field_passes_output_schema_with_id_zero() {
 		$schema = $this->get_list_fields_output_schema();
 
 		// Real list_callback, no mocks: aggregates the local field group.
@@ -367,21 +326,9 @@ class Test_SCF_List_Fields_Schema_Robustness extends BaseTestCase {
 
 		$validator = $this->validate_against_schema( $output, $schema );
 
-		$this->assertFalse(
+		$this->assertTrue(
 			$validator->isValid(),
-			'A listing containing a local field should (currently) fail the output schema'
-		);
-
-		// Confirm the ID minimum constraint is among the failures.
-		$minimum_errors = array_filter(
-			$validator->getErrors(),
-			function ( $error ) {
-				return 'minimum' === $error['constraint'] && '[0].ID' === $error['property'];
-			}
-		);
-		$this->assertNotEmpty(
-			$minimum_errors,
-			'Validation should fail on the ID >= 1 requirement. Errors: '
+			'A listing containing a local field should pass the output schema. Errors: '
 				. wp_json_encode( $validator->getErrors() )
 		);
 	}

--- a/tests/php/schemas/FieldSchemaTest.php
+++ b/tests/php/schemas/FieldSchemaTest.php
@@ -152,6 +152,17 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 				),
 				'Field with conditional logic should be valid',
 			),
+			'extension field type'            => array(
+				array(
+					'key'            => 'field_extension',
+					'label'          => 'Extension Field',
+					'name'           => 'extension_field',
+					'type'           => 'third_party_type',
+					'parent'         => 'group_test',
+					'custom_setting' => 'preserved',
+				),
+				'Third-party field types should use the permissive fallback',
+			),
 
 			// Multi-type property tests (properties accepting different types).
 			'maxlength as empty string'       => array(
@@ -835,16 +846,6 @@ class FieldSchemaTest extends BaseSchemaTestCase {
 			),
 
 			// Enum validation.
-			'invalid type'                             => array(
-				array(
-					'key'    => 'field_bad_type',
-					'label'  => 'Bad Type Field',
-					'name'   => 'bad_type',
-					'type'   => 'nonexistent_type',
-					'parent' => 'group_test',
-				),
-				'Field with invalid type should fail validation',
-			),
 			'invalid new_lines enum'                   => array(
 				array(
 					'key'       => 'field_textarea_bad_nl',


### PR DESCRIPTION
The `scf/list-fields` output schema currently rejects two valid field configurations:

- Code-registered fields use `ID => 0` because they have no backing post.
- Fields registered by extensions may use types without a dedicated SCF schema.

This updates the field-specific internal properties schema to accept an ID of zero and adds a permissive fallback variant for extension field types. The fallback explicitly excludes known built-in types, preserving strict validation for all built-in fields.

The generated field schema and regression coverage are updated for both cases.

### Testing

- Full PHP suite: 2,943 tests, 22,754 assertions
- Focused schema suite: 103 tests, 503 assertions
- PHPCS: passed
- PHPStan: passed
- Generated schema check: passed

Closes #453

## Use of AI Tools

OpenAI Codex was used to assist with issue analysis and preparation of the implementation and tests. I reviewed the final changes and test results and take responsibility for the submitted contribution.
