### PR TITLE
Fix validation for third-party frontend forms

### DIFF
--- a/includes/forms/form-front.php
+++ b/includes/forms/form-front.php
@@ -43,6 +43,7 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 		 * @since ACF 5.0.0
 		 */
 		public function __construct() {
+			add_action( 'acf/form_data', array( $this, 'render_external_form_meta' ) );
 			add_action(
 				'acf/validate_save_post',
 				function () {
@@ -52,6 +53,57 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 			);
 			add_action( 'acf/validate_save_post', array( $this, 'validate_save_post' ), 1 );
 			add_filter( 'acf/pre_save_post', array( $this, 'pre_save_post' ), 5, 2 );
+		}
+
+		/**
+		 * Renders a signed validation grant for third-party front-end forms.
+		 *
+		 * Integrations that call acf_form_data() with `form => false` use ACF's
+		 * AJAX field validation without submitting through acf_form(). The grant
+		 * distinguishes those server-rendered integrations from native forms whose
+		 * form-specific authorization fields were removed from the request.
+		 *
+		 * @since SCF 6.9.5
+		 *
+		 * @param array $data Form data passed to acf_form_data().
+		 * @return void
+		 */
+		public function render_external_form_meta( array $data ): void {
+			if ( 'acf_form' !== ( $data['screen'] ?? '' )
+				|| ! array_key_exists( 'form', $data )
+				|| false !== $data['form']
+			) {
+				return;
+			}
+
+			$target_post_id = $data['post_id'] ?? '';
+			if ( is_bool( $target_post_id ) ) {
+				$target_post_id = (int) $target_post_id;
+			} elseif ( null !== $target_post_id && ! is_scalar( $target_post_id ) ) {
+				return;
+			}
+
+			$meta_payload = wp_json_encode(
+				array(
+					'blog_id'        => get_current_blog_id(),
+					'issued_at'      => time(),
+					'screen'         => 'acf_form',
+					'target_post_id' => (string) $target_post_id,
+				)
+			);
+
+			if ( ! is_string( $meta_payload ) ) {
+				return;
+			}
+
+			acf_hidden_input(
+				array(
+					'name'  => '_acf_external_form_meta',
+					'value' => base64_encode( $meta_payload ) // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Base64 transports signed JSON.
+						. '.'
+						. hash_hmac( 'sha256', 'acf_external_form|' . $meta_payload, wp_salt( 'nonce' ) ),
+				)
+			);
 		}
 
 		/**
@@ -241,6 +293,7 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 					|| isset( $_POST['_acf_form_meta'] ) // phpcs:ignore WordPress.Security.NonceVerification.Missing -- The existing AJAX handler verifies its nonce before firing this action.
 					|| isset( $_POST['_acf_render_id'] ) // phpcs:ignore WordPress.Security.NonceVerification.Missing -- The existing AJAX handler verifies its nonce before firing this action.
 				)
+				&& ! $this->has_valid_external_form_meta()
 				&& false === $this->prepare_submitted_form( true )
 			) {
 				wp_send_json_success(
@@ -255,6 +308,73 @@ if ( ! class_exists( 'acf_form_front' ) ) :
 					)
 				);
 			}
+		}
+
+		/**
+		 * Verifies a validation-only grant emitted for a third-party form.
+		 *
+		 * Native grant markers always take precedence, so an external token cannot
+		 * bypass a missing, expired, or tampered acf_form() grant.
+		 *
+		 * @since SCF 6.9.5
+		 *
+		 * @return bool Whether the request has valid external-form authority.
+		 */
+		private function has_valid_external_form_meta(): bool {
+			// phpcs:disable WordPress.Security.NonceVerification.Missing -- The AJAX handler verifies its nonce before firing the validation action; this method verifies the signed form metadata.
+			if ( isset( $_POST['_acf_form_meta'] ) || isset( $_POST['_acf_render_id'] ) ) {
+				return false;
+			}
+
+			if ( empty( $_POST['_acf_external_form_meta'] ) || ! is_scalar( $_POST['_acf_external_form_meta'] ) ) {
+				return false;
+			}
+
+			if ( ! isset( $_POST['_acf_screen'], $_POST['_acf_post_id'] )
+				|| ! is_scalar( $_POST['_acf_screen'] )
+				|| ! is_scalar( $_POST['_acf_post_id'] )
+			) {
+				return false;
+			}
+
+			$parts = explode( '.', (string) wp_unslash( $_POST['_acf_external_form_meta'] ), 2 ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- The HMAC authenticates the exact token bytes below.
+			if ( 2 !== count( $parts ) ) {
+				return false;
+			}
+
+			$payload = base64_decode( $parts[0], true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes signed JSON metadata.
+			if ( false === $payload ) {
+				return false;
+			}
+
+			$expected_mac = hash_hmac( 'sha256', 'acf_external_form|' . $payload, wp_salt( 'nonce' ) );
+			if ( ! hash_equals( $expected_mac, $parts[1] ) ) {
+				return false;
+			}
+
+			$meta = json_decode( $payload, true );
+			if ( ! is_array( $meta )
+				|| array_keys( $meta ) !== array( 'blog_id', 'issued_at', 'screen', 'target_post_id' )
+				|| ! is_int( $meta['blog_id'] )
+				|| ! is_int( $meta['issued_at'] )
+				|| ! is_string( $meta['screen'] )
+				|| ! is_string( $meta['target_post_id'] )
+			) {
+				return false;
+			}
+
+			$screen         = (string) wp_unslash( $_POST['_acf_screen'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Compared only with authenticated metadata.
+			$target_post_id = (string) wp_unslash( $_POST['_acf_post_id'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Compared only with authenticated metadata.
+			$ttl            = (int) apply_filters( 'acf/form/meta_ttl', DAY_IN_SECONDS );
+			$now            = time();
+
+			return $ttl > 0
+				&& get_current_blog_id() === $meta['blog_id']
+				&& hash_equals( $screen, $meta['screen'] )
+				&& hash_equals( $target_post_id, $meta['target_post_id'] )
+				&& $meta['issued_at'] <= $now + MINUTE_IN_SECONDS
+				&& ( $now - $meta['issued_at'] ) < $ttl;
+			// phpcs:enable WordPress.Security.NonceVerification.Missing
 		}
 
 		/**

--- a/tests/php/includes/forms/test-form-front-authorization.php
+++ b/tests/php/includes/forms/test-form-front-authorization.php
@@ -1587,6 +1587,175 @@ class Test_Form_Front_Authorization extends BaseTestCase {
 	}
 
 	/**
+	 * AJAX validation remains available to third-party forms that use
+	 * acf_form_data() without rendering an acf_form().
+	 *
+	 * Advanced Forms uses the acf_form screen and supplies its own encoded form
+	 * configuration, but it cannot emit SCF's acf_form()-specific grant fields.
+	 *
+	 * @return void
+	 * @throws RuntimeException If AJAX handling raises an unrelated exception.
+	 */
+	public function test_ajax_gate_allows_third_party_acf_form_data_validation(): void {
+		$field_key = 'field_front_grant_third_party';
+		$this->register_text_field( $field_key, 'front_grant_third_party' );
+
+		$encoded_args    = base64_encode( wp_json_encode( array( 'display_title' => false ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Matches the third-party form transport under test.
+		$validator_calls = 0;
+		$this->add_test_hook(
+			'acf/validate_value/key=' . $field_key,
+			static function ( $valid ) use ( &$validator_calls ) {
+				++$validator_calls;
+				return $valid;
+			},
+			PHP_INT_MAX
+		);
+
+		ob_start();
+		acf_form_data(
+			array(
+				'screen'  => 'acf_form',
+				'post_id' => false,
+				'form'    => false,
+			)
+		);
+		$request = $this->request_from_html( (string) ob_get_clean(), false );
+
+		$this->assertArrayHasKey( '_acf_external_form_meta', $request );
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Simulates Advanced Forms' AJAX validation request.
+		$_POST                  = $request;
+		$_POST['action']        = 'acf/validate_save_post';
+		$_POST['nonce']         = wp_create_nonce( 'acf_nonce' );
+		$_POST['_acf_form']     = $encoded_args;
+		$_POST['af_form']       = 'form_third_party';
+		$_POST['af_form_args']  = $encoded_args;
+		$_POST['af_form_nonce'] = wp_create_nonce( 'af_submission_form_third_party_' . hash( 'sha256', $encoded_args ) );
+		$_POST['acf']           = array( $field_key => 'third-party value' );
+		$_REQUEST               = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		$response = $this->invoke_ajax_validation();
+
+		$this->assertTrue( $response['success'] );
+		$this->assertSame( 1, $response['data']['valid'], 'Third-party front-end validation must not require an acf_form() grant.' );
+		$this->assertSame( 0, $response['data']['errors'] );
+		$this->assertSame( 1, $validator_calls );
+	}
+
+	/**
+	 * AJAX validation rejects a tampered third-party form grant.
+	 *
+	 * @return void
+	 * @throws RuntimeException If AJAX handling raises an unrelated exception.
+	 */
+	public function test_ajax_gate_rejects_tampered_third_party_form_grant(): void {
+		$field_key = 'field_front_grant_third_party_tampered';
+		$this->register_text_field( $field_key, 'front_grant_third_party_tampered' );
+
+		ob_start();
+		acf_form_data(
+			array(
+				'screen'  => 'acf_form',
+				'post_id' => false,
+				'form'    => false,
+			)
+		);
+		$request = $this->request_from_html( (string) ob_get_clean(), false );
+
+		$token                               = $request['_acf_external_form_meta'];
+		$last_character                      = substr( $token, -1 );
+		$request['_acf_external_form_meta']  = substr( $token, 0, -1 );
+		$request['_acf_external_form_meta'] .= 'a' === $last_character ? 'b' : 'a';
+
+		$validator_calls = 0;
+		$this->add_test_hook(
+			'acf/validate_value/key=' . $field_key,
+			static function ( $valid ) use ( &$validator_calls ) {
+				++$validator_calls;
+				return $valid;
+			},
+			PHP_INT_MAX
+		);
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Submits a deliberately tampered signed grant to the AJAX handler under test.
+		$_POST           = $request;
+		$_POST['action'] = 'acf/validate_save_post';
+		$_POST['nonce']  = wp_create_nonce( 'acf_nonce' );
+		$_POST['acf']    = array( $field_key => 'must not validate' );
+		$_REQUEST        = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		$response = $this->invoke_ajax_validation();
+
+		$this->assertTrue( $response['success'] );
+		$this->assertSame( 0, $response['data']['valid'] );
+		$this->assertSame( 0, $validator_calls );
+	}
+
+	/**
+	 * A third-party grant cannot override a tampered native acf_form() grant.
+	 *
+	 * @return void
+	 * @throws RuntimeException If AJAX handling raises an unrelated exception.
+	 */
+	public function test_ajax_external_grant_cannot_bypass_tampered_native_grant(): void {
+		$field_key = 'field_front_grant_external_native_tampered';
+		$post_id   = $this->create_post( 'External grant native tamper target' );
+		$this->register_text_field( $field_key, 'front_grant_external_native_tampered' );
+
+		$request = $this->render_request(
+			array(
+				'id'       => 'front-grant-external-native-tampered',
+				'post_id'  => $post_id,
+				'fields'   => array( $field_key ),
+				'honeypot' => false,
+				'return'   => '',
+			)
+		);
+
+		ob_start();
+		acf_form_data(
+			array(
+				'screen'  => 'acf_form',
+				'post_id' => $post_id,
+				'form'    => false,
+			)
+		);
+		$external_request                   = $this->request_from_html( (string) ob_get_clean(), false );
+		$request['_acf_external_form_meta'] = $external_request['_acf_external_form_meta'];
+
+		$token                         = $request['_acf_form_meta'][0];
+		$last_character                = substr( $token, -1 );
+		$request['_acf_form_meta'][0]  = substr( $token, 0, -1 );
+		$request['_acf_form_meta'][0] .= 'a' === $last_character ? 'b' : 'a';
+
+		$validator_calls = 0;
+		$this->add_test_hook(
+			'acf/validate_value/key=' . $field_key,
+			static function ( $valid ) use ( &$validator_calls ) {
+				++$validator_calls;
+				return $valid;
+			},
+			PHP_INT_MAX
+		);
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Submits a valid external grant beside a deliberately tampered native grant.
+		$_POST           = $request;
+		$_POST['action'] = 'acf/validate_save_post';
+		$_POST['nonce']  = wp_create_nonce( 'acf_nonce' );
+		$_POST['acf']    = array( $field_key => 'must not validate' );
+		$_REQUEST        = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		$response = $this->invoke_ajax_validation();
+
+		$this->assertTrue( $response['success'] );
+		$this->assertSame( 0, $response['data']['valid'] );
+		$this->assertSame( 0, $validator_calls );
+	}
+
+	/**
 	 * The AJAX grant gate applies only to acf_form() submissions. Requests from
 	 * the post editor have no front-end markers and follow normal validation.
 	 *
@@ -1766,6 +1935,7 @@ class Test_Form_Front_Authorization extends BaseTestCase {
 	 * @return void
 	 */
 	private function detach_request_hooks( acf_form_front $front ): void {
+		remove_action( 'acf/form_data', array( $front, 'render_external_form_meta' ) );
 		remove_action( 'acf/validate_save_post', array( $front, 'validate_save_post' ), 1 );
 		remove_filter( 'acf/pre_save_post', array( $front, 'pre_save_post' ), 5 );
 	}
@@ -1819,10 +1989,11 @@ class Test_Form_Front_Authorization extends BaseTestCase {
 	/**
 	 * Extracts hidden ACF form values from rendered HTML.
 	 *
-	 * @param string $html Rendered HTML.
+	 * @param string $html           Rendered HTML.
+	 * @param bool   $require_native Whether native acf_form() grant fields are required.
 	 * @return array
 	 */
-	private function request_from_html( string $html ): array {
+	private function request_from_html( string $html, bool $require_native = true ): array {
 		$inputs  = array();
 		$request = array();
 
@@ -1853,8 +2024,10 @@ class Test_Form_Front_Authorization extends BaseTestCase {
 			}
 		}
 
-		foreach ( array( '_acf_nonce', '_acf_post_id', '_acf_form', '_acf_render_id', '_acf_form_meta' ) as $required_key ) {
-			$this->assertArrayHasKey( $required_key, $request, "Rendered form is missing {$required_key}." );
+		if ( $require_native ) {
+			foreach ( array( '_acf_nonce', '_acf_post_id', '_acf_form', '_acf_render_id', '_acf_form_meta' ) as $required_key ) {
+				$this->assertArrayHasKey( $required_key, $request, "Rendered form is missing {$required_key}." );
+			}
 		}
 
 		return $request;


### PR DESCRIPTION
I reproduced this against the current `trunk` authorization gate using the request shape generated by Advanced Forms. The integration calls `acf_form_data()` for AJAX validation but does not render through `acf_form()`, so it cannot provide SCF's native form grant. I have a scoped fix with regression coverage that adds a signed validation-only grant for this server-rendered third-party path while keeping native form grants authoritative. I'd like to submit the patch for review.

Closes #541

## Use of AI Tools

Codex assisted with implementation and test development. I reviewed and tested the resulting changes and take responsibility for the contribution.
